### PR TITLE
ci(docs): publish gh-pages via docs publisher app token

### DIFF
--- a/.github/workflows/docs-build-push-latest-dev.yaml
+++ b/.github/workflows/docs-build-push-latest-dev.yaml
@@ -23,9 +23,20 @@ jobs:
         shell: bash
         working-directory: ./docs
     steps:
+      - name: Create GitHub App token for docs publish
+        id: docs-app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.DOCS_PUBLISHER_GITHUB_APP_ID }}
+          private-key: ${{ secrets.DOCS_PUBLISHER_GITHUB_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: |
+            ${{ github.event.repository.name }}
+
       - name: Checkout kubara repo
         uses: actions/checkout@v6
         with:
+          token: ${{ steps.docs-app-token.outputs.token }}
           fetch-depth: 0
           fetch-tags: true
 

--- a/.github/workflows/docs-build-push-latest-stable.yaml
+++ b/.github/workflows/docs-build-push-latest-stable.yaml
@@ -21,9 +21,20 @@ jobs:
         shell: bash
         working-directory: ./docs
     steps:
+      - name: Create GitHub App token for docs publish
+        id: docs-app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.DOCS_PUBLISHER_GITHUB_APP_ID }}
+          private-key: ${{ secrets.DOCS_PUBLISHER_GITHUB_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: |
+            ${{ github.event.repository.name }}
+
       - name: Checkout kubara repo
         uses: actions/checkout@v6
         with:
+          token: ${{ steps.docs-app-token.outputs.token }}
           fetch-depth: 0
           fetch-tags: true
 


### PR DESCRIPTION
Please read first: https://docs.kubara.io/latest-stable/5_community/contributing/

## 📝 Summary
Use a GitHub App installation token for docs publishing workflows so pushes to `gh-pages` are performed by the docs publisher app (compatible with gh-pages ruleset bypass).

## 🧩 Type of change
- [ ] 🔧 CLI / Go code
- [ ] 📦 Helm chart
- [ ] 🧱 Terraform module
- [ ] 📝 Documentation
- [x] 🧪 Test or CI change
- [ ] ♻️ Refactor / cleanup

## ⚠️ Is this a breaking change?
- [ ] Yes, this change breaks existing functionality (explain in summary)

## 🧪 Testing
- [ ] CI passed
- [ ] Manually tested (local/dev cluster)
- [ ] Unit tested
- [x] Not tested (explain why below)

Not tested locally because this change is validated by running GitHub Actions workflows (`workflow_dispatch` / normal triggers).

## 🔗 Related Issues / Tickets
- Related to branch protection setup for `gh-pages`

## ✅ Checklist
- [ ] Code compiles and passes all tests
- [ ] Linting and style checks pass
- [x] Comments added for complex logic
- [ ] Documentation updated (if applicable)

## 📎 Additional Context (optional)
Updated workflows:
- `.github/workflows/docs-build-push-latest-dev.yaml`
- `.github/workflows/docs-build-push-latest-stable.yaml`
