### PR TITLE
fix: kyverno-policy skip rule for kyverno owned job 'kyverno-migrate-resources'

### DIFF
--- a/go-binary/templates/embedded/managed-service-catalog/helm/kyverno-policies/values.yaml
+++ b/go-binary/templates/embedded/managed-service-catalog/helm/kyverno-policies/values.yaml
@@ -306,6 +306,7 @@ kyverno-policies:
             names:
               - kyverno-background-controller-*
               - kyverno-reports-controller-*
+              - kyverno-migrate-resources-*
             namespaces:
               - kyverno
 global:


### PR DESCRIPTION
## 📝 Summary
Add skip for kyverno-policy require-pod-probes for kyverno owned job 'kyverno-migrate-resources'. Probes aren't necessary for this job.

## 🧩 Type of change
- [ ] 🔧 CLI / Go code
- [X] 📦 Helm chart
- [ ] 🧱 Terraform module
- [ ] 📝 Documentation
- [ ] 🧪 Test or CI change
- [ ] ♻️ Refactor / cleanup

## ⚠️ Is this a breaking change?
- [ ] Yes, this change breaks existing functionality (explain in summary)

## 🧪 Testing
- [X] CI passed
- [X] Manually tested (local/dev cluster)
- [X] Unit tested
- [ ] Not tested (explain why below)
  
## ✅ Checklist
- [X] Code compiles and passes all tests
- [X] Linting and style checks pass
- [ ] Comments added for complex logic
- [ ] Documentation updated (if applicable)
  
