### PR TITLE
ci(release): add GitHub release

### DIFF
--- a/.github/workflows/release-announce-google-chat.yaml
+++ b/.github/workflows/release-announce-google-chat.yaml
@@ -1,0 +1,102 @@
+name: announce release in Google Chat
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to announce (e.g. v1.2.3)'
+        required: true
+        type: string
+      confirm_send:
+        description: 'Actually send the message to Google Chat'
+        required: true
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+jobs:
+  announce:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.RELEASE_GITHUB_APP_ID }}
+          private-key: ${{ secrets.RELEASE_GITHUB_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: |
+            ${{ github.event.repository.name }}
+
+      - name: Fetch GitHub release and compose message
+        id: compose
+        env:
+          TAG: ${{ inputs.tag }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          API="https://api.github.com/repos/${REPO}/releases/tags/${TAG}"
+          RESP=$(curl -sS -w "\nHTTP_STATUS:%{http_code}\n" \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "$API")
+
+          STATUS=$(echo "$RESP" | sed -n 's/HTTP_STATUS://p')
+          BODY_JSON=$(echo "$RESP" | sed '/HTTP_STATUS:/d')
+
+          echo "HTTP status: ${STATUS}"
+          if [ "$STATUS" != "200" ]; then
+            echo "GitHub release API call failed (status ${STATUS})" >&2
+            echo "$BODY_JSON" >&2
+            exit 1
+          fi
+
+          NOTES_RAW=$(echo "$BODY_JSON" | jq -r '.body // ""')
+          URL=$(echo "$BODY_JSON" | jq -r '.html_url // ""')
+
+          PAYLOAD=$(jq -n \
+            --arg tag "$TAG" \
+            --arg url "$URL" \
+            --arg notes "$NOTES_RAW" \
+            '{
+              text:
+                ("*Kubara " + $tag + " is released now!*" + "\n\n" +
+                 "Hi Kubara Community! @all" + "\n" +
+                 "Happy to share that we released " + $tag + " of Kubara today: " + $url + "\n\n" +
+                 "Check out the release notes below and feel free to ask questions in this group." + "\n\n" +
+                 $notes)
+            }')
+
+          {
+            echo 'payload<<EOF'
+            echo "$PAYLOAD"
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Preview message payload
+        env:
+          PAYLOAD: ${{ steps.compose.outputs.payload }}
+        run: |
+          printf '%s\n' "$PAYLOAD"
+
+      - name: Stop without sending (confirmation not enabled)
+        if: ${{ !inputs.confirm_send }}
+        run: |
+          echo "confirm_send=false -> preview only, no message sent."
+
+      - name: Send message to Google Chat
+        if: ${{ inputs.confirm_send }}
+        env:
+          GOOGLE_CHAT_WEBHOOK_URL: ${{ secrets.GOOGLE_CHAT_WEBHOOK_URL }}
+          PAYLOAD: ${{ steps.compose.outputs.payload }}
+        run: |
+          set -euo pipefail
+          curl -sS -X POST \
+            -H "Content-Type: application/json" \
+            --data "$PAYLOAD" \
+            "${GOOGLE_CHAT_WEBHOOK_URL}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,50 @@
+name: release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+        working-directory: ./go-binary
+    steps:
+      - name: Checkout kubara repo
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Create GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.RELEASE_GITHUB_APP_ID }}
+          private-key: ${{ secrets.RELEASE_GITHUB_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: |
+            ${{ github.event.repository.name }}
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go-binary/go.mod
+          cache: true
+          cache-dependency-path: go-binary/go.sum
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: '~> v2'
+          workdir: go-binary
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/go-binary/.goreleaser.yaml
+++ b/go-binary/.goreleaser.yaml
@@ -1,15 +1,40 @@
 ---
 version: 2
 project_name: kubara
-gitea_urls:
-  api: https://kubara.git.onstackit.cloud/api/v1
-  download: https://kubara.git.onstackit.cloud
 release:
-  gitea:
-    owner: STACKIT
+  github:
+    owner: kubara-io
     name: kubara
-  draft: false
+  draft: true
   replace_existing_draft: true
+changelog:
+  use: git
+  sort: asc
+  filters:
+    exclude:
+      - '^.*?Merge (pull request|branch).*$'
+      - '^.*?chore\(release\):.+$'
+  groups:
+    - title: Breaking changes
+      regexp: '^.*?[a-z]+(\([^)]+\))?!:.+$'
+      order: 1
+    - title: Features
+      regexp: '^.*?feat(\([^)]+\))?:.+$'
+      order: 10
+    - title: Bug fixes
+      regexp: '^.*?fix(\([^)]+\))?:.+$'
+      order: 20
+    - title: Dependency updates
+      regexp: '^.*?[a-z]+\((deps[^)]*)\)!?:.+$|^.*?deps(\([^)]+\))?!?:.+$|^.*?bump .+$'
+      order: 30
+    - title: Documentation
+      regexp: '^.*?docs(\([^)]+\))?!?:.+$'
+      order: 40
+    - title: CI / Build
+      regexp: '^.*?(build|ci)(\([^)]+\))?!?:.+$'
+      order: 50
+    - title: Other changes
+      order: 999
 builds:
   - id: kubara
     main: ./main.go


### PR DESCRIPTION
# 📝 Summary
This PR adds a GitHub-based release workflow for Kubara and wires GoReleaser to publish draft releases on GitHub when a version tag (`v*`) is pushed.

It also adds a manual Google Chat announcement workflow with a preview/confirmation step, so release announcements can be reviewed before sending.

In addition, the branch includes CI workflow adjustments (e.g. `pr-checks`, `pre-commit`) that support the updated release/CI setup.

## 🧩 Type of change
- [ ] 🔧 CLI / Go code
- [ ] 📦 Helm chart
- [ ] 🧱 Terraform module
- [ ] 📝 Documentation
- [x] 🧪 Test or CI change
- [ ] ♻️ Refactor / cleanup

## ⚠️ Is this a breaking change?
- [ ] Yes, this change breaks existing functionality (explain in summary)

## 🧪 Testing
- [ ] CI passed
- [ ] Manually tested (local/dev cluster)
- [ ] Unit tested
- [x] Not tested (explain why below)

Workflows were prepared/updated but not yet fully validated end-to-end in GitHub Actions (tag-triggered release + manual Google Chat announcement).

## 🔗 Related Issues / Tickets
<!-- e.g. Closes #42, Related to #99 -->

## ✅ Checklist
- [ ] Code compiles and passes all tests
- [ ] Linting and style checks pass
- [ ] Comments added for complex logic
- [ ] Documentation updated (if applicable)

## 📎 Additional Context (optional)
Key changes:
- Added `.github/workflows/release.yaml` to run GoReleaser on pushed tags (`v*`) using a GitHub App token
- Added `.github/workflows/release-announce-google-chat.yaml` for manual release announcements with `confirm_send` safeguard
- Updated `go-binary/.goreleaser.yaml` to publish draft releases to GitHub (`kubara-io/kubara`) and generate grouped changelog sections

Required GitHub secrets:
- `RELEASE_GITHUB_APP_ID`
- `RELEASE_GITHUB_APP_PRIVATE_KEY`
- `GOOGLE_CHAT_WEBHOOK_URL`
