### PR TITLE
chore(renovate): group Go module updates by ecosystem

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -25,6 +25,38 @@
       "description": "Run go mod tidy for all go module updates",
       "matchManagers": ["gomod"],
       "postUpdateOptions": ["gomodTidy"]
+    },
+    {
+      "description": "Group k8s.io go modules (minor and patch)",
+      "matchManagers": ["gomod"],
+      "matchPackagePrefixes": ["k8s.io/"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "k8s.io go modules",
+      "groupSlug": "k8s-io-go-modules"
+    },
+    {
+      "description": "Group sigs.k8s.io go modules (minor and patch)",
+      "matchManagers": ["gomod"],
+      "matchPackagePrefixes": ["sigs.k8s.io/"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "sigs.k8s.io go modules",
+      "groupSlug": "sigs-k8s-io-go-modules"
+    },
+    {
+      "description": "Group golang.org/x go modules (minor and patch)",
+      "matchManagers": ["gomod"],
+      "matchPackagePrefixes": ["golang.org/x/"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "golang.org/x go modules",
+      "groupSlug": "golang-org-x-go-modules"
+    },
+    {
+      "description": "Group koanf go modules (minor and patch)",
+      "matchManagers": ["gomod"],
+      "matchPackagePrefixes": ["github.com/knadh/koanf/"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "koanf go modules",
+      "groupSlug": "koanf-go-modules"
     }
   ]
 }


### PR DESCRIPTION
## 📝 Summary
This PR updates Renovate `packageRules` to group related Go module updates by ecosystem for `minor` and `patch` releases:
- `k8s.io/*`
- `sigs.k8s.io/*`
- `golang.org/x/*`
- `github.com/knadh/koanf/*`

`major` updates remain separate PRs.
Existing `gomodTidy` post-update behavior is unchanged.

## 🧩 Type of change
- [ ] 🔧 CLI / Go code
- [ ] 📦 Helm chart
- [ ] 🧱 Terraform module
- [ ] 📝 Documentation
- [x] 🧪 Test or CI change
- [x] ♻️ Refactor / cleanup

## ⚠️ Is this a breaking change?
- [ ] Yes, this change breaks existing functionality (explain in summary)

## 🧪 Testing
- [ ] CI passed
- [ ] Manually tested (local/dev cluster)
- [ ] Unit tested
- [x] Not tested (explain why below)

Validated `renovate.json` syntax locally (`jq`).
Behavior will be verified on the next Renovate run.

## 🔗 Related Issues / Tickets
N/A

## ✅ Checklist
- [ ] Code compiles and passes all tests
- [ ] Linting and style checks pass
- [ ] Comments added for complex logic
- [ ] Documentation updated (if applicable)

## 📎 Additional Context (optional)
No runtime code changes, only Renovate configuration updates.