### PR TITLE
fix(bootstrap): align completion URL behavior with PR #129

### DIFF
--- a/go-binary/internal/bootstrap/bootstrap.go
+++ b/go-binary/internal/bootstrap/bootstrap.go
@@ -328,11 +328,8 @@ func applySecrets(ctx context.Context, client *k8s.Client, opts *Options) error 
 	return nil
 }
 
-// Helper struct for seperation of concerns and better testability
+// CompletionLogConfig contains the data needed to render the bootstrap completion output.
 type CompletionLogConfig struct {
-	ProjectName    string
-	ProjectStage   string
-	DomainName     string
 	WizardPassword string
 	ClusterDNSName string
 }
@@ -343,28 +340,26 @@ func printCompletionMessage(opts *Options) {
 		log.Info().Msg("[DRY-RUN] ArgoCD bootstrap completed successfully")
 	} else {
 		config := CompletionLogConfig{}
-		config.ProjectName = opts.EnvMap.ProjectStage
-		config.ProjectStage = opts.EnvMap.ProjectStage
-		config.DomainName = opts.EnvMap.DomainName
-		config.ClusterDNSName = opts.ClusterConfig.DNSName
+		if opts.ClusterConfig != nil {
+			config.ClusterDNSName = opts.ClusterConfig.DNSName
+		}
 		config.WizardPassword = opts.EnvMap.ArgocdWizardAccountPassword
 		log.Info().Msg(CreateCompletionMessage(config))
 	}
 }
 
-// CreateCompletionMessage take a given CompletionLogConfig
-// Depending on the fields set inside the config, the function returns a formatted message with either the full url being present or omitted
+func completionIngressHost(config CompletionLogConfig) string {
+	return config.ClusterDNSName
+}
+
+// CreateCompletionMessage returns the formatted completion message.
 func CreateCompletionMessage(config CompletionLogConfig) string {
 	formattedOutput := ""
-	// TODO: check are they ever not set?
-	if config.ProjectName != "" && config.ProjectStage != "" {
-		domainName := config.DomainName
-		if config.ClusterDNSName != "" {
-			domainName = config.ClusterDNSName
-		}
-		completeDomainName := config.ProjectName + "-" + config.ProjectStage + "." + domainName
-		formattedOutput = fmt.Sprintf(" or try: http://%s/argocd (if ingress is running)", completeDomainName)
+	ingressHost := completionIngressHost(config)
+	if ingressHost != "" {
+		formattedOutput = fmt.Sprintf(" or try: https://%s/argocd (if ingress is running)", ingressHost)
 	}
+
 	return fmt.Sprintf(`
 🎉 ArgoCD bootstrap complete!
 

--- a/go-binary/internal/bootstrap/bootstrap_test.go
+++ b/go-binary/internal/bootstrap/bootstrap_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-const STRING_TEMPLATE string = `
+const completionMessageTemplate = `
 🎉 ArgoCD bootstrap complete!
 
 You can access the Argo CD UI with user "wizard" and your chosen password "%s" at:
@@ -21,15 +21,13 @@ Then open: http://localhost:8080/argocd%s
 2. Configure your applications
 3. Set up monitoring and logging as needed`
 
-func Test_CorrectCompletionOutput(t *testing.T) {
+func Test_UsesClusterDNSNameForIngressURL(t *testing.T) {
 	config := CompletionLogConfig{}
 	config.WizardPassword = "wizard_password"
-	config.DomainName = "example.com"
-	config.ProjectName = "ProjectName"
-	config.ProjectStage = "StageName"
+	config.ClusterDNSName = "cluster.example.com"
 
-	expected := fmt.Sprintf(STRING_TEMPLATE, config.WizardPassword,
-		" or try: http://ProjectName-StageName.example.com/argocd (if ingress is running)")
+	expected := fmt.Sprintf(completionMessageTemplate, config.WizardPassword,
+		" or try: https://cluster.example.com/argocd (if ingress is running)")
 	actual := CreateCompletionMessage(config)
 	assert.Equal(t, expected, actual)
 }
@@ -39,24 +37,8 @@ func Test_MissingEnvVariableLeadsToURLBeingOmitted(t *testing.T) {
 
 	config.WizardPassword = "wizard_password"
 
-	expected := fmt.Sprintf(STRING_TEMPLATE, config.WizardPassword, "")
+	expected := fmt.Sprintf(completionMessageTemplate, config.WizardPassword, "")
 	actual := CreateCompletionMessage(config)
 
 	assert.Equal(t, expected, actual)
-}
-
-func Test_ClusterDNSNameOverwritesDomainName(t *testing.T) {
-	config := CompletionLogConfig{}
-	config.WizardPassword = "wizard_password"
-	config.DomainName = "example.com"
-	config.ProjectName = "ProjectName"
-	config.ProjectStage = "StageName"
-	config.ClusterDNSName = "cluster.example.com"
-
-	expected := fmt.Sprintf(STRING_TEMPLATE, config.WizardPassword,
-		" or try: http://ProjectName-StageName.cluster.example.com/argocd (if ingress is running)")
-	actual := CreateCompletionMessage(config)
-
-	assert.Equal(t, expected, actual)
-
 }


### PR DESCRIPTION
Please read first: https://github.com/kubara-io/kubara/blob/main/CONTRIBUTING.md

## 📝 Summary
This PR aligns bootstrap completion URL behavior with PR #129 and hardens it with unit tests.

Changes made:
- Use `ClusterConfig.DNSName` as the source of truth for the ingress URL hint.
- Keep `https` in the completion output URL.
- Remove env-based fallback URL construction to avoid mixed or duplicated host composition.
- Keep the completion message refactor and update tests accordingly.

## 🧩 Type of change
- [X] 🔧 CLI / Go code
- [ ] 📦 Helm chart
- [ ] 🧱 Terraform module
- [ ] 📝 Documentation
- [X] 🧪 Test or CI change
- [X] ♻️ Refactor / cleanup

## ⚠️ Is this a breaking change?
- [ ] Yes, this change breaks existing functionality (explain in summary)

## 🧪 Testing
- [X] Unit tested (`go test ./internal/bootstrap -count=1`)
- [ ] CI passed
- [ ] Manually tested (local/dev cluster)
- [ ] Not tested (explain why below)

## 🔗 Related Issues / Tickets
- Follow-up alignment to #129

## ✅ Checklist
- [X] Code compiles and passes all tests
- [X] Linting and style checks pass
- [X] Comments added for complex logic
- [ ] Documentation updated (if applicable)

## 📎 Additional Context (optional)
The original functional bug was fixed in #129. This PR keeps that behavior intact while making the completion message logic test-backed and regression-resistant.