### PR TITLE
ci: add release artifacts for licenses and sbom

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,14 +15,14 @@ jobs:
     environment: signing
     steps:
       - name: Checkout kubara repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
         with:
           fetch-depth: 0
           fetch-tags: true
 
       - name: Create GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 #v3.0.0
         with:
           app-id: ${{ secrets.RELEASE_GITHUB_APP_ID }}
           private-key: ${{ secrets.RELEASE_GITHUB_APP_PRIVATE_KEY }}
@@ -32,28 +32,34 @@ jobs:
             homebrew-tap
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c #v6.4.0
         with:
           go-version-file: go-binary/go.mod
           cache: true
           cache-dependency-path: go-binary/go.sum
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a #v4.0.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd #v4.0.0
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 #v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Install Syft
+        uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 #v0.24.0
+
+      - name: Install go-licenses
+        run: go install github.com/google/go-licenses/v2@3e084b0caf710f7bfead967567539214f598c0a2 #v2.0.1
+
       - name: Run GoReleaser
         if: github.event_name == 'push'
-        uses: goreleaser/goreleaser-action@v7
+        uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29  #v7.0.0
         with:
           distribution: goreleaser
           version: '~> v2'

--- a/go-binary/.gitignore
+++ b/go-binary/.gitignore
@@ -22,3 +22,4 @@ test/
 .idea/
 
 dist/
+licenses.csv

--- a/go-binary/.goreleaser.yaml
+++ b/go-binary/.goreleaser.yaml
@@ -1,6 +1,9 @@
 ---
 version: 2
 project_name: kubara
+before:
+  hooks:
+    - sh -c 'go-licenses report . --ignore kubara > licenses.csv'
 release:
   github:
     owner: kubara-io
@@ -8,6 +11,8 @@ release:
   draft: true
   replace_existing_draft: true
   replace_existing_artifacts: true
+  extra_files:
+    - glob: licenses.csv
 changelog:
   use: git
   sort: asc
@@ -174,6 +179,10 @@ homebrew_casks:
     binaries:
       - kubara
     skip_upload: "auto"
+sboms:
+  - artifacts: archive
+    documents:
+      - "{{ .ArtifactName }}.sbom.json"
 dockers_v2:
   - dockerfile: ../Dockerfile
     images:
@@ -186,6 +195,6 @@ nfpms:
   - id: kubara-packages
     ids:
       - kubara-linux
-    maintainer: "Kubara Maintainer <kubara@schwary.digits>"
+    maintainer: "Kubara Maintainer <kubara@schwarz.digits>"
     formats:
       - deb

--- a/go-binary/.goreleaser.yaml
+++ b/go-binary/.goreleaser.yaml
@@ -195,6 +195,6 @@ nfpms:
   - id: kubara-packages
     ids:
       - kubara-linux
-    maintainer: "Kubara Maintainer <kubara@schwarz.digits>"
+    maintainer: "Kubara Maintainer <kubara@digits.schwarz>"
     formats:
       - deb


### PR DESCRIPTION
## 📝 Summary

This PR introduces license compliance and SBOM generation, as part of the release publishing process.

Additionally it changes the GitHub Actions to use pinned commit SHAs for better supply chain security.

## 🧩 Type of change
- [ ] 🔧 CLI / Go code
- [ ] 📦 Helm chart
- [ ] 🧱 Terraform module
- [ ] 📝 Documentation
- [X] 🧪 Test or CI change
- [ ] ♻️ Refactor / cleanup

## ⚠️ Is this a breaking change?
- [ ] Yes, this change breaks existing functionality (explain in summary)

## 🧪 Testing
- [ ] CI passed
- [X] Manually tested (local/dev cluster)
- [ ] Unit tested
- [ ] Not tested (explain why below)
  
## 🔗 Related Issues / Tickets
Closes #181 

## ✅ Checklist
- [X] Code compiles and passes all tests
- [X] Linting and style checks pass
- [ ] Comments added for complex logic
- [ ] Documentation updated (if applicable)
  
## 📎 Additional Context (optional)
<!-- Add logs, screenshots, diagrams, or design notes. -->
