### PR TITLE
chore(go): propose upgrading to Go 1.26.1

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -18,9 +18,9 @@ env:
   RENDER_DIR: ${{ github.workspace }}/rendered
   OUTPUT_GENERATED_DIR: ${{ github.workspace }}/output-generated
   # renovate: datasource=github-releases depName=golangci/golangci-lint
-  GOLANGCI_LINT_VERSION: "v2.8.0"
+  GOLANGCI_LINT_VERSION: "v2.11.3"
   # renovate: datasource=github-releases depName=securego/gosec
-  GOSEC_VERSION: "v2.22.11"
+  GOSEC_VERSION: "v2.25.0"
   # renovate: datasource=github-releases depName=yannh/kubeconform
   KUBECONFORM_VERSION: "v0.7.0"
   # renovate: datasource=github-releases depName=terraform-linters/tflint

--- a/go-binary/assets/envmap/envMapMngr.go
+++ b/go-binary/assets/envmap/envMapMngr.go
@@ -109,7 +109,7 @@ func (em *Manager) SaveToFile(path string) error {
 		if koanfKey == "" {
 			continue
 		}
-		b.WriteString(fmt.Sprintf("%s='%v'\n", koanfKey, fieldVal.Interface()))
+		fmt.Fprintf(&b, "%s='%v'\n", koanfKey, fieldVal.Interface())
 	}
 
 	return os.WriteFile(path, []byte(b.String()), 0600)
@@ -137,7 +137,7 @@ func (em *Manager) GenerateEnvExample() ([]byte, error) {
 		if koanfKey != "" {
 			// Use the default value from the tag, or the current value
 			defaultVal := fieldType.Tag.Get("default")
-			b.WriteString(fmt.Sprintf("%s='%s'\n", koanfKey, defaultVal))
+			fmt.Fprintf(&b, "%s='%s'\n", koanfKey, defaultVal)
 		}
 	}
 

--- a/go-binary/go.mod
+++ b/go-binary/go.mod
@@ -5,7 +5,7 @@ go 1.26.1
 require (
 	github.com/Masterminds/semver/v3 v3.4.0
 	github.com/Masterminds/sprig/v3 v3.3.0
-	github.com/external-secrets/external-secrets/apis v0.0.0-20260313124138-3b3cf7ae76da
+	github.com/external-secrets/external-secrets/apis v0.0.0-20260316180332-fed3824a0ef6
 	github.com/fatih/color v1.18.0
 	github.com/go-git/go-git/v5 v5.17.0
 	github.com/go-viper/mapstructure/v2 v2.5.0

--- a/go-binary/go.sum
+++ b/go-binary/go.sum
@@ -26,8 +26,8 @@ github.com/evanphx/json-patch v0.5.2 h1:xVCHIVMUu1wtM/VkR9jVZ45N3FhZfYMMYGorLCR8
 github.com/evanphx/json-patch v0.5.2/go.mod h1:ZWS5hhDbVDyob71nXKNL0+PWn6ToqBHMikGIFbs31qQ=
 github.com/evanphx/json-patch/v5 v5.9.11 h1:/8HVnzMq13/3x9TPvjG08wUGqBTmZBsCWzjTM0wiaDU=
 github.com/evanphx/json-patch/v5 v5.9.11/go.mod h1:3j+LviiESTElxA4p3EMKAB9HXj3/XEtnUf6OZxqIQTM=
-github.com/external-secrets/external-secrets/apis v0.0.0-20260313124138-3b3cf7ae76da h1:YTJdDV0I/sypBF8oASDW54xHyGn8My+BVWD6oyJp5L8=
-github.com/external-secrets/external-secrets/apis v0.0.0-20260313124138-3b3cf7ae76da/go.mod h1:Ne6H/bciRDZLiH8IB17B1BiIi7BtOoGN2TCRNsrCBsI=
+github.com/external-secrets/external-secrets/apis v0.0.0-20260316180332-fed3824a0ef6 h1:7VT7rpLDuH7LoazxUBEkTHEcfbx4Rf8ytLcIlFWDJaE=
+github.com/external-secrets/external-secrets/apis v0.0.0-20260316180332-fed3824a0ef6/go.mod h1:MfydIMxbsp/ESsVR3nhOsycAub3iMPLMutElN/XAlm0=
 github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=
 github.com/fatih/color v1.18.0/go.mod h1:4FelSpRwEGDpQ12mAdzqdOukCy4u8WUtOY6lkT/6HfU=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=


### PR DESCRIPTION
## 📝 Summary
Proposes upgrading the project Go version from `1.25.7` to `1.26.1` and bundles the related CI/tooling updates needed to make this transition mergeable.

This PR consolidates the scope of:
- #99 (`external-secrets/apis` digest update requiring Go 1.26.1)
- #140 (`golangci-lint` to `v2.11.3`)
- #141 (`gosec` to `v2.25.0`)

Additionally, it includes two small lint fixes in `envMapMngr.go` required by the newer `golangci-lint` release.

## 🧩 Type of change
- [x] 🔧 CLI / Go code
- [ ] 📦 Helm chart
- [ ] 🧱 Terraform module
- [ ] 📝 Documentation
- [x] 🧪 Test or CI change
- [ ] ♻️ Refactor / cleanup

## ⚠️ Is this a breaking change?
- [ ] Yes, this change breaks existing functionality (explain in summary)

## 🧪 Testing
- [ ] CI passed
- [x] Manually tested (local/dev cluster)
- [x] Unit tested
- [ ] Not tested (explain why below)

## 🔗 Related Issues / Tickets
Related to #99
Related to #140
Related to #141

## ✅ Checklist
- [x] Code compiles and passes all tests
- [x] Linting and style checks pass
- [ ] Comments added for complex logic
- [ ] Documentation updated (if applicable)

## 📎 Additional Context (optional)
Local verification commands:
- `go mod tidy -v`
- `go test ./...`
- `golangci-lint run --path-mode=abs --output.text.path stdout`