### PR TITLE
KPE282 cleanup hardcoded projectname

### DIFF
--- a/go-binary/templates/embedded/customer-service-catalog/terraform/example/infrastructure/env.auto.tfvars.tplt
+++ b/go-binary/templates/embedded/customer-service-catalog/terraform/example/infrastructure/env.auto.tfvars.tplt
@@ -33,7 +33,7 @@ node_pools = [
     minimum            = 2
     name               = "pool-infra"
     labels = {
-      "role"    = "infra"
+      "role" = "infra"
     }
     taints = []
   }


### PR DESCRIPTION
Please read first: https://docs.kubara.io/latest-stable/5_community/contributing/
  
  ## 📝 Summary
  <!-- What does this PR do? e.g. "Adds Terraform module for SKE setup" -->
  
 Reason for this PR is the removal of a hardcoded-value.
 While thinking it through i removed the label entirely since these labels affect the nodepool that is attached to one cluster anyway.
 The value does not enhance experience nor helps to find association of a resource
  
  ## 🧩 Type of change
  - [ ] 🔧 CLI / Go code
  - [ ] 📦 Helm chart
  - [x] 🧱 Terraform module
  - [ ] 📝 Documentation
  - [ ] 🧪 Test or CI change
  - [x] ♻️ Refactor / cleanup
  
  ## ⚠️ Is this a breaking change?
  - [ ] Yes, this change breaks existing functionality (explain in summary)
  
  ## 🧪 Testing
  - [ ] CI passed
  - [ ] Manually tested (local/dev cluster)
  - [ ] Unit tested
  - [ ] Not tested (explain why below)
    
    ## 🔗 Related Issues / Tickets
      <!-- e.g. Closes #42, Related to #99 -->
  
  ## ✅ Checklist
  - [ ] Code compiles and passes all tests
  - [ ] Linting and style checks pass
  - [ ] Comments added for complex logic
  - [ ] Documentation updated (if applicable)
    
    ## 📎 Additional Context (optional)
      <!-- Add logs, screenshots, diagrams, or design notes. -->
