### PR TITLE
ci: grant release workflow access to homebrew-tap

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,6 +28,7 @@ jobs:
           owner: ${{ github.repository_owner }}
           repositories: |
             ${{ github.event.repository.name }}
+            homebrew-tap
 
       - name: Set up Go
         uses: actions/setup-go@v6


### PR DESCRIPTION
Please read first: https://docs.kubara.io/latest-stable/5_community/contributing/
  
  ## 📝 Summary
Updates the `release.yaml` workflow to grant the GitHub App token access to the new `homebrew-tap` repository. This is the required CI infrastructure step to allow GoReleaser to automatically push the Homebrew formula for macOS/Linux users during a release.
  
  ## 🧩 Type of change
  - [ ] 🔧 CLI / Go code
  - [ ] 📦 Helm chart
  - [ ] 🧱 Terraform module
  - [ ] 📝 Documentation
  - [x] 🧪 Test or CI change
  - [ ] ♻️ Refactor / cleanup
  
  ## ⚠️ Is this a breaking change?
  - [ ] Yes, this change breaks existing functionality (explain in summary)
  
  ## 🧪 Testing
  - [ ] CI passed
  - [ ] Manually tested (local/dev cluster)
  - [ ] Unit tested
  - [x] Not tested (explain why below)
    
    ## 🔗 Related Issues / Tickets
     Provide package via homebrew tap? #102 
  
  ## ✅ Checklist
  - [ ] Code compiles and passes all tests
  - [ ] Linting and style checks pass
  - [ ] Comments added for complex logic
  - [ ] Documentation updated (if applicable)
    
    ## 📎 Additional Context (optional)
      This PR only focuses on granting the required repository permissions to the GitHub App token.
