### PR TITLE
fix: argo out-off-sync issues because of newly introduced external secret null byte policy

### DIFF
--- a/go-binary/templates/embedded/managed-service-catalog/helm/template-library/templates/external-secrets/_externalSecret.es.argo.cluster.tpl
+++ b/go-binary/templates/embedded/managed-service-catalog/helm/template-library/templates/external-secrets/_externalSecret.es.argo.cluster.tpl
@@ -44,5 +44,6 @@ spec:
         conversionStrategy: Default
         decodingStrategy: None
         metadataPolicy: None
+        nullBytePolicy: Fail
 ---
 {{- end }}

--- a/go-binary/templates/embedded/managed-service-catalog/helm/template-library/templates/external-secrets/_externalSecret.es.argo.repo.tpl
+++ b/go-binary/templates/embedded/managed-service-catalog/helm/template-library/templates/external-secrets/_externalSecret.es.argo.repo.tpl
@@ -50,5 +50,6 @@ spec:
         conversionStrategy: Default
         decodingStrategy: None
         metadataPolicy: None
+        nullBytePolicy: Fail
 ---
 {{- end }}

--- a/go-binary/templates/embedded/managed-service-catalog/helm/template-library/templates/external-secrets/_externalSecrets.ces.dockerPullSecret.tpl
+++ b/go-binary/templates/embedded/managed-service-catalog/helm/template-library/templates/external-secrets/_externalSecrets.ces.dockerPullSecret.tpl
@@ -39,5 +39,6 @@ spec:
           conversionStrategy: Default
           decodingStrategy: None
           metadataPolicy: None
+          nullBytePolicy: Fail
 ---
 {{- end }}

--- a/go-binary/templates/embedded/managed-service-catalog/helm/template-library/templates/external-secrets/_externalSecrets.es.generic.tpl
+++ b/go-binary/templates/embedded/managed-service-catalog/helm/template-library/templates/external-secrets/_externalSecrets.es.generic.tpl
@@ -45,6 +45,7 @@ spec:
         conversionStrategy: Default
         decodingStrategy: None
         metadataPolicy: None
+        nullBytePolicy: Fail
     {{- end }}
   {{- else if $item.dataFrom }}
   dataFrom:
@@ -60,6 +61,7 @@ spec:
         conversionStrategy: Default
         decodingStrategy: None
         metadataPolicy: None
+        nullBytePolicy: Fail
     {{- end }}
   {{- end }}
 ---


### PR DESCRIPTION
## 📝 Summary
All Argo CD apps have been constantly out-of-sync because external-secrets introduced a new field called nullBytePolicy for how to handle secrets that have no contents.

This is now being set to "Fail" with this PR. To indicate to the user that the contents of a secret will not be of use to an application, to more easily trace the issue and not allow applications to be able to start as they expect an mountable secret to have valid content.

## 🧩 Type of change
- [ ] 🔧 CLI / Go code
- [X] 📦 Helm chart
- [ ] 🧱 Terraform module
- [ ] 📝 Documentation
- [ ] 🧪 Test or CI change
- [ ] ♻️ Refactor / cleanup

## ⚠️ Is this a breaking change?
- [ ] Yes, this change breaks existing functionality (explain in summary)

## 🧪 Testing
- [X] CI passed
- [X] Manually tested (local/dev cluster)
- [ ] Unit tested
- [ ] Not tested (explain why below)
  
## 🔗 Related Issues / Tickets
<!-- e.g. Closes #42, Related to #99 -->

## ✅ Checklist
- [X] Code compiles and passes all tests
- [X] Linting and style checks pass
- [ ] Comments added for complex logic
- [ ] Documentation updated (if applicable)
  
## 📎 Additional Context (optional)
https://external-secrets.io/main/api/spec/#external-secrets.io/v1.ExternalSecretNullBytePolicy
https://github.com/external-secrets/external-secrets/pull/6194
https://github.com/external-secrets/external-secrets/releases/tag/v2.3.0
