### PR TITLE
docs: add faq for consequences of disabling OAuth2 Proxy

### DIFF
--- a/docs/content/1_getting_started/bootstrap_process.md
+++ b/docs/content/1_getting_started/bootstrap_process.md
@@ -190,6 +190,9 @@ export AWS_SECRET_ACCESS_KEY="<from terraform output>"
 ```
 
 ### 2.2 Provisioning Infrastructure
+!!! warning
+    If you do not intend to use OAuth2 Proxy you can ignore some of the steps in the guide below pertaining to it, but might encounter some issues later.
+    For more infos please look at our [FAQ](../6_reference/faq.md#what-happens-when-oauth2-proxy-is-disabled).
 
 Then proceed to:
 
@@ -256,6 +259,8 @@ terraform apply
 
 !!! warning
      You need to set these environment variables again before re-applying Terraform if they are not persisted in your shell/session setup.
+
+
 
 To clean up:
 

--- a/docs/content/1_getting_started/prerequisites.md
+++ b/docs/content/1_getting_started/prerequisites.md
@@ -48,6 +48,9 @@ If you are relying on publicly available images (e.g. from dockerhub) you need a
     -  OAuth2-Proxy App (reverse proxy) that handles authentication for most dashboards
     -  Argo CD App that handles authentication for Argo CD  UI. Dex is used for handling Argo CD  RBAC once authenticated
     -  Grafana App that handles authentication for Grafana.
+
+    If you choose not to use OAuth2-Proxy you might run into some issues with your setup.
+    For more infos please look at our [FAQ](../6_reference/faq.md#what-happens-when-oauth2-proxy-is-disabled).
 - **Credentials for external-secrets / secret backend (required when not using managed identities)**
 Prepare the provider credentials you will need later during bootstrap to create the Kubernetes secret(s) and configure external-secrets / `ClusterSecretStore` (see the bootstrap guide).
 

--- a/docs/content/6_reference/faq.md
+++ b/docs/content/6_reference/faq.md
@@ -134,8 +134,9 @@ Each serves a different purpose and can coexist in the same Argo CD setup.
 
 ---
 
-## What happens when oauth2-proxy is disabled?
+## What happens when OAuth2 Proxy is disabled?
 
-If you choose to disable oauth2-proxy during setup, you skip the oauth2-proxy configuration step (part of [step 2.2](../1_getting_started/bootstrap_process.md#22-provisioning-infrastructure) in the bootstrap guide).
-Since oauth2-proxy provides authentication for ingress routes, no traefik routes are deployed.
+If you choose to disable OAuth2 Proxy during setup, you skip the OAuth2 Proxy configuration step (part of [step 2.2](../1_getting_started/bootstrap_process.md#22-provisioning-infrastructure) in the bootstrap guide).
+
+Since OAuth2 Proxy provides authentication for ingress routes, no traefik routes are deployed.
 Without them none of your apps will be publicly reachable until you configure an alternative authentication mechanism and deploy the routes.

--- a/docs/content/6_reference/faq.md
+++ b/docs/content/6_reference/faq.md
@@ -133,3 +133,9 @@ Each serves a different purpose and can coexist in the same Argo CD setup.
 - `ApplicationSets` for scalable, templated application rollout
 
 ---
+
+## What happens when oauth2-proxy is disabled?
+
+If you choose to disable oauth2-proxy during setup, you skip the oauth2-proxy configuration step (part of [step 2.2](../1_getting_started/bootstrap_process.md#22-provisioning-infrastructure) in the bootstrap guide).
+Since oauth2-proxy provides authentication for ingress routes, no traefik routes are deployed.
+Without them none of your apps will be publicly reachable until you configure an alternative authentication mechanism and deploy the routes.

--- a/go-binary/templates/embedded/customer-service-catalog/helm/example/kube-prometheus-stack/values.yaml.tplt
+++ b/go-binary/templates/embedded/customer-service-catalog/helm/example/kube-prometheus-stack/values.yaml.tplt
@@ -196,8 +196,10 @@ kube-prometheus-stack:
         - secretName: tls-grafana
           hosts:
             - {{ .cluster.dnsName }}
+{{- if (eq .cluster.services.oauth2Proxy.status "enabled") }}
     envFromSecrets:
       - name: oauth2-credentials
+{{- end }}
     grafana.ini:
       server:
         root_url: https://{{ .cluster.dnsName }}/grafana/


### PR DESCRIPTION
## 📝 Summary
This PR adds a secetion in the faq to include information that if the user chooses to bootstrap their cluster without oauth2-proxy, no ingress routes will be deployd for their app.
In addition it includes a bugfix, that the grafana pod doesn't ask about the oauth2 secrets.

## 🧩 Type of change
- [x] 🔧 CLI / Go code
- [ ] 📦 Helm chart
- [ ] 🧱 Terraform module
- [X] 📝 Documentation
- [ ] 🧪 Test or CI change
- [ ] ♻️ Refactor / cleanup

## ⚠️ Is this a breaking change?
- [ ] Yes, this change breaks existing functionality (explain in summary)

## 🧪 Testing
- [ ] CI passed
- [X] Manually tested (local/dev cluster)
- [ ] Unit tested
- [ ] Not tested (explain why below)
  
## 🔗 Related Issues / Tickets
Closes #182 

## ✅ Checklist
- [X] Code compiles and passes all tests
- [ ] Linting and style checks pass
- [ ] Comments added for complex logic
- [X] Documentation updated (if applicable)
  
## 📎 Additional Context (optional)
<!-- Add logs, screenshots, diagrams, or design notes. -->
