### PR TITLE
ci: validate CRDs from rendered schemas (fix #230)

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -23,6 +23,8 @@ env:
   GOSEC_VERSION: "v2.25.0"
   # renovate: datasource=github-releases depName=yannh/kubeconform
   KUBECONFORM_VERSION: "v0.7.0"
+  # renovate: datasource=github-releases depName=mikefarah/yq
+  YQ_VERSION: "v4.48.1"
   # renovate: datasource=github-releases depName=terraform-linters/tflint
   TFLINT_VERSION: "v0.61.0"
   ARTIFACT_RETENTION_DAYS: "15"
@@ -339,6 +341,28 @@ jobs:
           set -euo pipefail
           helm version --short
 
+      - name: Install yq (pinned)
+        run: |
+          set -euo pipefail
+          mkdir -p ~/.local/bin
+
+          YQ_BASE_URL="https://github.com/mikefarah/yq/releases/download/${{ env.YQ_VERSION }}"
+          YQ_BINARY="yq_linux_amd64"
+          YQ_SHA256="$(curl -fsSL "$YQ_BASE_URL/checksums" | awk '$2 == "yq_linux_amd64" {print $1}')"
+          TMP_BINARY="$(mktemp)"
+
+          if [[ -z "$YQ_SHA256" ]]; then
+            echo "::error::Could not resolve checksum for $YQ_BINARY"
+            exit 1
+          fi
+
+          curl -fsSL "$YQ_BASE_URL/$YQ_BINARY" -o "$TMP_BINARY"
+          echo "$YQ_SHA256  $TMP_BINARY" | sha256sum -c -
+          install -m 0755 "$TMP_BINARY" "$HOME/.local/bin/yq"
+          rm -f "$TMP_BINARY"
+
+          yq --version
+
       - name: Cache kubeconform
         id: cache-kubeconform
         uses: actions/cache@v5
@@ -458,8 +482,20 @@ jobs:
                 [[ -n "$CRD_KIND" ]] || continue
                 [[ -n "$CRD_VERSION" ]] || continue
                 [[ -n "$CRD_SCHEMA_B64" ]] || continue
-                mkdir -p "$SCHEMA_POOL_DIR/$CRD_GROUP"
-                printf '%s' "$CRD_SCHEMA_B64" | base64 --decode > "$SCHEMA_POOL_DIR/$CRD_GROUP/${CRD_KIND}_${CRD_VERSION}.json"
+                SCHEMA_DIR="$SCHEMA_POOL_DIR/$CRD_GROUP"
+                SCHEMA_FILE="$SCHEMA_DIR/${CRD_KIND}_${CRD_VERSION}.json"
+                TMP_SCHEMA_FILE="$(mktemp)"
+                mkdir -p "$SCHEMA_DIR"
+                printf '%s' "$CRD_SCHEMA_B64" | base64 --decode > "$TMP_SCHEMA_FILE"
+                if [[ -f "$SCHEMA_FILE" ]]; then
+                  if ! cmp -s "$SCHEMA_FILE" "$TMP_SCHEMA_FILE"; then
+                    echo "::error file=$RENDER_FILE::CRD schema collision for ${CRD_GROUP}/${CRD_KIND}/${CRD_VERSION}: definitions differ across rendered charts"
+                    FAILED_CHARTS+=("$CHART:schema-collision-${CRD_GROUP}-${CRD_KIND}-${CRD_VERSION}")
+                  fi
+                  rm -f "$TMP_SCHEMA_FILE"
+                else
+                  mv "$TMP_SCHEMA_FILE" "$SCHEMA_FILE"
+                fi
               done < <(
                 yq -r 'select(.kind == "CustomResourceDefinition") | .spec as $spec | $spec.group as $group | $spec.names.kind as $kind | $spec.versions[] | select(.schema.openAPIV3Schema != null) | [$group, $kind, .name, (.schema.openAPIV3Schema | tojson | @base64)] | @tsv' "$RENDER_FILE"
               )

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -474,13 +474,11 @@ jobs:
             # CRD status is server-populated and may contain null placeholders in chart output.
             # Remove it before schema validation to avoid false negatives in kubeconform.
             yq eval -i 'select(.kind == "CustomResourceDefinition") |= del(.status)' "$RENDER_FILE"
-            VALIDATION_FILE="${RENDER_FILE%.yaml}.validation.yaml"
-            # CRD manifests are sourced from upstream charts; validate rendered workloads against the extracted schema pool.
-            yq eval 'select(.kind != "CustomResourceDefinition")' "$RENDER_FILE" > "$VALIDATION_FILE"
             if ! kubeconform -output pretty -strict -kubernetes-version="$KUBE_VERSION" \
                 -schema-location "$SCHEMA_POOL_DIR/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json" \
                 -schema-location default \
-                "$VALIDATION_FILE" \
+                -schema-location https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/{{.NormalizedKubernetesVersion}}/{{.ResourceKind}}.json \
+                "$RENDER_FILE" \
                 | tee "${{ env.REPORT_DIR }}/helm/${RENDER_CHART}-${RENDER_NAME}-kubeconform.log"; then
               echo "::error file=$RENDER_FILE::kubeconform failed for $RENDER_CHART ($RENDER_NAME)"
               FAILED_CHARTS+=("$RENDER_CHART:$RENDER_NAME")

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -384,6 +384,10 @@ jobs:
           CUSTOMER_BASE="customer-service-catalog/helm/kubara"
           echo "🔍 Scanning managed Helm charts..."
           FAILED_CHARTS=()
+          RENDER_TARGETS=()
+          SCHEMA_POOL_DIR="${{ env.RENDER_DIR }}/schema-pool"
+          rm -rf "$SCHEMA_POOL_DIR"
+          mkdir -p "$SCHEMA_POOL_DIR"
           for CHART in $(find "$MANAGED_BASE" -mindepth 1 -maxdepth 1 -type d -printf '%f\n' | sort); do
             echo ""
             echo "::group::Processing chart: $CHART"
@@ -444,43 +448,42 @@ jobs:
               echo "📄 Rendering chart with default values"
               helm template "${HELM_TEMPLATE_API_ARGS[@]}" --include-crds "$CHART" "$MANAGED_CHART_PATH" > "$OUT_DIR/render.yaml"
             fi
-            SCHEMA_DIR="$OUT_DIR/schemas"
-            rm -rf "$SCHEMA_DIR"
-            mkdir -p "$SCHEMA_DIR"
             echo "🧬 Extracting CRD schemas from rendered manifests"
             for RENDER_FILE in "$OUT_DIR"/render*.yaml; do
               [[ -e "$RENDER_FILE" ]] || continue
+              RENDER_NAME="$(basename "$RENDER_FILE" .yaml)"
+              RENDER_TARGETS+=("${CHART}|${RENDER_NAME}|${RENDER_FILE}")
               while IFS=$'\t' read -r CRD_GROUP CRD_KIND CRD_VERSION CRD_SCHEMA_B64; do
                 [[ -n "$CRD_GROUP" ]] || continue
                 [[ -n "$CRD_KIND" ]] || continue
                 [[ -n "$CRD_VERSION" ]] || continue
                 [[ -n "$CRD_SCHEMA_B64" ]] || continue
-                mkdir -p "$SCHEMA_DIR/$CRD_GROUP"
-                printf '%s' "$CRD_SCHEMA_B64" | base64 --decode > "$SCHEMA_DIR/$CRD_GROUP/${CRD_KIND}_${CRD_VERSION}.json"
+                mkdir -p "$SCHEMA_POOL_DIR/$CRD_GROUP"
+                printf '%s' "$CRD_SCHEMA_B64" | base64 --decode > "$SCHEMA_POOL_DIR/$CRD_GROUP/${CRD_KIND}_${CRD_VERSION}.json"
               done < <(
                 yq -r 'select(.kind == "CustomResourceDefinition") | .spec as $spec | $spec.group as $group | $spec.names.kind as $kind | $spec.versions[] | select(.schema.openAPIV3Schema != null) | [$group, $kind, .name, (.schema.openAPIV3Schema | tojson | @base64)] | @tsv' "$RENDER_FILE"
               )
             done
-            for RENDER_FILE in "$OUT_DIR"/render*.yaml; do
-              [[ -e "$RENDER_FILE" ]] || continue
-              RENDER_NAME="$(basename "$RENDER_FILE" .yaml)"
-              # CRD status is server-populated and may contain null placeholders in chart output.
-              # Remove it before schema validation to avoid false negatives in kubeconform.
-              yq eval -i 'select(.kind == "CustomResourceDefinition") |= del(.status)' "$RENDER_FILE"
-              echo "🔎 Validating rendered manifests with kubeconform: $RENDER_NAME"
-              if ! kubeconform -output pretty -strict -kubernetes-version="$KUBE_VERSION" \
-                  -schema-location "$SCHEMA_DIR/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json" \
-                  -schema-location default \
-                  -schema-location https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/{{.NormalizedKubernetesVersion}}/{{.ResourceKind}}.json \
-                  -schema-location https://json.schemastore.org/{{.ResourceKind}}.json  \
-                  "$RENDER_FILE" \
-                  | tee "${{ env.REPORT_DIR }}/helm/${CHART}-${RENDER_NAME}-kubeconform.log"; then
-                echo "::error file=$RENDER_FILE::kubeconform failed for $CHART ($RENDER_NAME)"
-                FAILED_CHARTS+=("$CHART:$RENDER_NAME")
-              fi
-            done
             echo "✅ Finished processing: $CHART"
             echo "::endgroup::"
+          done
+          echo ""
+          echo "🔎 Validating rendered manifests with global CRD schema pool"
+          for RENDER_TARGET in "${RENDER_TARGETS[@]}"; do
+            IFS='|' read -r RENDER_CHART RENDER_NAME RENDER_FILE <<< "$RENDER_TARGET"
+            # CRD status is server-populated and may contain null placeholders in chart output.
+            # Remove it before schema validation to avoid false negatives in kubeconform.
+            yq eval -i 'select(.kind == "CustomResourceDefinition") |= del(.status)' "$RENDER_FILE"
+            if ! kubeconform -output pretty -strict -kubernetes-version="$KUBE_VERSION" \
+                -schema-location "$SCHEMA_POOL_DIR/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json" \
+                -schema-location default \
+                -schema-location https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/{{.NormalizedKubernetesVersion}}/{{.ResourceKind}}.json \
+                -schema-location https://json.schemastore.org/{{.ResourceKind}}.json  \
+                "$RENDER_FILE" \
+                | tee "${{ env.REPORT_DIR }}/helm/${RENDER_CHART}-${RENDER_NAME}-kubeconform.log"; then
+              echo "::error file=$RENDER_FILE::kubeconform failed for $RENDER_CHART ($RENDER_NAME)"
+              FAILED_CHARTS+=("$RENDER_CHART:$RENDER_NAME")
+            fi
           done
           echo ""
           echo "────────────────────────────────────"

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -474,12 +474,13 @@ jobs:
             # CRD status is server-populated and may contain null placeholders in chart output.
             # Remove it before schema validation to avoid false negatives in kubeconform.
             yq eval -i 'select(.kind == "CustomResourceDefinition") |= del(.status)' "$RENDER_FILE"
+            VALIDATION_FILE="${RENDER_FILE%.yaml}.validation.yaml"
+            # CRD manifests are sourced from upstream charts; validate rendered workloads against the extracted schema pool.
+            yq eval 'select(.kind != "CustomResourceDefinition")' "$RENDER_FILE" > "$VALIDATION_FILE"
             if ! kubeconform -output pretty -strict -kubernetes-version="$KUBE_VERSION" \
                 -schema-location "$SCHEMA_POOL_DIR/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json" \
                 -schema-location default \
-                -schema-location https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/{{.NormalizedKubernetesVersion}}/{{.ResourceKind}}.json \
-                -schema-location https://json.schemastore.org/{{.ResourceKind}}.json  \
-                "$RENDER_FILE" \
+                "$VALIDATION_FILE" \
                 | tee "${{ env.REPORT_DIR }}/helm/${RENDER_CHART}-${RENDER_NAME}-kubeconform.log"; then
               echo "::error file=$RENDER_FILE::kubeconform failed for $RENDER_CHART ($RENDER_NAME)"
               FAILED_CHARTS+=("$RENDER_CHART:$RENDER_NAME")

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -23,8 +23,6 @@ env:
   GOSEC_VERSION: "v2.25.0"
   # renovate: datasource=github-releases depName=yannh/kubeconform
   KUBECONFORM_VERSION: "v0.7.0"
-  # renovate: datasource=github-releases depName=mikefarah/yq
-  YQ_VERSION: "v4.48.1"
   # renovate: datasource=github-releases depName=terraform-linters/tflint
   TFLINT_VERSION: "v0.61.0"
   ARTIFACT_RETENTION_DAYS: "15"
@@ -340,28 +338,6 @@ jobs:
         run: |
           set -euo pipefail
           helm version --short
-
-      - name: Install yq (pinned)
-        run: |
-          set -euo pipefail
-          mkdir -p ~/.local/bin
-
-          YQ_BASE_URL="https://github.com/mikefarah/yq/releases/download/${{ env.YQ_VERSION }}"
-          YQ_BINARY="yq_linux_amd64"
-          YQ_SHA256="$(curl -fsSL "$YQ_BASE_URL/checksums" | awk '$2 == "yq_linux_amd64" {print $1}')"
-          TMP_BINARY="$(mktemp)"
-
-          if [[ -z "$YQ_SHA256" ]]; then
-            echo "::error::Could not resolve checksum for $YQ_BINARY"
-            exit 1
-          fi
-
-          curl -fsSL "$YQ_BASE_URL/$YQ_BINARY" -o "$TMP_BINARY"
-          echo "$YQ_SHA256  $TMP_BINARY" | sha256sum -c -
-          install -m 0755 "$TMP_BINARY" "$HOME/.local/bin/yq"
-          rm -f "$TMP_BINARY"
-
-          yq --version
 
       - name: Cache kubeconform
         id: cache-kubeconform

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -462,7 +462,7 @@ jobs:
                 SCHEMA_FILE="$SCHEMA_DIR/${CRD_KIND}_${CRD_VERSION}.json"
                 TMP_SCHEMA_FILE="$(mktemp)"
                 mkdir -p "$SCHEMA_DIR"
-                printf '%s' "$CRD_SCHEMA_B64" | base64 --decode > "$TMP_SCHEMA_FILE"
+                echo "$CRD_SCHEMA_B64" | base64 -d > "$TMP_SCHEMA_FILE"
                 if [[ -f "$SCHEMA_FILE" ]]; then
                   if ! cmp -s "$SCHEMA_FILE" "$TMP_SCHEMA_FILE"; then
                     echo "::error file=$RENDER_FILE::CRD schema collision for ${CRD_GROUP}/${CRD_KIND}/${CRD_VERSION}: definitions differ across rendered charts"

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -444,6 +444,23 @@ jobs:
               echo "📄 Rendering chart with default values"
               helm template "${HELM_TEMPLATE_API_ARGS[@]}" --include-crds "$CHART" "$MANAGED_CHART_PATH" > "$OUT_DIR/render.yaml"
             fi
+            SCHEMA_DIR="$OUT_DIR/schemas"
+            rm -rf "$SCHEMA_DIR"
+            mkdir -p "$SCHEMA_DIR"
+            echo "🧬 Extracting CRD schemas from rendered manifests"
+            for RENDER_FILE in "$OUT_DIR"/render*.yaml; do
+              [[ -e "$RENDER_FILE" ]] || continue
+              while IFS=$'\t' read -r CRD_GROUP CRD_KIND CRD_VERSION CRD_SCHEMA_B64; do
+                [[ -n "$CRD_GROUP" ]] || continue
+                [[ -n "$CRD_KIND" ]] || continue
+                [[ -n "$CRD_VERSION" ]] || continue
+                [[ -n "$CRD_SCHEMA_B64" ]] || continue
+                mkdir -p "$SCHEMA_DIR/$CRD_GROUP"
+                printf '%s' "$CRD_SCHEMA_B64" | base64 --decode > "$SCHEMA_DIR/$CRD_GROUP/${CRD_KIND}_${CRD_VERSION}.json"
+              done < <(
+                yq -r 'select(.kind == "CustomResourceDefinition") | .spec as $spec | $spec.group as $group | $spec.names.kind as $kind | $spec.versions[] | select(.schema.openAPIV3Schema != null) | [$group, $kind, .name, (.schema.openAPIV3Schema | tojson | @base64)] | @tsv' "$RENDER_FILE"
+              )
+            done
             for RENDER_FILE in "$OUT_DIR"/render*.yaml; do
               [[ -e "$RENDER_FILE" ]] || continue
               RENDER_NAME="$(basename "$RENDER_FILE" .yaml)"
@@ -452,8 +469,8 @@ jobs:
               yq eval -i 'select(.kind == "CustomResourceDefinition") |= del(.status)' "$RENDER_FILE"
               echo "🔎 Validating rendered manifests with kubeconform: $RENDER_NAME"
               if ! kubeconform -output pretty -strict -kubernetes-version="$KUBE_VERSION" \
+                  -schema-location "$SCHEMA_DIR/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json" \
                   -schema-location default \
-                  -schema-location https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json \
                   -schema-location https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/{{.NormalizedKubernetesVersion}}/{{.ResourceKind}}.json \
                   -schema-location https://json.schemastore.org/{{.ResourceKind}}.json  \
                   "$RENDER_FILE" \


### PR DESCRIPTION
Please read first: https://github.com/kubara-io/kubara/blob/main/CONTRIBUTING.md

## 📝 Summary
This PR removes the dependency on `datreeio/CRDs-catalog` for Helm CRD validation in CI.

`helm-checks` now builds a **global CRD schema pool** from all rendered manifests and validates all rendered files against that shared pool.

Why build the pool first:
- CRDs referenced in one rendered chart can be defined in a different chart/dependency.
- Per-chart validation can fail with missing schemas even when the repository contains all required CRDs overall.
- Building one shared pool in pass 1 guarantees schema availability before strict validation in pass 2.

Examples:
- `argo-cd` renders `ExternalSecret` / `ClusterExternalSecret`, while the CRD definitions come from the `external-secrets` chart.
- `kyverno-policies` renders `ClusterPolicy`, while CRD definitions are provided by the `kyverno` chart.
- multiple charts render `ServiceMonitor`, where CRD definitions are provided by `kube-prometheus-stack`.

Validation order is now:
- `-schema-location "$SCHEMA_POOL_DIR/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json"`
- `-schema-location default`
- `-schema-location https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/{{.NormalizedKubernetesVersion}}/{{.ResourceKind}}.json`

Why keep the `yannh` fallback:
- We still validate CRD manifests themselves (`kind: CustomResourceDefinition`) in strict mode.
- In local end-to-end runs, `schema-pool + default` alone could not consistently resolve the schema for `CustomResourceDefinition`.
- Keeping `yannh` preserves strict CRD validation while still removing the lag-prone `datreeio/CRDs-catalog` and `json.schemastore.org` sources.

Hardening included in this PR:
- Pin `yq` to a fixed release (`YQ_VERSION`) and install it with checksum verification so v4-specific operators (`tojson`, `@base64`, `@tsv`) remain deterministic in CI.
- Detect CRD schema collisions while building the pool: if two charts define the same Group/Kind/Version with different schemas, `helm-checks` now fails with an explicit error.

This removes the lag-prone `datreeio/CRDs-catalog` source while keeping stable validation coverage for CRDs and core Kubernetes resources.

## 🧩 Type of change
- [ ] 🔧 CLI / Go code
- [ ] 📦 Helm chart
- [ ] 🧱 Terraform module
- [ ] 📝 Documentation
- [X] 🧪 Test or CI change
- [ ] ♻️ Refactor / cleanup

## ⚠️ Is this a breaking change?
- [ ] Yes, this change breaks existing functionality (explain in summary)

## 🧪 Testing
- [ ] CI passed
- [X] Manually tested (local/dev cluster)
- [ ] Unit tested
- [X] Not tested (explain why below)
  
Local/manual validation performed:
- ran `init --prep`, `init`, `generate`, then Helm lint/render + kubeconform checks with the updated workflow logic,
- verified all managed charts pass with the new global pool approach,
- confirmed `nullBytePolicy`-related CRD validation is no longer blocked by datree schema lag.

Full GitHub Actions run is pending on this PR.

## 🔗 Related Issues / Tickets
Closes #230

## ✅ Checklist
- [ ] Code compiles and passes all tests
- [ ] Linting and style checks pass
- [X] Comments added for complex logic
- [ ] Documentation updated (if applicable)
  
## 📎 Additional Context (optional)
Changed workflow file:
- `.github/workflows/pr-checks.yaml`

Key behavior change:
- removed `datreeio/CRDs-catalog` schema location from `kubeconform`
- removed `json.schemastore.org` schema location from `kubeconform`
- switched from per-chart schema directories to a global schema pool (`$SCHEMA_POOL_DIR`)
- switched to two-pass flow:
  - pass 1: render charts and extract CRD schemas into pool
  - pass 2: validate all rendered manifests against shared pool
