### PR TITLE
feat: automatic config migration from legacy definition to schema driven approach

### DIFF
--- a/src/cmd/bootstrap.go
+++ b/src/cmd/bootstrap.go
@@ -130,9 +130,6 @@ func (flags *BootstrapFlags) ToOptions(cmd *cli.Command) (*bootstrap.Options, er
 	if err := cs.Load(); err != nil {
 		return nil, fmt.Errorf("load config: %w", err)
 	}
-	if err := cs.Validate(); err != nil {
-		return nil, fmt.Errorf("validate config: %w", err)
-	}
 
 	// Find the cluster by name from the argument
 	clusterName := cmd.StringArg("cluster-name")

--- a/src/cmd/init.go
+++ b/src/cmd/init.go
@@ -182,9 +182,6 @@ func (o *InitOptions) runForceMode(es *envconfig.EnvStore, cs *config.ConfigStor
 	if err := workflow.CreateOrUpdateClusterFromEnvWithCatalog(cs.GetConfig(), es.GetConfig(), o.catalogLoadOptions()); err != nil {
 		return fmt.Errorf("create or update cluster from env: %w", err)
 	}
-	if err := cs.Validate(); err != nil {
-		return fmt.Errorf("validate config file: %w", err)
-	}
 	if err := cs.SaveToFile(); err != nil {
 		return fmt.Errorf("write config file: %w", err)
 	}
@@ -202,9 +199,6 @@ func (o *InitOptions) runNormalMode(es *envconfig.EnvStore, cs *config.ConfigSto
 
 	if fileExists {
 		log.Info().Msgf("Config file already exist. To overwrite existing variables in the config from env: set flag \"--overwrite\"")
-		if err := cs.Validate(); err != nil {
-			return err
-		}
 		log.Info().Msg("Initialized successfully")
 		return nil
 	}

--- a/src/internal/config/store.go
+++ b/src/internal/config/store.go
@@ -52,6 +52,14 @@ func (cs *ConfigStore) Load() error {
 		return fmt.Errorf("parse YAML config: %w", err)
 	}
 
+	legacyConfig := isLegacyConfig(raw)
+	if legacyConfig {
+		raw, err = migrateLegacyConfig(raw)
+		if err != nil {
+			return fmt.Errorf("migrate legacy config: %w", err)
+		}
+	}
+
 	dc := &mapstructure.DecoderConfig{
 		TagName:          "yaml",
 		WeaklyTypedInput: false,
@@ -71,7 +79,207 @@ func (cs *ConfigStore) Load() error {
 		return fmt.Errorf("apply service catalog defaults: %w", err)
 	}
 
+	if err = cs.validate(); err != nil {
+		return fmt.Errorf("validate config: %w", err)
+	}
+
+	if legacyConfig {
+		if err := cs.SaveToFile(); err != nil {
+			return fmt.Errorf("persist migrated config: %w", err)
+		}
+	}
+
 	return nil
+}
+
+func isLegacyConfig(raw map[string]any) bool {
+	_, hasVersion := raw["version"]
+	return !hasVersion
+}
+
+func migrateLegacyConfig(raw map[string]any) (map[string]any, error) {
+	clustersRaw, ok := raw["clusters"]
+	if !ok {
+		return raw, nil
+	}
+
+	clusters, ok := clustersRaw.([]any)
+	if !ok {
+		return raw, nil
+	}
+
+	for i, clusterRaw := range clusters {
+		cluster, ok := clusterRaw.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		if err := migrateLegacyCluster(cluster, i); err != nil {
+			return nil, err
+		}
+
+		clusters[i] = cluster
+	}
+
+	raw["clusters"] = clusters
+	return raw, nil
+}
+
+func migrateLegacyCluster(cluster map[string]any, clusterIndex int) error {
+	servicesRaw, ok := cluster["services"]
+	if !ok {
+		return nil
+	}
+
+	servicesMap, ok := servicesRaw.(map[string]any)
+	if !ok {
+		return fmt.Errorf("%s.services must be an object", legacyClusterLabel(cluster, clusterIndex))
+	}
+
+	serviceContext := legacyClusterLabel(cluster, clusterIndex)
+	migratedServices := make(map[string]any, len(servicesMap))
+	sourceByCanonical := make(map[string]string, len(servicesMap))
+
+	for originalName, serviceRaw := range servicesMap {
+		canonicalName := catalog.CanonicalServiceName(originalName)
+		if previousName, exists := sourceByCanonical[canonicalName]; exists {
+			return fmt.Errorf("%s.services has conflicting keys %q and %q for canonical service %q", serviceContext, previousName, originalName, canonicalName)
+		}
+
+		if serviceMap, ok := serviceRaw.(map[string]any); ok {
+			if err := migrateLegacyService(canonicalName, serviceMap, serviceContext); err != nil {
+				return err
+			}
+			migratedServices[canonicalName] = serviceMap
+		} else {
+			migratedServices[canonicalName] = serviceRaw
+		}
+
+		sourceByCanonical[canonicalName] = originalName
+	}
+
+	cluster["services"] = migratedServices
+	return nil
+}
+
+func migrateLegacyService(serviceName string, serviceMap map[string]any, clusterContext string) error {
+	serviceContext := fmt.Sprintf("%s.services.%s", clusterContext, serviceName)
+
+	if serviceName == "cert-manager" {
+		if err := migrateLegacyClusterIssuer(serviceMap, serviceContext); err != nil {
+			return err
+		}
+	}
+
+	switch serviceName {
+	case "kube-prometheus-stack", "loki":
+		if err := migrateLegacyStorageClassName(serviceMap, serviceContext); err != nil {
+			return err
+		}
+	}
+
+	if err := migrateLegacyIngressAnnotations(serviceMap, serviceContext); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func migrateLegacyClusterIssuer(serviceMap map[string]any, serviceContext string) error {
+	clusterIssuer, ok := serviceMap["clusterIssuer"]
+	if !ok {
+		return nil
+	}
+
+	configMap, err := ensureNestedObject(serviceMap, "config", serviceContext)
+	if err != nil {
+		return err
+	}
+	if _, exists := configMap["clusterIssuer"]; exists {
+		return fmt.Errorf("%s has both legacy clusterIssuer and config.clusterIssuer", serviceContext)
+	}
+
+	configMap["clusterIssuer"] = clusterIssuer
+	delete(serviceMap, "clusterIssuer")
+	return nil
+}
+
+func migrateLegacyStorageClassName(serviceMap map[string]any, serviceContext string) error {
+	storageClassName, ok := serviceMap["storageClassName"]
+	if !ok {
+		return nil
+	}
+
+	storageMap, err := ensureNestedObject(serviceMap, "storage", serviceContext)
+	if err != nil {
+		return err
+	}
+	if _, exists := storageMap["className"]; exists {
+		return fmt.Errorf("%s has both legacy storageClassName and storage.className", serviceContext)
+	}
+
+	storageMap["className"] = storageClassName
+	delete(serviceMap, "storageClassName")
+	return nil
+}
+
+func migrateLegacyIngressAnnotations(serviceMap map[string]any, serviceContext string) error {
+	ingressRaw, ok := serviceMap["ingress"]
+	if !ok {
+		return nil
+	}
+
+	ingressMap, ok := ingressRaw.(map[string]any)
+	if !ok {
+		return fmt.Errorf("%s.ingress must be an object", serviceContext)
+	}
+
+	annotations, ok := ingressMap["annotations"]
+	if !ok {
+		return nil
+	}
+
+	networkingMap, err := ensureNestedObject(serviceMap, "networking", serviceContext)
+	if err != nil {
+		return err
+	}
+	if _, exists := networkingMap["annotations"]; exists {
+		return fmt.Errorf("%s has both legacy ingress.annotations and networking.annotations", serviceContext)
+	}
+
+	networkingMap["annotations"] = annotations
+	delete(ingressMap, "annotations")
+	if len(ingressMap) == 0 {
+		delete(serviceMap, "ingress")
+	} else {
+		serviceMap["ingress"] = ingressMap
+	}
+
+	return nil
+}
+
+func ensureNestedObject(parent map[string]any, key, context string) (map[string]any, error) {
+	raw, exists := parent[key]
+	if !exists || raw == nil {
+		nested := map[string]any{}
+		parent[key] = nested
+		return nested, nil
+	}
+
+	nested, ok := raw.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("%s.%s must be an object", context, key)
+	}
+
+	return nested, nil
+}
+
+func legacyClusterLabel(cluster map[string]any, clusterIndex int) string {
+	if name, ok := cluster["name"].(string); ok && strings.TrimSpace(name) != "" {
+		return fmt.Sprintf("cluster %q", name)
+	}
+
+	return fmt.Sprintf("clusters[%d]", clusterIndex)
 }
 
 // GenerateSchema generates a JSON schema from the Config struct
@@ -139,7 +347,7 @@ func ensureServiceConfigDefinition(schemaDoc map[string]any) {
 	}
 }
 
-func (cs *ConfigStore) Validate() error {
+func (cs *ConfigStore) validate() error {
 	cat, err := cs.GetCatalog()
 	if err != nil {
 		return fmt.Errorf("load catalog: %w", err)

--- a/src/internal/config/store_test.go
+++ b/src/internal/config/store_test.go
@@ -179,6 +179,166 @@ clusters:
 	}
 }
 
+func TestConfigStore_LoadMigratesLegacyConfig(t *testing.T) {
+	legacyYAML := `
+clusters:
+  - name: legacy-cluster
+    dnsName: legacy.example.com
+    argocd:
+      repo:
+        https:
+          customer:
+            url: "https://github.com/customer/repo.git"
+          managed:
+            url: "https://github.com/managed/repo.git"
+    services:
+      argocd:
+        status: enabled
+      certManager:
+        status: enabled
+        clusterIssuer:
+          name: letsencrypt-staging
+          email: cert@example.com
+          server: https://acme-staging-v02.api.letsencrypt.org/directory
+      kubePrometheusStack:
+        status: enabled
+        storageClassName: metrics-rwo
+      loki:
+        status: enabled
+        storageClassName: logs-rwo
+      oauth2Proxy:
+        status: enabled
+        ingress:
+          annotations:
+            foo: bar
+`
+
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, "legacy-config.yaml")
+	require.NoError(t, os.WriteFile(configPath, []byte(legacyYAML), 0644))
+
+	cs := NewConfigStore(configPath)
+	require.NoError(t, cs.Load())
+
+	loaded := cs.GetConfig()
+	require.Equal(t, ConfigVersionV1Alpha1, loaded.Version)
+	require.Len(t, loaded.Clusters, 1)
+
+	cluster := loaded.Clusters[0]
+	assert.Contains(t, cluster.Services, "argocd")
+
+	certManager := cluster.Services["cert-manager"]
+	clusterIssuer, ok := certManager.Config["clusterIssuer"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "letsencrypt-staging", clusterIssuer["name"])
+	assert.Equal(t, "cert@example.com", clusterIssuer["email"])
+
+	require.NotNil(t, cluster.Services["kube-prometheus-stack"].Storage)
+	assert.Equal(t, "metrics-rwo", cluster.Services["kube-prometheus-stack"].Storage.ClassName)
+
+	require.NotNil(t, cluster.Services["loki"].Storage)
+	assert.Equal(t, "logs-rwo", cluster.Services["loki"].Storage.ClassName)
+
+	require.NotNil(t, cluster.Services["oauth2-proxy"].Networking)
+	assert.Equal(t, "bar", cluster.Services["oauth2-proxy"].Networking.Annotations["foo"])
+
+	savedBytes, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+	savedContent := string(savedBytes)
+	assert.Contains(t, savedContent, "version: v1alpha1")
+	assert.Contains(t, savedContent, "cert-manager:")
+	assert.Contains(t, savedContent, "argocd:")
+	assert.NotContains(t, savedContent, "certManager:")
+	assert.NotContains(t, savedContent, "storageClassName:")
+	assert.NotContains(t, savedContent, "ingress:")
+	assert.Contains(t, savedContent, "className: metrics-rwo")
+	assert.Contains(t, savedContent, "className: logs-rwo")
+	assert.Contains(t, savedContent, "networking:")
+	assert.Contains(t, savedContent, "clusterIssuer:")
+}
+
+func TestConfigStore_LoadRejectsLegacyMigrationConflicts(t *testing.T) {
+	tests := []struct {
+		name        string
+		servicesYML string
+		wantErr     string
+	}{
+		{
+			name: "duplicate canonical service names",
+			servicesYML: `
+      certManager:
+        status: enabled
+      cert-manager:
+        status: enabled
+`,
+			wantErr: `conflicting keys "certManager" and "cert-manager"`,
+		},
+		{
+			name: "cert-manager clusterIssuer conflict",
+			servicesYML: `
+      certManager:
+        status: enabled
+        clusterIssuer:
+          name: letsencrypt-staging
+        config:
+          clusterIssuer:
+            name: letsencrypt-prod
+`,
+			wantErr: "both legacy clusterIssuer and config.clusterIssuer",
+		},
+		{
+			name: "storage class conflict",
+			servicesYML: `
+      loki:
+        status: enabled
+        storageClassName: logs-rwo
+        storage:
+          className: already-set
+`,
+			wantErr: "both legacy storageClassName and storage.className",
+		},
+		{
+			name: "ingress annotations conflict",
+			servicesYML: `
+      oauth2Proxy:
+        status: enabled
+        ingress:
+          annotations:
+            foo: bar
+        networking:
+          annotations:
+            custom: value
+`,
+			wantErr: "both legacy ingress.annotations and networking.annotations",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			legacyYAML := fmt.Sprintf(`
+clusters:
+  - name: legacy-cluster
+    dnsName: legacy.example.com
+    argocd:
+      repo:
+        https:
+          customer:
+            url: "https://github.com/customer/repo.git"
+          managed:
+            url: "https://github.com/managed/repo.git"
+    services:%s`, tt.servicesYML)
+
+			configPath := filepath.Join(t.TempDir(), "legacy-conflict.yaml")
+			require.NoError(t, os.WriteFile(configPath, []byte(legacyYAML), 0644))
+
+			cs := NewConfigStore(configPath)
+			err := cs.Load()
+			require.Error(t, err)
+			assert.ErrorContains(t, err, tt.wantErr)
+		})
+	}
+}
+
 func TestConfigStore_Validate(t *testing.T) {
 	validConfig := newValidTestConfig()
 
@@ -285,7 +445,7 @@ func TestConfigStore_Validate(t *testing.T) {
 			cs := &ConfigStore{
 				config: tt.config,
 			}
-			err := cs.Validate()
+			err := cs.validate()
 			if tt.wantErr {
 				assert.Error(t, err)
 			} else {
@@ -548,5 +708,5 @@ clusters:
 	assert.Equal(t, "controlplane", c.Type, "Type should be defaulted")
 	assert.Equal(t, "traefik", c.IngressClassName, "IngressClassName should be defaulted")
 
-	assert.NoError(t, cs.Validate(), "Validate should pass after defaults are applied")
+	assert.NoError(t, cs.validate(), "Validate should pass after defaults are applied")
 }

--- a/src/internal/generate/generator.go
+++ b/src/internal/generate/generator.go
@@ -171,10 +171,6 @@ func (o *Options) processClusters() ([]render.TemplateResult, error) {
 		return nil, fmt.Errorf("load config: %w", CnfLoadErr)
 	}
 
-	if err := cs.Validate(); err != nil {
-		return nil, fmt.Errorf("validate config: %w", err)
-	}
-
 	cnf := cs.GetConfig()
 	var allResults []render.TemplateResult
 


### PR DESCRIPTION
## 📝 Summary
Automatic migration of legacy configs into the new schema driven catalog service definitions.


## 🧩 Type of change
- [X] 🔧 CLI / Go code
- [ ] 📦 Helm chart
- [ ] 🧱 Terraform module
- [ ] 📝 Documentation
- [X] 🧪 Test or CI change
- [X] ♻️ Refactor / cleanup

## ⚠️ Is this a breaking change?
- [ ] Yes, this change breaks existing functionality (explain in summary)

## 🧪 Testing
- [X] CI passed
- [X] Manually tested (local/dev cluster)
- [X] Unit tested
- [ ] Not tested (explain why below)
  
## 🔗 Related Issues / Tickets
<!-- e.g. Closes #42, Related to #99 -->

## ✅ Checklist
- [X] Code compiles and passes all tests
- [X] Linting and style checks pass
- [X] Comments added for complex logic
- [ ] Documentation updated (if applicable)
  
## 📎 Additional Context (optional)
<!-- Add logs, screenshots, diagrams, or design notes. -->
