### PR TITLE
feat: bash completion and command docs automation

### DIFF
--- a/.github/workflows/docs-check.yaml
+++ b/.github/workflows/docs-check.yaml
@@ -26,6 +26,13 @@ jobs:
       - name: Checkout kubara repo
         uses: actions/checkout@v6
 
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: src/go.mod
+          cache: true
+          cache-dependency-path: src/go.sum
+
       - name: Install and setup uv
         uses: astral-sh/setup-uv@v8.1.0
         with:
@@ -40,4 +47,12 @@ jobs:
         run: uv sync --frozen
 
       - name: Validate docs build (strict)
-        run: uv run mkdocs build --strict
+        run: make docs-build
+
+      - name: Check command docs is up to date
+        run: |
+          if ! git diff-index --quiet HEAD -- docs; then
+            echo "::error::Commands document isn't up to date:"
+            echo "::error::Please run 'make docs-build' locally to fix it."
+            exit 1
+          fi

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ docs-serve-dev:
 	@$(MAKE) -C docs serve-dev
 
 docs-build:
+	@$(MAKE) -C src docs
 	@$(MAKE) -C docs build
 
 docs-deploy:

--- a/docs/content/1_getting_started/commands.md
+++ b/docs/content/1_getting_started/commands.md
@@ -1,0 +1,154 @@
+# kubara commands
+
+# NAME
+
+kubara - Opinionated CLI for Kubernetes platform engineering
+
+# SYNOPSIS
+
+kubara
+
+```
+[--base64]
+[--catalog-overwrite]
+[--catalog]=[value]
+[--check-update]
+[--config-file|-c]=[value]
+[--decode]
+[--encode]
+[--env-file]=[value]
+[--file]=[value]
+[--help|-h]
+[--kubeconfig]=[value]
+[--string]=[value]
+[--test-connection]
+[--version|-v]
+[--work-dir|-w]=[value]
+```
+
+# DESCRIPTION
+
+kubara is an opinionated CLI to bootstrap and operate Kubernetes platforms with GitOps-first workflows.
+
+**Usage**:
+
+```
+kubara [GLOBAL OPTIONS] [command [COMMAND OPTIONS]] [ARGUMENTS...]
+```
+
+# GLOBAL OPTIONS
+
+**--base64**: Enable base64 encode/decode mode
+
+**--catalog**="": Path to external ServiceDefinition catalog directory.
+
+**--catalog-overwrite**: Allow external service definitions from --catalog to overwrite built-in definitions on name collisions.
+
+**--check-update**: Check online for a newer kubara release
+
+**--config-file, -c**="": Path to the configuration file (default: "config.yaml")
+
+**--decode**: Base64 decode input
+
+**--encode**: Base64 encode input
+
+**--env-file**="": Path to the .env file (default: ".env")
+
+**--file**="": Input file path for base64 operation
+
+**--help, -h**: show help
+
+**--kubeconfig**="": Path to kubeconfig file (default: "~/.kube/config")
+
+**--string**="": Input string for base64 operation
+
+**--test-connection**: Check if Kubernetes cluster can be reached. List namespaces and exit
+
+**--version, -v**: print the version
+
+**--work-dir, -w**="": Working directory (default: ".")
+
+
+# COMMANDS
+
+## init
+
+Initialize a new kubara directory
+
+**--envVarPrefix**="": Prefix for envs read from envVars (default: "KUBARA_")
+
+**--help, -h**: show help
+
+**--overwrite**: Overwrite config if exists
+
+**--prep**: Copy embedded prep/ folder into current working directory
+
+### help, h
+
+Shows a list of commands or help for one command
+
+## generate
+
+generates files from embedded templates and the config file; by default for both Helm and Terraform
+
+>generate [--terraform|--helm] [--managed-catalog <path> --overlay-values <path>] [--catalog <path> [--catalog-overwrite]] [--dry-run]
+
+**--dry-run**: Preview generation without creating files
+
+**--helm**: Only generate Helm files
+
+**--help, -h**: show help
+
+**--managed-catalog**="": Path to the managed catalog directory. (default: "managed-service-catalog")
+
+**--overlay-values**="": Path to overlay values directory. (default: "customer-service-catalog")
+
+**--terraform**: Only generate Terraform files
+
+### help, h
+
+Shows a list of commands or help for one command
+
+## bootstrap
+
+Bootstrap ArgoCD onto the specified cluster with optional external-secrets and prometheus CRD
+
+**--dry-run**: Run with dry-run
+
+**--envVarPrefix**="": Prefix for envs read from envVars (default: "KUBARA_")
+
+**--help, -h**: show help
+
+**--managed-catalog**="": Path to the managed catalog directory (default: "managed-service-catalog")
+
+**--overlay-values**="": Path to overlay values directory (default: "customer-service-catalog")
+
+**--timeout**="": Timeout for kubernetes API calls (e.g. 10s, 1m) (default: 5m0s)
+
+**--with-es-crds**: Also install external-secrets
+
+**--with-es-css-file**="": Path to the ClusterSecretStore manifest file (supports go-template + sprig)
+
+**--with-prometheus-crds**: Also install kube-prometheus-stack
+
+### help, h
+
+Shows a list of commands or help for one command
+
+## schema
+
+Generate JSON schema file for config structure
+
+>schema [--output] [--catalog <path> [--catalog-overwrite]]
+
+**--help, -h**: show help
+
+**--output, -o**="": Output file path for the JSON schema (default: "config.schema.json")
+
+### help, h
+
+Shows a list of commands or help for one command
+
+## help, h
+
+Shows a list of commands or help for one command

--- a/docs/content/1_getting_started/installation.md
+++ b/docs/content/1_getting_started/installation.md
@@ -127,3 +127,21 @@ On macOS you can also use:
 ```bash
 shasum -a 256 kubara_<version>_<os>_<arch>.<ext>
 ```
+
+## Shell Completion
+
+kubara supports shell completion for bash, zsh, fish and powershell.
+
+```shell
+# add the following line to your .bashrc
+$ source <(kubara completion bash)
+# or for zsh
+$ source <(kubara completion zsh)
+# after loading your rc file or opening a new terminal you will have tab completion for kubara
+$ kubara <tab>
+bootstrap  -- Bootstrap ArgoCD onto the specified cluster with optional external-secrets and prometheus CRD
+generate   -- generates files from embedded templates and the config file; by default for both Helm and Terraform
+help       -- Shows a list of commands or help for one command
+init       -- Initialize a new kubara directory
+schema     -- Generate JSON schema file for config structure
+```

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -12,6 +12,7 @@ nav:
       - Bootstrapping: 1_getting_started/bootstrapping.md
       - Providers:
           - STACKIT: 1_getting_started/providers/stackit.md
+      - Commands: 1_getting_started/commands.md
   - Managing Your Platform:
       - Add Spoke Cluster: 2_managing_your_platform/add_spoke_cluster.md
       - Add Project: 2_managing_your_platform/add_app_project.md

--- a/src/Makefile
+++ b/src/Makefile
@@ -65,6 +65,11 @@ format:
 	@echo "Formatting Go code..."
 	@go fmt ./...
 
+# Update command docs
+docs:
+	@echo "Updating command docs..."
+	@go run main.go --docs ../docs/content/1_getting_started/commands.md
+
 # Lint code (requires golangci-lint)
 lint:
 	@echo "Linting Go code..."

--- a/src/cmd/flags.go
+++ b/src/cmd/flags.go
@@ -22,6 +22,7 @@ type GlobalFlags struct {
 	CatalogPath        string
 	CatalogOverwrite   bool
 	TestK8sConnection  bool
+	DocsOutputPath     string
 	Base64Mode         bool
 	EncodeFlag         bool
 	DecodeFlag         bool
@@ -41,6 +42,7 @@ type RootOptions struct {
 	KubeconfigFilePath string
 	TestK8sConnection  bool
 	CheckUpdateFlag    bool
+	DocsOutputPath     string
 	Base64Mode         bool
 	Base64             Base64Options
 }
@@ -66,6 +68,7 @@ func (flags *GlobalFlags) ToRootOptions() RootOptions {
 		KubeconfigFilePath: kubeconfigFilePath,
 		TestK8sConnection:  flags.TestK8sConnection,
 		CheckUpdateFlag:    flags.CheckUpdateFlag,
+		DocsOutputPath:     flags.DocsOutputPath,
 		Base64Mode:         flags.Base64Mode,
 		Base64: Base64Options{
 			Encode:      flags.EncodeFlag,
@@ -122,6 +125,13 @@ func (flags *GlobalFlags) CLIFlags() []cli.Flag {
 			Value:       flags.TestK8sConnection,
 			Usage:       "Check if Kubernetes cluster can be reached. List namespaces and exit",
 			Destination: &flags.TestK8sConnection,
+		},
+		&cli.StringFlag{
+			Name:        "docs",
+			Value:       flags.DocsOutputPath,
+			Usage:       "Output file path for generated command docs",
+			Destination: &flags.DocsOutputPath,
+			Hidden:      true,
 		},
 		&cli.BoolFlag{
 			Name:        "base64",

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -6,11 +6,13 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/kubara-io/kubara/internal/k8s"
 	"github.com/kubara-io/kubara/internal/updatecheck"
 	"github.com/rs/zerolog/log"
+	docs "github.com/urfave/cli-docs/v3"
 	"github.com/urfave/cli/v3"
 )
 
@@ -22,11 +24,16 @@ var Authors = []any{
 var version string
 
 type rootActionDeps struct {
+	notifyUpdate   func(string)
 	checkUpdate    func(string) error
 	testConnection func(string)
+	writeDocs      func(*cli.Command, string) error
 }
 
 var defaultRootActionDeps = rootActionDeps{
+	notifyUpdate: func(ver string) {
+		updatecheck.NotifyIfNewReleaseAvailable(ver, os.Stderr)
+	},
 	checkUpdate: func(ver string) error {
 		if err := updatecheck.PrintLiveCheck(ver, os.Stdout); err != nil {
 			return cli.Exit(fmt.Sprintf("Error: update check failed: %v", err), 1)
@@ -34,6 +41,7 @@ var defaultRootActionDeps = rootActionDeps{
 		return nil
 	},
 	testConnection: testConnection,
+	writeDocs:      writeCommandDocs,
 }
 
 // NewRootCmd builds and returns the root CLI command. ver is injected from
@@ -43,18 +51,25 @@ func NewRootCmd(ver string) *cli.Command {
 	globalFlags := NewGlobalFlags()
 
 	return &cli.Command{
-		Name:        AppName,
-		Version:     ver,
-		Authors:     Authors,
-		Copyright:   "",
-		Usage:       "Opinionated CLI for Kubernetes platform engineering",
-		Description: "kubara is an opinionated CLI to bootstrap and operate Kubernetes platforms with GitOps-first workflows.",
-		Flags:       globalFlags.CLIFlags(),
+		Name:                  AppName,
+		Version:               ver,
+		Authors:               Authors,
+		Copyright:             "",
+		Usage:                 "Opinionated CLI for Kubernetes platform engineering",
+		Description:           "kubara is an opinionated CLI to bootstrap and operate Kubernetes platforms with GitOps-first workflows.",
+		Flags:                 globalFlags.CLIFlags(),
+		EnableShellCompletion: true,
 		Commands: []*cli.Command{
 			NewInitCmd(),
 			NewGenerateCmd(),
 			NewBootstrapCmd(),
 			NewSchemaCmd(),
+		},
+		Before: func(ctx context.Context, _ *cli.Command) (context.Context, error) {
+			if shouldNotifyStartupUpdate(globalFlags.ToRootOptions()) {
+				defaultRootActionDeps.notifyUpdate(ver)
+			}
+			return ctx, nil
 		},
 		Action: func(_ context.Context, cmd *cli.Command) error {
 			return newAppAction(cmd, globalFlags.ToRootOptions(), defaultRootActionDeps)
@@ -63,6 +78,10 @@ func NewRootCmd(ver string) *cli.Command {
 }
 
 func newAppAction(cmd *cli.Command, options RootOptions, deps rootActionDeps) error {
+	if strings.TrimSpace(options.DocsOutputPath) != "" {
+		return deps.writeDocs(cmd, options.DocsOutputPath)
+	}
+
 	if options.Base64Mode {
 		return runBase64Mode(options.Base64)
 	}
@@ -79,6 +98,28 @@ func newAppAction(cmd *cli.Command, options RootOptions, deps rootActionDeps) er
 		cli.ShowAppHelpAndExit(cmd, 0)
 	}
 
+	return nil
+}
+
+func shouldNotifyStartupUpdate(options RootOptions) bool {
+	return !options.CheckUpdateFlag && strings.TrimSpace(options.DocsOutputPath) == ""
+}
+
+func writeCommandDocs(app *cli.Command, outputPath string) error {
+	md, err := docs.ToMarkdown(app)
+	if err != nil {
+		return fmt.Errorf("create markdown: %w", err)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(outputPath), 0o755); err != nil {
+		return fmt.Errorf("create docs directory: %w", err)
+	}
+
+	if err := os.WriteFile(outputPath, []byte("# kubara commands\n\n"+md), 0o644); err != nil {
+		return fmt.Errorf("write docs file: %w", err)
+	}
+
+	log.Info().Str("path", outputPath).Msg("successfully created docs")
 	return nil
 }
 

--- a/src/go.mod
+++ b/src/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/rs/zerolog v1.35.1
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	github.com/stretchr/testify v1.11.1
+	github.com/urfave/cli-docs/v3 v3.1.0
 	github.com/urfave/cli/v3 v3.8.0
 	go.yaml.in/yaml/v3 v3.0.4
 	golang.org/x/crypto v0.50.0
@@ -37,6 +38,7 @@ require (
 	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/buger/jsonparser v1.1.2 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/cpuguy83/go-md2man/v2 v2.0.6 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/emicklei/go-restful/v3 v3.13.0 // indirect
 	github.com/evanphx/json-patch/v5 v5.9.11 // indirect
@@ -83,6 +85,7 @@ require (
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.5 // indirect
 	github.com/prometheus/procfs v0.19.2 // indirect
+	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/shopspring/decimal v1.4.0 // indirect
 	github.com/spf13/cast v1.7.0 // indirect
 	github.com/spf13/cobra v1.10.0 // indirect

--- a/src/go.sum
+++ b/src/go.sum
@@ -26,6 +26,7 @@ github.com/coreos/go-semver v0.3.1 h1:yi21YpKnrx1gt5R+la8n5WgS0kCrsPp33dmEyHReZr
 github.com/coreos/go-semver v0.3.1/go.mod h1:irMmmIw/7yzSRPWryHsK7EYSg09caPQL03VsM8rvUec=
 github.com/coreos/go-systemd/v22 v22.7.0 h1:LAEzFkke61DFROc7zNLX/WA2i5J8gYqe0rSj9KI28KA=
 github.com/coreos/go-systemd/v22 v22.7.0/go.mod h1:xNUYtjHu2EDXbsxz1i41wouACIwT7Ybq9o0BQhMwD0w=
+github.com/cpuguy83/go-md2man/v2 v2.0.6 h1:XJtiaUW6dEEqVuZiMTn1ldk455QWwEIsMIJlo5vtkx0=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -191,6 +192,7 @@ github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0t
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/rs/zerolog v1.35.1 h1:m7xQeoiLIiV0BCEY4Hs+j2NG4Gp2o2KPKmhnnLiazKI=
 github.com/rs/zerolog v1.35.1/go.mod h1:EjML9kdfa/RMA7h/6z6pYmq1ykOuA8/mjWaEvGI+jcw=
+github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 h1:KRzFb2m7YtdldCEkzs6KqmJw4nqEVZGK7IN2kJkjTuQ=
 github.com/santhosh-tekuri/jsonschema/v6 v6.0.2/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
@@ -216,6 +218,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/urfave/cli-docs/v3 v3.1.0 h1:Sa5xm19IpE5gpm6tZzXdfjdFxn67PnEsE4dpXF7vsKw=
+github.com/urfave/cli-docs/v3 v3.1.0/go.mod h1:59d+5Hz1h6GSGJ10cvcEkbIe3j233t4XDqI72UIx7to=
 github.com/urfave/cli/v3 v3.8.0 h1:XqKPrm0q4P0q5JpoclYoCAv0/MIvH/jZ2umzuf8pNTI=
 github.com/urfave/cli/v3 v3.8.0/go.mod h1:ysVLtOEmg2tOy6PknnYVhDoouyC/6N42TMeoMzskhso=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=

--- a/src/main.go
+++ b/src/main.go
@@ -3,10 +3,8 @@ package main
 import (
 	"context"
 	"os"
-	"slices"
 
 	"github.com/kubara-io/kubara/cmd"
-	"github.com/kubara-io/kubara/internal/updatecheck"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 )
@@ -24,11 +22,9 @@ func init() {
 }
 
 func main() {
-	if !slices.Contains(os.Args[1:], "--check-update") {
-		updatecheck.NotifyIfNewReleaseAvailable(version, os.Stderr)
-	}
+	app := cmd.NewRootCmd(version)
 
-	if err := cmd.NewRootCmd(version).Run(context.Background(), os.Args); err != nil {
+	if err := app.Run(context.Background(), os.Args); err != nil {
 		log.Fatal().Err(err).Msg("Error running program")
 	}
 }


### PR DESCRIPTION
## 📝 Summary
This PR introduces bash completion for kubara:

```shell
# add the following line to your .bashrc
$ source <(kubara completion bash)
# or for zsh
$ source <(kubara completion zsh)
# after loading your rc file or opening a new terminal you will have tab completion for kubara
$ kubara <tab>
bootstrap  -- Bootstrap ArgoCD onto the specified cluster with optional external-secrets and prometheus CRD
generate   -- generates files from embedded templates and the config file; by default for both Helm and Terraform
help       -- Shows a list of commands or help for one command
init       -- Initialize a new kubara directory
schema     -- Generate JSON schema file for config structure
```

## 🧩 Type of change
- [X] 🔧 CLI / Go code
- [ ] 📦 Helm chart
- [ ] 🧱 Terraform module
- [X] 📝 Documentation
- [X] 🧪 Test or CI change
- [X] ♻️ Refactor / cleanup

## ⚠️ Is this a breaking change?
- [ ] Yes, this change breaks existing functionality (explain in summary)

## 🧪 Testing
- [X] CI passed
- [X] Manually tested (local/dev cluster)
- [X] Unit tested
- [ ] Not tested (explain why below)
  
## 🔗 Related Issues / Tickets
<!-- e.g. Closes #42, Related to #99 -->

## ✅ Checklist
- [X] Code compiles and passes all tests
- [X] Linting and style checks pass
- [X] Comments added for complex logic
- [X] Documentation updated (if applicable)
  
## 📎 Additional Context (optional)
<!-- Add logs, screenshots, diagrams, or design notes. -->
