### PR TITLE
chore: right-size managed service resources

### DIFF
--- a/go-binary/templates/embedded/managed-service-catalog/helm/argo-cd/values.yaml
+++ b/go-binary/templates/embedded/managed-service-catalog/helm/argo-cd/values.yaml
@@ -33,9 +33,9 @@ argo-cd:
     resources:
       requests:
         cpu: 50m
-        memory: 150Mi
+        memory: 256Mi
       limits:
-        memory: 200Mi
+        memory: 256Mi
     livenessProbe:
       enabled: true
     readinessProbe:
@@ -46,7 +46,7 @@ argo-cd:
         cpu: 100m
         memory: 256Mi
       limits:
-        memory: 512Mi
+        memory: 256Mi
     livenessProbe:
       enabled: true
     readinessProbe:
@@ -60,10 +60,10 @@ argo-cd:
       enabled: false
     resources:
       requests:
-        cpu: 256m
-        memory: 500Mi
+        cpu: 100m
+        memory: 512Mi
       limits:
-        memory: 1000Mi
+        memory: 512Mi
     livenessProbe:
       enabled: true
     readinessProbe:
@@ -81,10 +81,10 @@ argo-cd:
       automountServiceAccountToken: true
     resources:
       requests:
-        cpu: 500m
+        cpu: 100m
         memory: 512Mi
       limits:
-        memory: 1000Mi
+        memory: 512Mi
   configs:
     cm:
       exec.enabled: false
@@ -116,18 +116,18 @@ argo-cd:
       minAvailable: 1
     resources:
       requests:
-        cpu: 1500m
-        memory: 2000Mi
+        cpu: 250m
+        memory: 1000Mi
       limits:
-        memory: 2500Mi
+        memory: 1000Mi
 
   controller:
     resources:
       requests:
-        cpu: 2000m
+        cpu: 250m
         memory: 2000Mi
       limits:
-        memory: 2500Mi
+        memory: 2000Mi
     metrics:
       enabled: false
       serviceMonitor:

--- a/go-binary/templates/embedded/managed-service-catalog/helm/cert-manager/values.yaml
+++ b/go-binary/templates/embedded/managed-service-catalog/helm/cert-manager/values.yaml
@@ -24,9 +24,9 @@ cert-manager:
     resources:
       requests:
         cpu: 10m
-        memory: 100Mi
+        memory: 150Mi
       limits:
-        memory: 100Mi
+        memory: 150Mi
   startupapicheck:
     resources:
       requests:

--- a/go-binary/templates/embedded/managed-service-catalog/helm/external-secrets/values.yaml
+++ b/go-binary/templates/embedded/managed-service-catalog/helm/external-secrets/values.yaml
@@ -6,9 +6,9 @@ external-secrets:
     resources:
       requests:
         cpu: 10m
-        memory: 100Mi
+        memory: 150Mi
       limits:
-        memory: 100Mi
+        memory: 150Mi
   webhook:
     replicaCount: 1
     resources:

--- a/go-binary/templates/embedded/managed-service-catalog/helm/kube-prometheus-stack/values.yaml
+++ b/go-binary/templates/embedded/managed-service-catalog/helm/kube-prometheus-stack/values.yaml
@@ -80,10 +80,10 @@ kube-prometheus-stack:
     prometheusSpec:
       resources:
         requests:
-          cpu: 57m
-          memory: 700Mi
+          cpu: 50m
+          memory: 1024Mi
         limits:
-          memory: 700Mi
+          memory: 1024Mi
       securityContext:
         runAsGroup: 2000
         runAsNonRoot: true
@@ -128,9 +128,9 @@ kube-prometheus-stack:
     resources:
       requests:
         cpu: 10m
-        memory: 200Mi
+        memory: 768Mi
       limits:
-        memory: 200Mi
+        memory: 768Mi
     securityContext:
       runAsUser: 472
       runAsGroup: 472
@@ -168,9 +168,9 @@ kube-prometheus-stack:
       resources:
         requests:
           cpu: 10m
-          memory: 150Mi
+          memory: 100Mi
         limits:
-          memory: 150Mi
+          memory: 100Mi
       securityContext:
         runAsNonRoot: true
         runAsUser: 472

--- a/go-binary/templates/embedded/managed-service-catalog/helm/kyverno-policy-reporter/values.yaml
+++ b/go-binary/templates/embedded/managed-service-catalog/helm/kyverno-policy-reporter/values.yaml
@@ -23,7 +23,7 @@ policy-reporter:
     enabled: false
   resources:
     requests:
-      cpu: 30m
+      cpu: 10m
       memory: 100Mi
     limits:
       memory: 100Mi

--- a/go-binary/templates/embedded/managed-service-catalog/helm/kyverno/values.yaml
+++ b/go-binary/templates/embedded/managed-service-catalog/helm/kyverno/values.yaml
@@ -1,14 +1,66 @@
 namespace: {}
 kyverno:
+  crds:
+    migration:
+      podResources: null
+  test:
+    resources:
+      limits:
+        cpu: null
+        memory: 256Mi
+      requests:
+        cpu: 10m
+        memory: 256Mi
+  webhooksCleanup:
+    resources:
+      limits:
+        cpu: null
+        memory: 256Mi
+      requests:
+        cpu: 10m
+        memory: 256Mi
   admissionController:
+    initContainer:
+      resources:
+        requests:
+          cpu: 10m
+          memory: 256Mi
+        limits:
+          cpu: null
+          memory: 256Mi
+    container:
+      resources:
+        requests:
+          cpu: 50m
+          memory: 384Mi
+        limits:
+          memory: 384Mi
     serviceMonitor:
       enabled: false
   backgroundController:
+    resources:
+      requests:
+        cpu: 50m
+        memory: 128Mi
+      limits:
+        memory: 128Mi
     serviceMonitor:
       enabled: false
   cleanupController:
+    resources:
+      requests:
+        cpu: 50m
+        memory: 128Mi
+      limits:
+        memory: 128Mi
     serviceMonitor:
       enabled: false
   reportsController:
+    resources:
+      requests:
+        cpu: 50m
+        memory: 128Mi
+      limits:
+        memory: 128Mi
     serviceMonitor:
       enabled: false

--- a/go-binary/templates/embedded/managed-service-catalog/helm/loki/values.yaml
+++ b/go-binary/templates/embedded/managed-service-catalog/helm/loki/values.yaml
@@ -75,10 +75,10 @@ alloy:
           mountPath: /tmp
     resources:
       requests:
-        cpu: 300m
-        memory: 100Mi
+        cpu: 100m
+        memory: 300Mi
       limits:
-        memory: 500Mi
+        memory: 300Mi
     securityContext:
       runAsUser: 0
       runAsGroup: 0
@@ -99,9 +99,9 @@ alloy:
     resources:
       requests:
         cpu: 10m
-        memory: 50Mi
+        memory: 100Mi
       limits:
-        memory: 50Mi
+        memory: 100Mi
     securityContext:
       readOnlyRootFilesystem: true
       allowPrivilegeEscalation: false
@@ -208,10 +208,10 @@ loki:
   singleBinary:
     resources:
       requests:
-        cpu: 10m
-        memory: 300Mi
+        cpu: 50m
+        memory: 500Mi
       limits:
-        memory: 300Mi
+        memory: 500Mi
   lokiCanary:
     resources:
       requests:
@@ -223,7 +223,7 @@ loki:
     resources:
       requests:
         cpu: 10m
-        memory: 150Mi
+        memory: 100Mi
       limits:
-        memory: 150Mi
+        memory: 100Mi
 namespace: {}

--- a/go-binary/templates/embedded/managed-service-catalog/helm/traefik/values.yaml
+++ b/go-binary/templates/embedded/managed-service-catalog/helm/traefik/values.yaml
@@ -1,7 +1,7 @@
 traefik:
   resources:
     requests:
-        cpu: 250m
-        memory: 512Mi
+        cpu: 100m
+        memory: 256Mi
     limits:
-      memory: 1024Mi
+      memory: 256Mi


### PR DESCRIPTION
## 📝 Summary
<!-- Please read first: https://github.com/kubara-io/kubara/blob/main/CONTRIBUTING.md -->
  
Right-sizes resource requests and memory limits for managed service Helm charts based on observed dev cluster usage and KRR recommendations.

This reduces excessive CPU requests, especially for Argo CD and Alloy, keeps CPU limits absent from rendered workloads, and aligns memory requests with memory limits for more predictable scheduling and capacity planning. Grafana memory is increased to account for observed OOMKills during dashboard usage.

## 🧩 Type of change
- [ ] 🔧 CLI / Go code
- [x] 📦 Helm chart
- [ ] 🧱 Terraform module
- [ ] 📝 Documentation
- [ ] 🧪 Test or CI change
- [ ] ♻️ Refactor / cleanup

## ⚠️ Is this a breaking change?
- [ ] Yes, this change breaks existing functionality (explain in summary)

## 🧪 Testing
- [ ] CI passed
- [ ] Manually tested (local/dev cluster)
- [x] Unit tested
- [ ] Not tested (explain why below)

Deploy testing is still pending; this is opened as a draft PR for validation on the target cluster.
  
## 🔗 Related Issues / Tickets
N/A

## ✅ Checklist
- [x] Code compiles and passes all tests
- [x] Linting and style checks pass
- [ ] Comments added for complex logic
- [x] Documentation updated (if applicable)
  
## 📎 Additional Context (optional)
Validated with local Helm rendering across the managed service catalog.

Checks performed:
- `go test ./...`
- YAML parse for changed values files
- `git diff --check`
- rendered resource scan: no `resources.limits.cpu`
- rendered resource scan: memory requests match memory limits where memory resources are set

Resource changes cover Argo CD, Loki/Alloy, kube-prometheus-stack/Grafana, Traefik, Kyverno, and Kyverno Policy Reporter.
