### PR TITLE
fix(ci): avoid duplicate goreleaser release runs

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,8 +4,6 @@ on:
   push:
     tags:
       - 'v*.*.*'
-  release:
-    types: [published]
 
 permissions:
   contents: write
@@ -62,14 +60,3 @@ jobs:
           # You can find it in the Apple Developer Portal website.
           MACOS_NOTARY_ISSUER_ID: ${{ secrets.MACOS_NOTARY_ISSUER_ID }}
           # CHOCOLATEY_API_KEY: ${{ secrets.CHOCOLATEY_API_KEY }}
-
-      - name: Run GoReleaser
-        if: github.event_name == 'release' && github.event.action == 'published'
-        uses: goreleaser/goreleaser-action@v7
-        with:
-          distribution: goreleaser
-          version: '~> v2'
-          workdir: go-binary
-          args: release --clean
-        env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Summary
- remove the release.published trigger from the release workflow
- remove the second GoReleaser execution block
- keep a single deterministic release path on tag push

## Why
Running GoReleaser twice for the same version can overwrite artifacts when replace_existing_artifacts is enabled. This PR keeps only one release execution path to prevent accidental artifact replacement.