### PR TITLE
chore: track Helm template image tags with Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,18 @@
   "terraform": {
     "fileMatch": ["\\.tf(\\.tplt)?$"]
   },
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Update Docker image tags in Helm values templates",
+      "managerFilePatterns": ["/(^|/)values\\.ya?ml\\.tplt$/"],
+      "matchStrings": [
+        "repository:\\s*[\"']?(?<depName>[^\"'\\s]+)[\"']?\\s*\\n\\s*tag:\\s*[\"']?(?<currentValue>[^\"'\\s]+)[\"']?"
+      ],
+      "datasourceTemplate": "docker",
+      "versioningTemplate": "docker"
+    }
+  ],
   "packageRules": [
     {
       "matchFiles": ["**/Chart.{yaml,yml}"],

--- a/renovate.json
+++ b/renovate.json
@@ -9,7 +9,7 @@
     {
       "customType": "regex",
       "description": "Update Docker image tags in Helm values templates",
-      "managerFilePatterns": ["/(^|/)values\\.ya?ml\\.tplt$/"],
+      "managerFilePatterns": ["/values\\.ya?ml\\.tplt$/"],
       "matchStrings": [
         "repository:\\s*[\"']?(?<depName>[^\"'\\s]+)[\"']?\\s*\\n\\s*tag:\\s*[\"']?(?<currentValue>[^\"'\\s]+)[\"']?"
       ],


### PR DESCRIPTION
## 📝 Summary
<!-- Please read first: https://github.com/kubara-io/kubara/blob/main/CONTRIBUTING.md -->

Add a Renovate regex custom manager for Docker image tags defined in Helm values templates.

- scan `values.yaml.tplt` / `values.yml.tplt` files for adjacent `repository` and `tag` fields
- use Renovate's Docker datasource/versioning for matched image tags
- currently this picks up `ghcr.io/stackitcloud/external-dns-stackit-webhook:v0.3.2`

## 🧩 Type of change
- [ ] 🔧 CLI / Go code
- [ ] 📦 Helm chart
- [ ] 🧱 Terraform module
- [ ] 📝 Documentation
- [x] 🧪 Test or CI change
- [ ] ♻️ Refactor / cleanup

## ⚠️ Is this a breaking change?
- [ ] Yes, this change breaks existing functionality (explain in summary)

No. This only changes Renovate dependency detection.

## 🧪 Testing
- [ ] CI passed
- [ ] Manually tested (local/dev cluster)
- [ ] Unit tested
- [ ] Not tested (explain why below)

Validated locally with:

- `jq empty renovate.json`
- `renovate-config-validator renovate.json`
- a Node regex smoke test confirming the custom manager extracts `ghcr.io/stackitcloud/external-dns-stackit-webhook:v0.3.2`

## 🔗 Related Issues / Tickets
N/A

## ✅ Checklist
- [ ] Code compiles and passes all tests
- [x] Linting and style checks pass
- [x] Comments added for complex logic
- [ ] Documentation updated (if applicable)

## 📎 Additional Context (optional)
We noticed that the STACKIT ExternalDNS webhook image stayed on `v0.3.2` although upstream has newer tags. The reason is that the image is configured in `go-binary/templates/embedded/customer-service-catalog/helm/example/external-dns/values.yaml.tplt`, and the existing Renovate setup only covered Helm `Chart.yaml`, Terraform templates, Go modules, and GitHub Actions versions.

Without a custom manager, Renovate does not detect this `repository`/`tag` pair in the `.tplt` values file, so no update PR is created. The first known missed image is `ghcr.io/stackitcloud/external-dns-stackit-webhook`, and the new matcher should also cover future images using the same values-template structure.