### PR TITLE
chore(renovate): group controller-runtime with k8s modules

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -49,12 +49,21 @@
       "groupSlug": "k8s-io-go-modules"
     },
     {
-      "description": "Group sigs.k8s.io go modules (minor and patch)",
+      "description": "Group sigs.k8s.io go modules except controller-runtime (minor and patch)",
       "matchManagers": ["gomod"],
-      "matchPackagePrefixes": ["sigs.k8s.io/"],
+      "matchPackageNames": ["sigs.k8s.io/**", "!sigs.k8s.io/controller-runtime"],
       "matchUpdateTypes": ["minor", "patch"],
       "groupName": "sigs.k8s.io go modules",
       "groupSlug": "sigs-k8s-io-go-modules"
+    },
+    {
+      "description": "Group controller-runtime with k8s.io go modules",
+      "matchManagers": ["gomod"],
+      "matchPackageNames": ["sigs.k8s.io/controller-runtime"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "enabled": true,
+      "groupName": "k8s.io go modules",
+      "groupSlug": "k8s-io-go-modules"
     },
     {
       "description": "Group golang.org/x go modules (minor and patch)",

--- a/renovate.json
+++ b/renovate.json
@@ -49,15 +49,15 @@
       "groupSlug": "k8s-io-go-modules"
     },
     {
-      "description": "Group sigs.k8s.io go modules except controller-runtime (minor and patch)",
+      "description": "Group sigs.k8s.io go modules (minor and patch)",
       "matchManagers": ["gomod"],
-      "matchPackageNames": ["sigs.k8s.io/**", "!sigs.k8s.io/controller-runtime"],
+      "matchPackagePrefixes": ["sigs.k8s.io/"],
       "matchUpdateTypes": ["minor", "patch"],
       "groupName": "sigs.k8s.io go modules",
       "groupSlug": "sigs-k8s-io-go-modules"
     },
     {
-      "description": "Group controller-runtime with k8s.io go modules",
+      "description": "Override: group controller-runtime with k8s.io modules because it follows the k8s.io/client-go minor",
       "matchManagers": ["gomod"],
       "matchPackageNames": ["sigs.k8s.io/controller-runtime"],
       "matchUpdateTypes": ["minor", "patch"],


### PR DESCRIPTION
## 📝 Summary
Adds an explicit Renovate override for `sigs.k8s.io/controller-runtime` so it uses the existing `k8s.io` Go module group while keeping the generic `sigs.k8s.io` group unchanged.

`controller-runtime` needs to stay aligned with Kubernetes/client-go minor versions. This avoids broken Renovate PRs like #311 where `k8s.io/*` was updated without the compatible `controller-runtime` version.

## 🧩 Type of change
- [ ] 🔧 CLI / Go code
- [ ] 📦 Helm chart
- [ ] 🧱 Terraform module
- [ ] 📝 Documentation
- [x] 🧪 Test or CI change
- [ ] ♻️ Refactor / cleanup

## ⚠️ Is this a breaking change?
- [ ] Yes, this change breaks existing functionality (explain in summary)

## 🧪 Testing
- [ ] CI passed
- [ ] Manually tested (local/dev cluster)
- [ ] Unit tested
- [x] Not tested (explain why below)

No runtime tests were run because this is a Renovate configuration-only change. The config file was validated as JSON with `jq empty renovate.json`.

## 🔗 Related Issues / Tickets
Related to #311

## ✅ Checklist
- [ ] Code compiles and passes all tests
- [x] Linting and style checks pass
- [ ] Comments added for complex logic
- [ ] Documentation updated (if applicable)

## 📎 Additional Context (optional)
Renovate's built-in Kubernetes monorepo preset covers the `kubernetes/kubernetes` staging repositories (`k8s.io/*`) but does not include `sigs.k8s.io/controller-runtime`. The preset was introduced in renovatebot/renovate#41171 and consolidated in renovatebot/renovate#41454.

`controller-runtime` is still tied to the Kubernetes/client-go compatibility matrix: https://github.com/kubernetes-sigs/controller-runtime#compatibility
