### PR TITLE
fix: homer lighttpd configmap includes

### DIFF
--- a/go-binary/templates/embedded/managed-service-catalog/helm/homer-dashboard/templates/configmaps/lighttpdconfig-configmap.yaml
+++ b/go-binary/templates/embedded/managed-service-catalog/helm/homer-dashboard/templates/configmaps/lighttpdconfig-configmap.yaml
@@ -7,7 +7,6 @@ metadata:
     app: homer
 data:
   lighttpd: |
-    include "/etc/lighttpd/mime-types.conf"
     include_shell "/etc/lighttpd/ipv6.sh"
 
     server.port            = env.PORT


### PR DESCRIPTION
## 📝 Summary
Upstream Homer made an update and removed the lighttp mime-types file from the container image therefore our custom helm chart fails while starting the server as it still tries to include / load a file that doesn't exist anymore.

Therefore I removed the include in our helm chart as has been done in the official upstream repository, see: https://github.com/bastienwirtz/homer/pull/1032


## 🧩 Type of change
- [ ] 🔧 CLI / Go code
- [X] 📦 Helm chart
- [ ] 🧱 Terraform module
- [ ] 📝 Documentation
- [ ] 🧪 Test or CI change
- [ ] ♻️ Refactor / cleanup

## ⚠️ Is this a breaking change?
- [ ] Yes, this change breaks existing functionality (explain in summary)

## 🧪 Testing
- [ ] CI passed
- [X] Manually tested (local/dev cluster)
- [ ] Unit tested
- [ ] Not tested (explain why below)
  
## 🔗 Related Issues / Tickets
https://github.com/bastienwirtz/homer/pull/1032

## ✅ Checklist
- [X] Code compiles and passes all tests
- [X] Linting and style checks pass
- [ ] Comments added for complex logic
- [ ] Documentation updated (if applicable)
  
## 📎 Additional Context (optional)
<!-- Add logs, screenshots, diagrams, or design notes. -->
