### PR TITLE
feat(stackit): optimize naming scheme for terraform resources

### DIFF
--- a/go-binary/templates/embedded/customer-service-catalog/terraform/providers/stackit/example/infrastructure/main.tf.tplt
+++ b/go-binary/templates/embedded/customer-service-catalog/terraform/providers/stackit/example/infrastructure/main.tf.tplt
@@ -2,7 +2,7 @@ module "iam" {
   source = "../../../../managed-service-catalog/terraform/modules/iam"
 
   project_id = var.project_id
-  name       = "sa-${substr(var.name, 0, 8)}-${substr(var.stage, 0, 8)}" #the name just only allow 20 characters
+  name       = "sa-${substr(var.name, 0, 8)}-${substr(var.stage, 0, 8)}" # iam only allows for 20 characters
 
   sa_key_ttl_days                 = var.sa_key_ttl_days
   sa_key_ttl_rotation_buffer_days = var.sa_key_ttl_rotation_buffer_days
@@ -14,7 +14,7 @@ module "dns_zone" {
   source = "../../../../managed-service-catalog/terraform/modules/dns-zone"
 
   project_id    = var.project_id
-  name          = "dns-zone-${var.name}-${var.stage}"
+  name          = "${var.name}-${var.stage}"
   dns_name      = var.dns_name
   contact_email = var.contact_email
 }
@@ -24,7 +24,7 @@ module "secretsmanager" {
   source = "../../../../managed-service-catalog/terraform/modules/secretsmanager"
 
   project_id = var.project_id
-  name       = "secmgr-${var.name}-${var.stage}"
+  name       = "${var.name}-${var.stage}"
   acls       = var.acls
 
   users = var.users
@@ -35,7 +35,7 @@ module "ske_cluster" {
   source = "../../../../managed-service-catalog/terraform/modules/ske-cluster"
 
   project_id             = var.project_id
-  name                   = "ske-${substr(var.name, 0, 3)}-${substr(var.stage, 0, 3)}" #the name just only allow 11 characters
+  name                   = "${local.ske_name_prefix}-${random_string.ske_name_suffix.result}"
   region                 = var.region
   kubernetes_version_min = var.kubernetes_version_min
 
@@ -46,6 +46,18 @@ module "ske_cluster" {
   ### kubeconfig
   expiration = var.expiration
 }
+
+locals {
+  ske_name_prefix        = substr(var.name, 0, 5)
+  ske_name_suffix_length = 10 - length(local.ske_name_prefix)
+}
+
+resource "random_string" "ske_name_suffix" {
+  length  = local.ske_name_suffix_length # ske only allows for 11 characters
+  lower   = true
+  upper   = false
+  special = false
+}
 {{ end }}
 
 
@@ -53,7 +65,7 @@ module "ske_cluster" {
 module "edgecloud_cluster_controlplane" {
   source = "../../../../managed-service-catalog/terraform/modules/edge-cluster"
 
-  name               = "controlplane-${var.name}-${var.stage}"
+  name               = "${var.name}-${var.stage}"
   project_id         = var.project_id
   ipv4_prefix        = var.ipv4_prefix
   edgecloud_image_id = var.edgecloud_image_id

--- a/go-binary/templates/embedded/managed-service-catalog/terraform/providers/stackit/modules/ske-cluster/main.tf
+++ b/go-binary/templates/embedded/managed-service-catalog/terraform/providers/stackit/modules/ske-cluster/main.tf
@@ -6,6 +6,18 @@ resource "stackit_ske_cluster" "this" {
 
   node_pools  = var.node_pools
   maintenance = var.ske_maintenance
+
+  # The SKE API uses the name as the Cluster ID therefore any
+  # change to the naming scheme or cluster name causes a full
+  # disruptive recreate of the SKE cluster. Which will cause
+  # data loss. Therefore we enforce that name changes in the
+  # kubara config or naming scheme logic is not propagated to
+  # existing clusters to ensure a stable platform.
+  lifecycle {
+    ignore_changes = [
+      name
+    ]
+  }
 }
 
 resource "stackit_ske_kubeconfig" "this" {
@@ -14,7 +26,6 @@ resource "stackit_ske_kubeconfig" "this" {
   refresh      = var.refresh
   expiration   = var.expiration
 }
-
 
 resource "local_file" "kubeconfig" {
   count           = var.create_kubeconfig_local ? 1 : 0


### PR DESCRIPTION
## 📝 Summary
Ensure a stable naming scheme for clusters as SKE is unfortunately using the name as the cluster ID. The name conflict risk is high and overlap in naming easily occurs. This PR resolves this issue by introducing a random part to the names.

* Up to 5 letters of the cluster name
* Concatenate with `-` and random characters

Furthermore, this PR introduces lifecycle management ignore to the SKE cluster resource to ensure existing clusters aren't recreated due to potential name changes.

## 🧩 Type of change
- [ ] 🔧 CLI / Go code
- [ ] 📦 Helm chart
- [X] 🧱 Terraform module
- [ ] 📝 Documentation
- [ ] 🧪 Test or CI change
- [ ] ♻️ Refactor / cleanup

## ⚠️ Is this a breaking change?
- [ ] Yes, this change breaks existing functionality (explain in summary)

## 🧪 Testing
- [X] CI passed
- [ ] Manually tested (local/dev cluster)
- [ ] Unit tested
- [ ] Not tested (explain why below)
  
## 🔗 Related Issues / Tickets
<!-- e.g. Closes #42, Related to #99 -->

## ✅ Checklist
- [X] Code compiles and passes all tests
- [X] Linting and style checks pass
- [ ] Comments added for complex logic
- [ ] Documentation updated (if applicable)
  
## 📎 Additional Context (optional)
<!-- Add logs, screenshots, diagrams, or design notes. -->
