### PR TITLE
chore: increase SKE nodepool disk size

### DIFF
--- a/go-binary/templates/embedded/customer-service-catalog/terraform/providers/stackit/example/infrastructure/env.auto.tfvars.tplt
+++ b/go-binary/templates/embedded/customer-service-catalog/terraform/providers/stackit/example/infrastructure/env.auto.tfvars.tplt
@@ -29,6 +29,7 @@ node_pools = [
   {
     availability_zones = ["eu01-2"]
     machine_type       = "c2i.8"
+    volume_size        = 30
     maximum            = 4
     minimum            = 2
     name               = "pool-infra"

--- a/go-binary/templates/embedded/customer-service-catalog/terraform/providers/stackit/example/infrastructure/variables.tf.tplt
+++ b/go-binary/templates/embedded/customer-service-catalog/terraform/providers/stackit/example/infrastructure/variables.tf.tplt
@@ -92,6 +92,7 @@ List of node pools. Each element must be an object with:
 - name               = string
 - machine_type       = string
 - os_version_min     = optional(string)
+- volume_size        = optional(number, 30)
 - minimum            = number
 - maximum            = number
 - availability_zones = list(string)
@@ -106,6 +107,7 @@ EOF
     name               = string
     machine_type       = string
     os_version_min     = optional(string)
+    volume_size        = optional(number, 30)
     minimum            = number
     maximum            = number
     availability_zones = list(string)

--- a/go-binary/templates/embedded/managed-service-catalog/terraform/providers/stackit/README.md
+++ b/go-binary/templates/embedded/managed-service-catalog/terraform/providers/stackit/README.md
@@ -145,6 +145,7 @@ node_pools = [
         {
             availability_zones = ["eu01-2"]
             machine_type       = "c1.5"
+            volume_size        = 30
             maximum            = 4
             minimum            = 2
             name               = "pool-infra"

--- a/go-binary/templates/embedded/managed-service-catalog/terraform/providers/stackit/modules/ske-cluster/README.md
+++ b/go-binary/templates/embedded/managed-service-catalog/terraform/providers/stackit/modules/ske-cluster/README.md
@@ -17,6 +17,7 @@ module "ske_cluster" {
     {
       name               = "np-frontend"
       machine_type       = "c1.2"
+      volume_size        = 30
       minimum            = 2
       maximum            = 4
       availability_zones = ["eu01-1", "eu01-2"]
@@ -28,6 +29,7 @@ module "ske_cluster" {
     {
       name               = "np-backend"
       machine_type       = "c1.2"
+      volume_size        = 30
       minimum            = 2
       maximum            = 5
       availability_zones = ["eu01-1", "eu01-2", "eu01-3"]
@@ -74,7 +76,7 @@ No modules.
 | <a name="input_kubeconfig_path"></a> [kubeconfig\_path](#input\_kubeconfig\_path) | Filesystem path where the kubeconfig will be written if create\_kubeconfig\_local is true | `string` | `"~/.kube/config"` | no |
 | <a name="input_kubernetes_version_min"></a> [kubernetes\_version\_min](#input\_kubernetes\_version\_min) | Minimum Kubernetes version (e.g. "1.31.7"); uses latest if unset | `string` | `"1.31.8"` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name of the SKE cluster. Can only container 11 characters | `string` | n/a | yes |
-| <a name="input_node_pools"></a> [node\_pools](#input\_node\_pools) | List of node pools. Each element must be an object with:<br/>- name               = string<br/>- machine\_type       = string<br/>- os\_version\_min     = optional(string)<br/>- minimum            = number<br/>- maximum            = number<br/>- availability\_zones = list(string)<br/>- labels             = map(string)<br/>- taints             = list(object({<br/>    key    = string<br/>    value  = string<br/>    effect = string<br/>  })) | <pre>list(object({<br/>    name               = string<br/>    machine_type       = string<br/>    os_version_min     = optional(string)<br/>    minimum            = number<br/>    maximum            = number<br/>    availability_zones = list(string)<br/>    labels             = map(string)<br/>    taints = list(object({<br/>      key    = string<br/>      value  = string<br/>      effect = string<br/>    }))<br/>  }))</pre> | `[]` | no |
+| <a name="input_node_pools"></a> [node\_pools](#input\_node\_pools) | List of node pools. Each element must be an object with:<br/>- name               = string<br/>- machine\_type       = string<br/>- os\_version\_min     = optional(string)<br/>- volume\_size        = optional(number, 30)<br/>- minimum            = number<br/>- maximum            = number<br/>- availability\_zones = list(string)<br/>- labels             = map(string)<br/>- taints             = list(object({<br/>    key    = string<br/>    value  = string<br/>    effect = string<br/>  })) | <pre>list(object({<br/>    name               = string<br/>    machine_type       = string<br/>    os_version_min     = optional(string)<br/>    volume_size        = optional(number, 30)<br/>    minimum            = number<br/>    maximum            = number<br/>    availability_zones = list(string)<br/>    labels             = map(string)<br/>    taints = list(object({<br/>      key    = string<br/>      value  = string<br/>      effect = string<br/>    }))<br/>  }))</pre> | `[]` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | STACKIT project ID to associate the cluster with | `string` | n/a | yes |
 | <a name="input_refresh"></a> [refresh](#input\_refresh) | Refresh token for the SKE cluster | `bool` | `true` | no |
 | <a name="input_region"></a> [region](#input\_region) | Region for the cluster; falls back to provider region if null | `string` | `"eu01"` | no |

--- a/go-binary/templates/embedded/managed-service-catalog/terraform/providers/stackit/modules/ske-cluster/variables.tf
+++ b/go-binary/templates/embedded/managed-service-catalog/terraform/providers/stackit/modules/ske-cluster/variables.tf
@@ -26,6 +26,7 @@ List of node pools. Each element must be an object with:
 - name               = string
 - machine_type       = string
 - os_version_min     = optional(string)
+- volume_size        = optional(number, 30)
 - minimum            = number
 - maximum            = number
 - availability_zones = list(string)
@@ -40,6 +41,7 @@ EOF
     name               = string
     machine_type       = string
     os_version_min     = optional(string)
+    volume_size        = optional(number, 30)
     minimum            = number
     maximum            = number
     availability_zones = list(string)


### PR DESCRIPTION
## 📝 Summary
<!-- Please read first: https://github.com/kubara-io/kubara/blob/main/CONTRIBUTING.md -->

Increase the generated STACKIT SKE node pool root disk size from the provider default by making `volume_size` explicit.

- add `volume_size` to the generated SKE node pool input schema with a default of `30` GB
- set the generated example infrastructure node pool to `volume_size = 30`
- update the STACKIT Terraform README examples and module input docs

## 🧩 Type of change
- [ ] 🔧 CLI / Go code
- [ ] 📦 Helm chart
- [x] 🧱 Terraform module
- [x] 📝 Documentation
- [ ] 🧪 Test or CI change
- [ ] ♻️ Refactor / cleanup

## ⚠️ Is this a breaking change?
- [ ] Yes, this change breaks existing functionality (explain in summary)

No. According to the Terraform integration test, changing the node pool `volume_size` is planned as an in-place update.

## 🧪 Testing
- [ ] CI passed
- [ ] Manually tested (local/dev cluster)
- [x] Unit tested
- [ ] Not tested (explain why below)

Terraform integration test confirmed this is an in-place update.

## 🔗 Related Issues / Tickets
N/A

## ✅ Checklist
- [x] Code compiles and passes all tests
- [x] Linting and style checks pass
- [x] Comments added for complex logic
- [x] Documentation updated (if applicable)

## 📎 Additional Context (optional)
During the integration tests we saw node-level disk pressure/image garbage collection symptoms. This is separate from service PVC sizing: Prometheus and other stateful services can still use PVCs, while kubelet/container runtime images and writable node data use the SKE node pool root volume.

If `volume_size` is not set, the provider default is 20 GB. This PR uses 30 GB as a conservative first step that gives the node more headroom without making the default too opinionated. The right value still depends on workload, image churn, rollout patterns, and logging volume, and users can override it per node pool when they need more space.

Validation included `go test ./...` from `go-binary` and `terraform fmt -check go-binary/templates/embedded/managed-service-catalog/terraform/providers/stackit/modules/ske-cluster/variables.tf`.