### PR TITLE
fix: align external-dns webhook port

### DIFF
--- a/go-binary/templates/embedded/customer-service-catalog/helm/example/external-dns/values.yaml.tplt
+++ b/go-binary/templates/embedded/customer-service-catalog/helm/example/external-dns/values.yaml.tplt
@@ -28,7 +28,9 @@ external-dns:
   domainFilters:
     - {{ .cluster.dnsName}}
   extraArgs:
-    - --source=traefik-proxy
+    source:
+      - traefik-proxy
+    webhook-provider-url: http://localhost:8080
   rbac:
     create: true
     additionalPermissions:
@@ -65,6 +67,8 @@ external-dns:
         - name: stackit-sa-authentication
           mountPath: /var/run/secrets/stackit
       env:
+        - name: API_PORT
+          value: "8080"
         - name: AUTH_KEY_PATH
           value: /var/run/secrets/stackit/sa_key.json
         - name: PROJECT_ID

--- a/go-binary/templates/embedded/managed-service-catalog/helm/external-dns/CHANGELOG.md
+++ b/go-binary/templates/embedded/managed-service-catalog/helm/external-dns/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1] - 2026-05-18
+### Fixed
+- Align STACKIT webhook port configuration with the external-dns chart defaults.
+
 ## [0.2.0] - 2026-05-04
 ### Changed
 - Updated chart dependency version: external-dns 1.20.0 → 1.21.1

--- a/go-binary/templates/embedded/managed-service-catalog/helm/external-dns/Chart.yaml
+++ b/go-binary/templates/embedded/managed-service-catalog/helm/external-dns/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: external-dns
 description: Umbrella Chart for external-dns
 type: application
-version: 0.2.0
+version: 0.2.1
 dependencies:
   - name: template-library
     repository: file://../template-library

--- a/go-binary/templates/embedded/managed-service-catalog/helm/external-dns/values.yaml
+++ b/go-binary/templates/embedded/managed-service-catalog/helm/external-dns/values.yaml
@@ -51,7 +51,7 @@ external-dns:
           drop: [ "ALL" ]
       livenessProbe:
         httpGet:
-          port: 8888
+          port: http-webhook
       readinessProbe:
         httpGet:
-          port: 8888
+          port: http-webhook


### PR DESCRIPTION
## 📝 Summary
<!-- Please read first: https://github.com/kubara-io/kubara/blob/main/CONTRIBUTING.md -->

Align the generated STACKIT external-dns webhook configuration with the upstream external-dns chart defaults.

- configure the generated STACKIT webhook values to listen on `8080`
- point ExternalDNS explicitly to `http://localhost:8080` for the webhook provider
- align webhook liveness/readiness probes with the chart's `http-webhook` port
- bump the external-dns umbrella chart to `0.2.1` and add a changelog entry

## 🧩 Type of change
- [ ] 🔧 CLI / Go code
- [x] 📦 Helm chart
- [ ] 🧱 Terraform module
- [x] 📝 Documentation
- [ ] 🧪 Test or CI change
- [ ] ♻️ Refactor / cleanup

## ⚠️ Is this a breaking change?
- [ ] Yes, this change breaks existing functionality (explain in summary)

## 🧪 Testing
- [ ] CI passed
- [x] Manually tested (local/dev cluster)
- [x] Unit tested
- [ ] Not tested (explain why below)

## 🔗 Related Issues / Tickets
N/A

## ✅ Checklist
- [x] Code compiles and passes all tests
- [ ] Linting and style checks pass
- [x] Comments added for complex logic
- [x] Documentation updated (if applicable)

## 📎 Additional Context (optional)
During the integration tests, Prometheus reported the `serviceMonitor/external-dns/external-dns/1` target as down. The external-dns chart exposes and monitors the webhook container on the `http-webhook` service port, which maps to container port `8080`. The STACKIT webhook was effectively running on `8888`, so Prometheus tried to scrape `http://<pod-ip>:8080/metrics` and got `connection refused`.

The same change was verified in the integration target cluster: both external-dns Prometheus targets are `up` and scrape samples are present. Local validation also included `go test ./...` from `go-binary` and a `helm template` render containing `--webhook-provider-url=http://localhost:8080`, `API_PORT=8080`, `containerPort: 8080`, and probes on `http-webhook`.