### PR TITLE
fix: outdated and confusing info in env file

### DIFF
--- a/go-binary/assets/envmap/envMap.go
+++ b/go-binary/assets/envmap/envMap.go
@@ -34,8 +34,6 @@ type EnvMap struct {
 	ProjectName                 string   `default:"<...>" koanf:"PROJECT_NAME"`
 	ProjectStage                string   `default:"<...>" koanf:"PROJECT_STAGE"`
 	_                           struct{} `doc:"\n### Docker related values"`
-	_                           struct{} `doc:"# see https://docs.docker.com/reference/cli/docker/login/"`
-	_                           struct{} `doc:"# after successful login you can look inside envMap.json in your docker directory (~/.docker/envMap.json) on Linux/Mac"`
 	_                           struct{} `doc:"# the variable must be base64 encoded - how to: https://docs.kubara.io/latest-stable/6_reference/faq/#how-do-i-create-a-dockerconfigjson-for-env-file"`
 	DockerconfigBase64          string   `default:"<...>" koanf:"DOCKERCONFIG_BASE64"`
 	_                           struct{} `doc:"\n### Argo CD related values"`

--- a/go-binary/assets/envmap/envMap.go
+++ b/go-binary/assets/envmap/envMap.go
@@ -33,7 +33,7 @@ type EnvMap struct {
 	_                           struct{} `doc:"\n### Project related values"`
 	ProjectName                 string   `default:"<...>" koanf:"PROJECT_NAME"`
 	ProjectStage                string   `default:"<...>" koanf:"PROJECT_STAGE"`
-	_                           struct{} `doc:"\n### Docker related values"`
+	_                           struct{} `doc:"\n### Container Registry Config"`
 	_                           struct{} `doc:"# the variable must be base64 encoded - how to: https://docs.kubara.io/latest-stable/6_reference/faq/#how-do-i-create-a-dockerconfigjson-for-env-file"`
 	DockerconfigBase64          string   `default:"<...>" koanf:"DOCKERCONFIG_BASE64"`
 	_                           struct{} `doc:"\n### Argo CD related values"`


### PR DESCRIPTION
Please read first: https://github.com/kubara-io/kubara/blob/main/CONTRIBUTING.md
  
## 📝 Summary
We got some user feedback about a description of a comment in the .env-file regarding dockerconfig.json.
The filename was wrong and the whole comment was confusing for new users. This is some legacy relic and was removed. 

**Thank you** @bojidar-bg !



## 🧩 Type of change
- [x] 🔧 CLI / Go code
- [ ] 📦 Helm chart
- [ ] 🧱 Terraform module
- [ ] 📝 Documentation
- [ ] 🧪 Test or CI change
- [x] ♻️ Refactor / cleanup

## ⚠️ Is this a breaking change?
- [ ] Yes, this change breaks existing functionality (explain in summary)

## 🧪 Testing
- [ ] CI passed
- [ ] Manually tested (local/dev cluster)
- [ ] Unit tested
- [ ] Not tested (explain why below)
  
## 🔗 Related Issues / Tickets
<!-- e.g. Closes #42, Related to #99 -->

## ✅ Checklist
- [ ] Code compiles and passes all tests
- [ ] Linting and style checks pass
- [ ] Comments added for complex logic
- [ ] Documentation updated (if applicable)
  
## 📎 Additional Context (optional)
<!-- Add logs, screenshots, diagrams, or design notes. -->
