### PR TITLE
fix: resolve PR static analysis failures

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -101,12 +101,14 @@ jobs:
         uses: golangci/golangci-lint-action@v9
         with:
           version: ${{ env.GOLANGCI_LINT_VERSION }}
+          install-mode: goinstall
           working-directory: ${{ env.CODE_PATH }}
           args: |
             --output.text.path stdout \
             --output.html.path "${{ env.REPORT_DIR }}/golangci-results.html"
 
       - name: Cache gosec
+        if: always()
         id: cache-gosec
         uses: actions/cache@v5
         with:
@@ -114,7 +116,7 @@ jobs:
           key: ${{ runner.os }}-${{ runner.arch }}-gosec-${{ env.GOSEC_VERSION }}
 
       - name: Install gosec (if not cached)
-        if: steps.cache-gosec.outputs.cache-hit != 'true'
+        if: always() && steps.cache-gosec.outputs.cache-hit != 'true'
         run: |
           set -euo pipefail
           mkdir -p ~/.local/bin

--- a/src/internal/config/store.go
+++ b/src/internal/config/store.go
@@ -126,7 +126,7 @@ func migrateLegacyConfig(raw map[string]any) (map[string]any, error) {
 }
 
 func migrateLegacyCluster(cluster map[string]any, clusterIndex int) error {
-	clusterTypeRaw, _ := cluster["type"]
+	clusterTypeRaw := cluster["type"]
 	if clusterTypeRaw != nil {
 		clusterType, ok := clusterTypeRaw.(string)
 		if !ok {


### PR DESCRIPTION
## 📝 Summary
<!-- Please read first: https://github.com/kubara-io/kubara/blob/main/CONTRIBUTING.md -->
  
<!-- What does this PR do? e.g. "Adds Terraform module for SKE setup" -->

## 🧩 Type of change
- [x] 🔧 CLI / Go code
- [ ] 📦 Helm chart
- [ ] 🧱 Terraform module
- [ ] 📝 Documentation
- [x] 🧪 Test or CI change
- [x] ♻️ Refactor / cleanup

## ⚠️ Is this a breaking change?
- [ ] Yes, this change breaks existing functionality (explain in summary)

## 🧪 Testing
- [x] CI passed
- [ ] Manually tested (local/dev cluster)
- [x] Unit tested
- [ ] Not tested (explain why below)
  
## 🔗 Related Issues / Tickets
N/A

## ✅ Checklist
- [x] Code compiles and passes all tests
- [x] Linting and style checks pass
- [ ] Comments added for complex logic
- [x] Documentation updated (if applicable)
  
## 📎 Additional Context (optional)
The Go code change resolves a staticcheck S1005 finding in `src/internal/config/store.go`.

`cluster["type"]` can return two values: the map value and an `ok` flag. Since the code did not use the `ok` flag and ignored it with `_`, staticcheck reported S1005. The behavior stays the same: when `type` is missing, `clusterTypeRaw` is still `nil`, and the existing `if clusterTypeRaw != nil` check continues to work as before.

The CI change allows gosec cache/install and scan steps to run even when an earlier static analysis step fails, making security scan results available in the same PR check run.
