### PR TITLE
docs: better github issue template separation

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,30 +1,43 @@
 ---
-name: Bug or Feature Request
-description: Report a bug, suggest a feature, or ask a question related to Kubara
-title: "[Issue]: "
-labels: ["triage"]
+name: 🐛 Bug Report
+description: Report a bug in Kubara
+title: "[Bug]: "
+labels: ["bug", "triage"]
 assignees: []
 body:
-  - type: dropdown
-    id: type-of-issue
-    attributes:
-      label: 🧩 Type of Issue
-      options:
-        - 🐛 Bug
-        - ✨ Feature request
-        - ❓ Question or clarification
-        - 🧪 Improvement or refactor
-    validations:
-      required: true
-
   - type: textarea
     id: summary
     attributes:
       label: "📝 Description"
       description: |
         Please read first <a target="_blank" href="https://github.com/kubara-io/kubara/blob/main/CONTRIBUTING.md">how to contribute to Kubara</a>.
+      placeholder: Briefly describe the bug. What is the problem you encountered?
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: 🧪 Steps to Reproduce
+      description: List clear steps to reproduce the issue.
       placeholder: |
-        Briefly describe the issue or request. What is the problem, question, or improvement you're raising?
+        1. Run `kubara init`
+        2. Apply config X
+        3. Observe error Y
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: 💻 Environment
+      description: Provide relevant environment details.
+      placeholder: |
+        - Kubara version: v1.4.2
+        - Kubernetes version: 1.28 (EKS)
+        - Helm version: 3.13
+        - Platform: kind
+        - OS/Arch: Ubuntu 22.04 / amd64
     validations:
       required: true
 
@@ -33,28 +46,6 @@ body:
     attributes:
       label: 📎 Additional Context / Logs
       description: Paste logs, screenshots, or links to related docs or issues here.
-
-  - type: textarea
-    id: steps
-    attributes:
-      label: 🧪 Steps to Reproduce (for bugs)
-      description: List clear steps to reproduce the issue.
-      placeholder: |
-        1. Run `kubara init`
-        2. Apply config X
-        3. Observe error Y
-
-  - type: textarea
-    id: environment
-    attributes:
-      label: 💻 Environment (for bugs)
-      description: Provide relevant environment details.
-      placeholder: |
-        - Kubara version: v1.4.2
-        - Kubernetes version: 1.28 (EKS)
-        - Helm version: 3.13
-        - Platform: kind
-        - OS/Arch: Ubuntu 22.04 / amd64
 
   - type: checkboxes
     id: checklist

--- a/.github/ISSUE_TEMPLATE/change_request.yaml
+++ b/.github/ISSUE_TEMPLATE/change_request.yaml
@@ -1,0 +1,52 @@
+---
+name: ☂️ Request for Change
+description: Propose an major architectural improvement or refactor to existing Kubara behavior
+title: "[RFC]: "
+labels: ["architecture", "triage"]
+assignees: []
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: "📝 Summary"
+      description: Briefly describe the change you are proposing. What is the problem or limitation with the current behavior?
+    validations:
+      required: true
+  - type: textarea
+    id: motivation
+    attributes:
+      label: 🎯 Motivation
+      description: Describe the motivation behind this change. Why is it needed? What benefits does it provide to users or maintainers?
+      value: |
+        ** The Problem **
+        Describe the current behavior and its limitations. What issues or pain points does it cause?
+
+        ** Goals **
+        Describe the goals of this change. What are you trying to achieve with this improvement or ref
+
+        ** Out of Scope **
+        Describe any related problems or features that are out of scope for this change.
+
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: 💡 Proposal
+      description: Describe your proposed solution or improvement. How would you implement this change? What are the key design decisions or trade-offs?
+      value: |
+        ** Design **
+        Describe the high-level design of your proposed change. What components or modules would be affected? How would they interact?
+
+        ** Alternatives Considered **
+        Describe any alternative solutions you considered and why you rejected them.
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: ✅ Checklist
+      options:
+        - label: I have searched existing issues
+          required: true
+        - label: This is not a duplicate

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,0 +1,40 @@
+---
+name: ✨ Feature Request
+description: Suggest a new feature for Kubara
+title: "[Feature]: "
+labels: ["feature request", "triage"]
+assignees: []
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: "📝 Description"
+      description: |
+        Please read first <a target="_blank" href="https://github.com/kubara-io/kubara/blob/main/CONTRIBUTING.md">how to contribute to Kubara</a>.
+      placeholder: Briefly describe the feature you'd like to see. What problem does it solve?
+    validations:
+      required: true
+
+  - type: textarea
+    id: use_case
+    attributes:
+      label: 🎯 Use Case
+      description: Describe the scenario or workflow this feature would enable or improve.
+      placeholder: As a user, I want to...
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: 📎 Additional Context
+      description: Paste screenshots, links to related docs, issues, or prior art here.
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: ✅ Checklist
+      options:
+        - label: I have searched existing issues
+          required: true
+        - label: This is not a duplicate

--- a/.github/ISSUE_TEMPLATE/question.yaml
+++ b/.github/ISSUE_TEMPLATE/question.yaml
@@ -1,0 +1,38 @@
+---
+name: ❓ Question or Support
+description: Ask a question or request clarification about Kubara
+title: "[Question]: "
+labels: ["question", "help wanted", "triage"]
+assignees: []
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: "📝 Question"
+      description: |
+        Please read first <a target="_blank" href="https://github.com/kubara-io/kubara/blob/main/CONTRIBUTING.md">how to contribute to Kubara</a>.
+      placeholder: What would you like to know or clarify?
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: 💡 What Have You Tried?
+      description: Describe what you've already attempted or read before asking.
+      placeholder: I checked the docs at... and tried...
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: 📎 Additional Context / Logs
+      description: Paste logs, screenshots, or links to related docs or issues here.
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: ✅ Checklist
+      options:
+        - label: I have searched existing issues
+          required: true
+        - label: I have checked the documentation

--- a/.github/ISSUE_TEMPLATE/release.yaml
+++ b/.github/ISSUE_TEMPLATE/release.yaml
@@ -1,5 +1,5 @@
 ---
-name: Release
+name: 🚀 Release
 description: Next release ticket (to be used by maintainers only)
 title: "[Release]: next"
 labels: ["release"]

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
-Please read first: https://github.com/kubara-io/kubara/blob/main/CONTRIBUTING.md
-  
 ## 📝 Summary
+<!-- Please read first: https://github.com/kubara-io/kubara/blob/main/CONTRIBUTING.md -->
+  
 <!-- What does this PR do? e.g. "Adds Terraform module for SKE setup" -->
 
 ## 🧩 Type of change


### PR DESCRIPTION
## 📝 Summary

Better separation of GitHub issue types to separate them by labels and names for more flexible filtering and search

<img width="911" height="576" alt="image" src="https://github.com/user-attachments/assets/2f6d6eba-677f-4d1f-9141-90b4564c6394" />

Each type gets its own prefix in the title:

* [Bug]
* [RFC]
* [Feature]
* [Question]
* [Release]

And each get their own labels:

* bug
* architecture
* feature request
* question
* release