### PR TITLE
ci(renovate): add renovate workflow

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -1,0 +1,47 @@
+name: run renovatebot
+
+on:
+  schedule:
+    - cron: '0 2 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+  workflows: write
+
+concurrency:
+  group: renovate
+  cancel-in-progress: false
+
+jobs:
+  renovatebot:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout kubara repo
+        uses: actions/checkout@v6
+
+      - name: Create GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.RENOVATE_GITHUB_APP_ID }}
+          private-key: ${{ secrets.RENOVATE_GITHUB_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: |
+            ${{ github.event.repository.name }}
+
+      - name: Run renovatebot
+        uses: renovatebot/github-action@v46.0.2
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+        env:
+          RENOVATE_PLATFORM: github
+          RENOVATE_REPOSITORIES: ${{ github.repository }}
+          RENOVATE_GITHUB_COM_TOKEN: ${{ steps.app-token.outputs.token }}
+          RENOVATE_PR_HOURLY_LIMIT: 0
+          RENOVATE_PR_CONCURRENT_LIMIT: 50
+          RENOVATE_ALLOWED_COMMANDS: '^\.\/\.scripts\/renovate_bot_update_helm_changelog\.sh.*$'
+          # LOG_LEVEL: debug
+          # RENOVATE_DRY_RUN: full


### PR DESCRIPTION
## 📝 Summary
Add a GitHub Actions workflow to run Renovate on a schedule and via manual dispatch using the official `renovatebot/github-action`.

The workflow uses a GitHub App installation token (via `actions/create-github-app-token`) instead of a PAT and keeps the existing Renovate runtime settings (PR limits + allowed post-upgrade command for the Helm changelog script).

## 🧩 Type of change
- [ ] 🔧 CLI / Go code
- [ ] 📦 Helm chart
- [ ] 🧱 Terraform module
- [ ] 📝 Documentation
- [x] 🧪 Test or CI change
- [ ] ♻️ Refactor / cleanup
  
## ⚠️ Is this a breaking change?
- [ ] Yes, this change breaks existing functionality (explain in summary)
  
## 🧪 Testing
- [ ] CI passed
- [ ] Manually tested (local/dev cluster)
- [ ] Unit tested
- [x] Not tested (explain why below)

The workflow was added but has not been executed yet in this branch. Validation will happen after merge by:
- manual `workflow_dispatch`, or
- waiting for the scheduled run

## 🔗 Related Issues / Tickets
<!-- e.g. Closes #42, Related to #99 -->
  
## ✅ Checklist
- [ ] Code compiles and passes all tests
- [ ] Linting and style checks pass
- [ ] Comments added for complex logic
- [ ] Documentation updated (if applicable)
  
## 📎 Additional Context (optional)
- New workflow file: `.github/workflows/renovate.yaml`
- Required repo secrets:
  - `RENOVATE_GITHUB_APP_ID`
  - `RENOVATE_GITHUB_APP_PRIVATE_KEY`
- The GitHub App must be installed for this repository with permissions for contents / pull requests / issues / workflows.