### PR TITLE
chore(dep): replace archived gopkg.in/yaml.v3 with officially maintained go.yaml.in/yaml/v3

### DIFF
--- a/go-binary/assets/config/configMngr.go
+++ b/go-binary/assets/config/configMngr.go
@@ -14,7 +14,7 @@ import (
 	"github.com/knadh/koanf/providers/file"
 	"github.com/knadh/koanf/v2"
 	schemaValidator "github.com/santhosh-tekuri/jsonschema/v6"
-	goYaml "gopkg.in/yaml.v3"
+	goYaml "go.yaml.in/yaml/v3"
 
 	"github.com/knadh/koanf/parsers/yaml"
 )

--- a/go-binary/assets/config/configMngr_test.go
+++ b/go-binary/assets/config/configMngr_test.go
@@ -10,7 +10,7 @@ import (
 	schemaValidator "github.com/santhosh-tekuri/jsonschema/v6"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 // Helper function to create a valid test config

--- a/go-binary/cmd/generate_test.go
+++ b/go-binary/cmd/generate_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/urfave/cli/v3"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 func TestNewGenerateFlags(t *testing.T) {

--- a/go-binary/go.mod
+++ b/go-binary/go.mod
@@ -18,8 +18,8 @@ require (
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	github.com/stretchr/testify v1.11.1
 	github.com/urfave/cli/v3 v3.7.0
+	go.yaml.in/yaml/v3 v3.0.4
 	golang.org/x/crypto v0.49.0
-	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.35.2
 	k8s.io/apiextensions-apiserver v0.35.2
 	k8s.io/apimachinery v0.35.2
@@ -85,7 +85,6 @@ require (
 	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
-	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/net v0.51.0 // indirect
 	golang.org/x/oauth2 v0.34.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
@@ -98,6 +97,7 @@ require (
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20260127142750-a19766b6e2d4 // indirect
 	k8s.io/utils v0.0.0-20260108192941-914a6e750570 // indirect


### PR DESCRIPTION
## 📝 Summary
The package `gopkg.in/yaml.v3` has been archived since April 2025 and is not maintained anymore. The official Yaml org stepped up and is now maintaining a new repository under go.yaml.in/yaml/v3.

Ref.:

https://github.com/go-yaml/yaml
https://github.com/yaml/go-yaml

## 🧩 Type of change
- [X] 🔧 CLI / Go code
- [ ] 📦 Helm chart
- [ ] 🧱 Terraform module
- [ ] 📝 Documentation
- [ ] 🧪 Test or CI change
- [ ] ♻️ Refactor / cleanup

## ⚠️ Is this a breaking change?
- [ ] Yes, this change breaks existing functionality (explain in summary)

## 🧪 Testing
- [X] CI passed
- [ ] Manually tested (local/dev cluster)
- [X] Unit tested
- [ ] Not tested (explain why below)
  
## 🔗 Related Issues / Tickets
  <!-- e.g. Closes #42, Related to #99 -->

## ✅ Checklist
- [X] Code compiles and passes all tests
- [X] Linting and style checks pass
- [ ] Comments added for complex logic
- [ ] Documentation updated (if applicable)
  
## 📎 Additional Context (optional)
  <!-- Add logs, screenshots, diagrams, or design notes. -->
