### PR TITLE
ci(docs): harden docs check diff detection

### DIFF
--- a/.github/workflows/docs-check.yaml
+++ b/.github/workflows/docs-check.yaml
@@ -6,6 +6,7 @@ on:
       - 'main'
     paths:
       - 'docs/**'
+      - '.github/workflows/docs-check.yaml'
   workflow_dispatch:
 
 permissions:
@@ -51,7 +52,7 @@ jobs:
 
       - name: Check command docs is up to date
         run: |
-          if ! git diff-index --quiet HEAD -- docs; then
+          if ! git diff --exit-code -- docs; then
             echo "::error::Commands document isn't up to date:"
             echo "::error::Please run 'make docs-build' locally to fix it."
             exit 1


### PR DESCRIPTION
## 📝 Summary
<!-- Please read first: https://github.com/kubara-io/kubara/blob/main/CONTRIBUTING.md -->

Fix the docs-check CI failure currently blocking [#304](https://github.com/kubara-io/kubara/pull/304) after the generated command docs step:

- trigger docs-check when the workflow file itself changes
- replace `git diff-index --quiet HEAD -- docs` with `git diff --exit-code -- docs`

This keeps the generated docs guardrail, but checks for an actual content diff after `make docs-build` instead of relying on a more index-sensitive command.

## 🧩 Type of change
- [ ] 🔧 CLI / Go code
- [ ] 📦 Helm chart
- [ ] 🧱 Terraform module
- [ ] 📝 Documentation
- [X] 🧪 Test or CI change
- [ ] ♻️ Refactor / cleanup

## ⚠️ Is this a breaking change?
- [ ] Yes, this change breaks existing functionality (explain in summary)

## 🧪 Testing
- [X] CI passed
- [X] Manually tested (local/dev cluster)
- [ ] Unit tested
- [ ] Not tested (explain why below)

Local checks:

```bash
make docs-build
git diff --exit-code -- docs
git diff --check -- .github/workflows/docs-check.yaml
```

## 🔗 Related Issues / Tickets
Fixes the docs-check CI issue observed in [#304](https://github.com/kubara-io/kubara/pull/304)
Follow-up to [#331](https://github.com/kubara-io/kubara/pull/331)

## ✅ Checklist
- [ ] Code compiles and passes all tests
- [X] Linting and style checks pass
- [ ] Comments added for complex logic
- [ ] Documentation updated (if applicable)

## 📎 Additional Context (optional)
<!-- Add logs, screenshots, diagrams, or design notes. -->

The previous docs-check command could report a dirty docs tree after regenerating command docs even when there was no actual content diff. This PR keeps the same guardrail and makes the comparison match the intended check.
