### PR TITLE
feat(cli): add release update check

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,14 @@ help, h    Shows a list of commands or help for one command
 --decode                          Base64 decode input
 --string string                   Input string for base64 operation
 --file string                     Input file path for base64 operation
+--check-update                    Check online for a newer kubara release
 --help, -h                        show help
 --version, -v                     print the version
 ```
+
+## Update Check
+
+- kubara checks for newer GitHub releases on each run; disable with `KUBARA_UPDATE_CHECK=0`; run `kubara --check-update` for a live check.
 
 ## Community and Support
 

--- a/go-binary/go.mod
+++ b/go-binary/go.mod
@@ -3,6 +3,7 @@ module kubara
 go 1.25.7
 
 require (
+	github.com/Masterminds/semver/v3 v3.4.0
 	github.com/Masterminds/sprig/v3 v3.3.0
 	github.com/external-secrets/external-secrets/apis v0.0.0-20260313124138-3b3cf7ae76da
 	github.com/fatih/color v1.18.0
@@ -30,7 +31,6 @@ require (
 require (
 	dario.cat/mergo v1.0.1 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
-	github.com/Masterminds/semver/v3 v3.4.0 // indirect
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/buger/jsonparser v1.1.1 // indirect

--- a/go-binary/internal/updatecheck/check.go
+++ b/go-binary/internal/updatecheck/check.go
@@ -1,0 +1,286 @@
+package updatecheck
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	semver "github.com/Masterminds/semver/v3"
+	"github.com/fatih/color"
+)
+
+const (
+	githubLatestReleaseAPI = "https://api.github.com/repos/kubara-io/kubara/releases/latest"
+	defaultCacheTTL        = 24 * time.Hour
+	defaultHTTPTimeout     = 1500 * time.Millisecond
+	// UpdateCheckEnvVar controls the startup update hint (`0` disables it).
+	UpdateCheckEnvVar = "KUBARA_UPDATE_CHECK"
+)
+
+// Result represents an available update.
+type Result struct {
+	CurrentVersion string
+	LatestVersion  string
+}
+
+var releaseHintStyle = color.New(color.FgYellow, color.Bold).SprintFunc()
+
+type cacheEntry struct {
+	CheckedAt     time.Time `json:"checkedAt"`
+	LatestVersion string    `json:"latestVersion"`
+}
+
+type checkDeps struct {
+	now           func() time.Time
+	cacheFilePath string
+	httpClient    *http.Client
+}
+
+// NotifyIfNewReleaseAvailable checks for updates and writes a hint if a newer
+// release exists.
+func NotifyIfNewReleaseAvailable(currentVersion string, output io.Writer) {
+	if output == nil {
+		output = os.Stderr
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), defaultHTTPTimeout)
+	defer cancel()
+
+	result, err := Check(ctx, currentVersion)
+	// Fail-open: update checks must never block or fail normal CLI usage.
+	if err != nil || result == nil {
+		return
+	}
+
+	_, _ = fmt.Fprintf(output, "\n%s\n\n", formatReleaseHint(result))
+}
+
+// PrintLiveCheck runs an explicit online update check and writes a concise
+// status message.
+func PrintLiveCheck(currentVersion string, output io.Writer) error {
+	if output == nil {
+		output = os.Stdout
+	}
+
+	if strings.EqualFold(strings.TrimSpace(currentVersion), "dev") {
+		_, _ = fmt.Fprintln(output, "Update check is not available for dev builds.")
+		return nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	result, err := runCheck(ctx, currentVersion, false, false, defaultCheckDeps())
+	if err != nil {
+		return err
+	}
+
+	if result == nil {
+		_, _ = fmt.Fprintf(output, "kubara %s is up to date.\n", currentVersion)
+		return nil
+	}
+
+	_, _ = fmt.Fprintf(output, "%s\n", formatReleaseHint(result))
+	return nil
+}
+
+// Check compares currentVersion with the latest GitHub release and returns
+// update information when a newer version is available.
+func Check(ctx context.Context, currentVersion string) (*Result, error) {
+	return runCheck(ctx, currentVersion, true, true, defaultCheckDeps())
+}
+
+func runCheck(ctx context.Context, currentVersion string, useCache bool, respectDisable bool, deps checkDeps) (*Result, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if respectDisable && shouldSkipUpdateCheck() {
+		return nil, nil
+	}
+
+	if deps.now == nil {
+		deps.now = time.Now
+	}
+	if deps.httpClient == nil {
+		deps.httpClient = &http.Client{Timeout: defaultHTTPTimeout}
+	}
+	if _, hasDeadline := ctx.Deadline(); !hasDeadline {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, defaultHTTPTimeout)
+		defer cancel()
+	}
+
+	current, currentDisplay, ok := parseVersion(currentVersion)
+	// Skip checks for non-release builds (e.g. "dev").
+	if !ok {
+		return nil, nil
+	}
+
+	var cached *cacheEntry
+	if useCache {
+		cached = readCache(deps.cacheFilePath)
+		if isFresh(cached, deps.now()) {
+			return compareVersions(current, currentDisplay, cached.LatestVersion), nil
+		}
+	}
+
+	latestVersion, err := fetchLatestVersion(ctx, currentDisplay, deps.httpClient)
+	if err != nil {
+		// Fall back to stale cache if network access fails.
+		if useCache && cached != nil {
+			return compareVersions(current, currentDisplay, cached.LatestVersion), nil
+		}
+		return nil, err
+	}
+
+	if useCache && strings.TrimSpace(deps.cacheFilePath) != "" {
+		_ = writeCache(deps.cacheFilePath, cacheEntry{
+			CheckedAt:     deps.now().UTC(),
+			LatestVersion: latestVersion,
+		})
+	}
+
+	return compareVersions(current, currentDisplay, latestVersion), nil
+}
+
+func defaultCheckDeps() checkDeps {
+	deps := checkDeps{
+		now:        time.Now,
+		httpClient: &http.Client{Timeout: defaultHTTPTimeout},
+	}
+
+	if path, err := defaultCacheFilePath(); err == nil {
+		deps.cacheFilePath = path
+	}
+
+	return deps
+}
+
+func shouldSkipUpdateCheck() bool {
+	return strings.TrimSpace(os.Getenv(UpdateCheckEnvVar)) == "0"
+}
+
+func defaultCacheFilePath() (string, error) {
+	cacheDir, err := os.UserCacheDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(cacheDir, "kubara", "update-check.json"), nil
+}
+
+func readCache(cachePath string) *cacheEntry {
+	if strings.TrimSpace(cachePath) == "" {
+		return nil
+	}
+	data, err := os.ReadFile(cachePath)
+	// Missing or unreadable cache is fine; we simply treat it as a cache miss.
+	if err != nil {
+		return nil
+	}
+
+	var cached cacheEntry
+	if err := json.Unmarshal(data, &cached); err != nil {
+		return nil
+	}
+	if cached.CheckedAt.IsZero() || strings.TrimSpace(cached.LatestVersion) == "" {
+		return nil
+	}
+
+	return &cached
+}
+
+func writeCache(cachePath string, cached cacheEntry) error {
+	if strings.TrimSpace(cachePath) == "" {
+		return nil
+	}
+	if err := os.MkdirAll(filepath.Dir(cachePath), 0o755); err != nil {
+		return err
+	}
+	data, err := json.Marshal(cached)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(cachePath, data, 0o600)
+}
+
+func isFresh(cached *cacheEntry, now time.Time) bool {
+	if cached == nil {
+		return false
+	}
+	return now.Sub(cached.CheckedAt) < defaultCacheTTL
+}
+
+func compareVersions(current *semver.Version, currentDisplay, latestRaw string) *Result {
+	latest, latestDisplay, ok := parseVersion(latestRaw)
+	// No message when latest tag is invalid or not newer than current.
+	if !ok || !latest.GreaterThan(current) {
+		return nil
+	}
+
+	return &Result{
+		CurrentVersion: currentDisplay,
+		LatestVersion:  latestDisplay,
+	}
+}
+
+func parseVersion(raw string) (*semver.Version, string, bool) {
+	value := strings.TrimSpace(raw)
+	if value == "" || strings.EqualFold(value, "dev") {
+		return nil, "", false
+	}
+	value = strings.TrimPrefix(value, "v")
+	if value == "" {
+		return nil, "", false
+	}
+
+	parsed, err := semver.NewVersion(value)
+	if err != nil {
+		return nil, "", false
+	}
+
+	return parsed, "v" + parsed.String(), true
+}
+
+func fetchLatestVersion(ctx context.Context, currentVersion string, client *http.Client) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, githubLatestReleaseAPI, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("User-Agent", "kubara/"+currentVersion)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		return "", fmt.Errorf("github release check failed with status %s", resp.Status)
+	}
+
+	var payload struct {
+		TagName string `json:"tag_name"`
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&payload); err != nil {
+		return "", err
+	}
+	if strings.TrimSpace(payload.TagName) == "" {
+		return "", fmt.Errorf("github release response did not contain tag_name")
+	}
+
+	return payload.TagName, nil
+}
+
+func formatReleaseHint(result *Result) string {
+	return releaseHintStyle(fmt.Sprintf("A new kubara release is available: %s (current: %s)", result.LatestVersion, result.CurrentVersion))
+}

--- a/go-binary/internal/updatecheck/check_test.go
+++ b/go-binary/internal/updatecheck/check_test.go
@@ -1,0 +1,156 @@
+package updatecheck
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestCheckFetchesLatestReleaseAndCachesResult(t *testing.T) {
+	now := time.Date(2026, 3, 19, 10, 0, 0, 0, time.UTC)
+	cacheFile := filepath.Join(t.TempDir(), "update-check.json")
+
+	client := mockHTTPClient(func(_ *http.Request) (*http.Response, error) {
+		return newResponse(
+			http.StatusOK,
+			`{"tag_name":"v1.4.0"}`,
+		), nil
+	})
+
+	result, err := runCheck(context.Background(), "v1.3.0", true, true, checkDeps{
+		now:           func() time.Time { return now },
+		cacheFilePath: cacheFile,
+		httpClient:    client,
+	})
+	if err != nil {
+		t.Fatalf("check returned error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected update result, got nil")
+	}
+	if result.CurrentVersion != "v1.3.0" {
+		t.Fatalf("unexpected current version: %s", result.CurrentVersion)
+	}
+	if result.LatestVersion != "v1.4.0" {
+		t.Fatalf("unexpected latest version: %s", result.LatestVersion)
+	}
+
+	data, err := os.ReadFile(cacheFile)
+	if err != nil {
+		t.Fatalf("failed to read cache file: %v", err)
+	}
+	var cached cacheEntry
+	if err := json.Unmarshal(data, &cached); err != nil {
+		t.Fatalf("failed to parse cache: %v", err)
+	}
+	if cached.LatestVersion != "v1.4.0" {
+		t.Fatalf("unexpected cached latest version: %s", cached.LatestVersion)
+	}
+}
+
+func TestCheckUsesFreshCacheWithoutNetworkCall(t *testing.T) {
+	now := time.Date(2026, 3, 19, 12, 0, 0, 0, time.UTC)
+	cacheFile := filepath.Join(t.TempDir(), "update-check.json")
+
+	if err := writeCache(cacheFile, cacheEntry{
+		CheckedAt:     now.Add(-1 * time.Hour),
+		LatestVersion: "v2.0.0",
+	}); err != nil {
+		t.Fatalf("failed to seed cache: %v", err)
+	}
+
+	requestCount := 0
+	client := mockHTTPClient(func(_ *http.Request) (*http.Response, error) {
+		requestCount++
+		return newResponse(http.StatusInternalServerError, ``), nil
+	})
+
+	result, err := runCheck(context.Background(), "v1.9.0", true, true, checkDeps{
+		now:           func() time.Time { return now },
+		cacheFilePath: cacheFile,
+		httpClient:    client,
+	})
+	if err != nil {
+		t.Fatalf("check returned error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected update result from cache, got nil")
+	}
+	if requestCount != 0 {
+		t.Fatalf("expected 0 network calls, got %d", requestCount)
+	}
+}
+
+func TestCheckFallsBackToStaleCacheWhenRemoteFails(t *testing.T) {
+	now := time.Date(2026, 3, 19, 14, 0, 0, 0, time.UTC)
+	cacheFile := filepath.Join(t.TempDir(), "update-check.json")
+
+	if err := writeCache(cacheFile, cacheEntry{
+		CheckedAt:     now.Add(-48 * time.Hour),
+		LatestVersion: "v3.0.0",
+	}); err != nil {
+		t.Fatalf("failed to seed cache: %v", err)
+	}
+
+	client := mockHTTPClient(func(_ *http.Request) (*http.Response, error) {
+		return newResponse(http.StatusServiceUnavailable, ``), nil
+	})
+
+	result, err := runCheck(context.Background(), "v2.9.0", true, true, checkDeps{
+		now:           func() time.Time { return now },
+		cacheFilePath: cacheFile,
+		httpClient:    client,
+	})
+	if err != nil {
+		t.Fatalf("check returned error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected stale-cache fallback result, got nil")
+	}
+	if result.LatestVersion != "v3.0.0" {
+		t.Fatalf("unexpected fallback version: %s", result.LatestVersion)
+	}
+}
+
+func TestShouldSkipUpdateCheckUsesSimpleEnvFlag(t *testing.T) {
+	t.Setenv(UpdateCheckEnvVar, "0")
+	if !shouldSkipUpdateCheck() {
+		t.Fatal("expected update check to be skipped when env is 0")
+	}
+
+	t.Setenv(UpdateCheckEnvVar, "1")
+	if shouldSkipUpdateCheck() {
+		t.Fatal("expected update check to run when env is 1")
+	}
+
+	t.Setenv(UpdateCheckEnvVar, "")
+	if shouldSkipUpdateCheck() {
+		t.Fatal("expected update check to run when env is empty")
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func mockHTTPClient(fn roundTripFunc) *http.Client {
+	return &http.Client{Transport: fn}
+}
+
+func newResponse(statusCode int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: statusCode,
+		Status:     fmt.Sprintf("%d %s", statusCode, http.StatusText(statusCode)),
+		Header:     make(http.Header),
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+}

--- a/go-binary/main.go
+++ b/go-binary/main.go
@@ -5,9 +5,11 @@ import (
 	"encoding/base64"
 	"fmt"
 	"kubara/cmd"
+	"kubara/internal/updatecheck"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/rs/zerolog"
@@ -66,6 +68,7 @@ func execOrFatal(name string, args ...string) {
 var (
 	kubeconfigFilePath string
 	testK8sConnection  bool
+	checkUpdateFlag    bool
 	base64Mode         bool
 	encodeFlag         bool
 	decodeFlag         bool
@@ -121,6 +124,10 @@ func NewAppAction(cmd *cli.Command) error {
 	switch {
 	case testK8sConnection:
 		testConnection(kubeconfigFilePath)
+	case checkUpdateFlag:
+		if err := updatecheck.PrintLiveCheck(version, os.Stdout); err != nil {
+			return cli.Exit(fmt.Sprintf("Error: update check failed: %v", err), 1)
+		}
 	default:
 		cli.ShowAppHelpAndExit(cmd, 0)
 	}
@@ -188,6 +195,12 @@ func main() {
 			Usage:       "Input file path for base64 operation",
 			Destination: &inputFile,
 		},
+		&cli.BoolFlag{
+			Name:        "check-update",
+			Value:       false,
+			Usage:       "Check online for a newer kubara release",
+			Destination: &checkUpdateFlag,
+		},
 	}
 
 	app := &cli.Command{
@@ -195,10 +208,10 @@ func main() {
 		Version:     version,
 		Authors:     authors,
 		Copyright:   "",
-		Usage:       "",
+		Usage:       "Opinionated CLI for Kubernetes platform engineering",
 		Flags:       flags,
 		UsageText:   "",
-		Description: "",
+		Description: "kubara is an opinionated CLI to bootstrap and operate Kubernetes platforms with GitOps-first workflows.",
 		Commands: []*cli.Command{
 			cmd.NewInitCmd(),
 			cmd.NewGenerateCmd(),
@@ -209,6 +222,11 @@ func main() {
 			return NewAppAction(cmd)
 		},
 	}
+
+	if !slices.Contains(os.Args[1:], "--check-update") {
+		updatecheck.NotifyIfNewReleaseAvailable(version, os.Stderr)
+	}
+
 	if err := app.Run(context.Background(), os.Args); err != nil {
 		log.Fatal().Err(err).Msg("Error running program")
 	}


### PR DESCRIPTION
## 📝 Summary
This PR adds a simple update check for the kubara CLI.

Kubara now shows an update hint during normal command runs when a newer GitHub release exists.

The startup check uses a 24-hour cache to reduce GitHub API calls.
The cache does not hide the hint.
If the cached result already says that a newer release exists, the hint is still shown on every run.
The 24-hour window only controls when kubara fetches fresh release data again.

The new global flag `--check-update` always performs a live check.
It ignores both the cache and `KUBARA_UPDATE_CHECK=0`.

This PR does not add self-update behavior.
CLI help text and README were updated.

## 🧩 Type of change
- [x] 🔧 CLI / Go code
- [ ] 📦 Helm chart
- [ ] 🧱 Terraform module
- [x] 📝 Documentation
- [ ] 🧪 Test or CI change
- [x] ♻️ Refactor / cleanup

## ⚠️ Is this a breaking change?
- [ ] Yes, this change breaks existing functionality (explain in summary)

## 🧪 Testing
- [ ] CI passed
- [x] Manually tested (local/dev cluster)
- [x] Unit tested
- [ ] Not tested (explain why below)

## 🔗 Related Issues / Tickets
N/A

## ✅ Checklist
- [x] Code compiles and passes all tests
- [ ] Linting and style checks pass
- [x] Comments added for complex logic
- [x] Documentation updated (if applicable)

## 📎 Additional Context (optional)
Manual testing with `-ldflags` to simulate a specific local version:
- `go run -ldflags="-X main.version=v0.6.2" ./go-binary --check-update`
- `go run -ldflags="-X main.version=v0.6.2" ./go-binary --version`
- `KUBARA_UPDATE_CHECK=0 go run -ldflags="-X main.version=v0.6.2" ./go-binary --version`
