### PR TITLE
fix: include additional values during bootstrap

### DIFF
--- a/docs/content/1_getting_started/bootstrapping.md
+++ b/docs/content/1_getting_started/bootstrapping.md
@@ -195,7 +195,7 @@ Every generated app supports:
 * optional `additional-values.yaml` for overrides/extra values
 
 kubara's generated ApplicationSet already references both files and ignores missing files, so you can add `additional-values.yaml` only when needed.
-During direct bootstrap, kubara also loads chart-local `additional-values.yaml` files when they exist.
+During bootstrap kubara uses `additional-values.yaml` files when they exist as well.
 
 Merge behavior reminder:
 

--- a/docs/content/1_getting_started/bootstrapping.md
+++ b/docs/content/1_getting_started/bootstrapping.md
@@ -195,6 +195,7 @@ Every generated app supports:
 * optional `additional-values.yaml` for overrides/extra values
 
 kubara's generated ApplicationSet already references both files and ignores missing files, so you can add `additional-values.yaml` only when needed.
+During direct bootstrap, kubara also loads chart-local `additional-values.yaml` files when they exist.
 
 Merge behavior reminder:
 

--- a/src/internal/cmd/bootstrap/bootstrap.go
+++ b/src/internal/cmd/bootstrap/bootstrap.go
@@ -3,6 +3,7 @@ package bootstrap
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 	"time"
 
@@ -87,7 +88,7 @@ func Bootstrap(ctx context.Context, opts *Options) error {
 			Name:            "argocd",
 			Namespace:       argocdNamespace,
 			Path:            filepath.Join(opts.ManagedCatalog, "helm", argocdChartPath),
-			OverlayValues:   []string{filepath.Join(opts.OverlayValues, "helm", opts.ClusterName, argocdChartPath, "values.yaml")},
+			OverlayValues:   overlayValuesForChart(opts, argocdChartPath),
 			RepoURL:         "https://argoproj.github.io/argo-helm",
 			EnsureNamespace: true,
 			EnsureCRD:       true,
@@ -96,7 +97,7 @@ func Bootstrap(ctx context.Context, opts *Options) error {
 			Name:            "external-secrets",
 			Namespace:       externalSecretsNamespace,
 			Path:            filepath.Join(opts.ManagedCatalog, "helm", externalSecretsChartPath),
-			OverlayValues:   []string{filepath.Join(opts.OverlayValues, "helm", opts.ClusterName, externalSecretsChartPath, "values.yaml")},
+			OverlayValues:   overlayValuesForChart(opts, externalSecretsChartPath),
 			RepoURL:         "https://charts.external-secrets.io",
 			EnsureNamespace: opts.WithES,
 			EnsureCRD:       opts.WithES,
@@ -104,7 +105,7 @@ func Bootstrap(ctx context.Context, opts *Options) error {
 		{
 			Name:            "kube-prometheus-stack",
 			Path:            filepath.Join(opts.ManagedCatalog, "helm", prometheusChartPath),
-			OverlayValues:   []string{filepath.Join(opts.OverlayValues, "helm", opts.ClusterName, prometheusChartPath, "values.yaml")},
+			OverlayValues:   overlayValuesForChart(opts, prometheusChartPath),
 			RepoURL:         "https://prometheus-community.github.io/helm-charts",
 			EnsureNamespace: false,
 			EnsureCRD:       opts.WithProm,
@@ -173,6 +174,18 @@ func chartPathForService(cat catalog.Catalog, serviceName string) (string, error
 	}
 
 	return definition.Spec.ChartPath, nil
+}
+
+func overlayValuesForChart(opts *Options, chartPath string) []string {
+	chartOverlayPath := filepath.Join(opts.OverlayValues, "helm", opts.ClusterName, chartPath)
+	valuesPaths := []string{filepath.Join(chartOverlayPath, "values.yaml")}
+
+	additionalValuesPath := filepath.Join(chartOverlayPath, "additional-values.yaml")
+	if _, err := os.Stat(additionalValuesPath); err == nil {
+		valuesPaths = append(valuesPaths, additionalValuesPath)
+	}
+
+	return valuesPaths
 }
 
 // ensureNamespaces ensures required namespaces exist

--- a/src/internal/cmd/bootstrap/bootstrap_test.go
+++ b/src/internal/cmd/bootstrap/bootstrap_test.go
@@ -2,9 +2,12 @@ package bootstrap
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const completionMessageTemplate = `
@@ -41,4 +44,37 @@ func Test_MissingEnvVariableLeadsToURLBeingOmitted(t *testing.T) {
 	actual := CreateCompletionMessage(config)
 
 	assert.Equal(t, expected, actual)
+}
+
+func TestOverlayValuesForChartIncludesValuesYaml(t *testing.T) {
+	tempDir := t.TempDir()
+	opts := &Options{
+		OverlayValues: tempDir,
+		ClusterName:   "test-cluster",
+	}
+
+	valuesPaths := overlayValuesForChart(opts, "argo-cd")
+
+	assert.Equal(t, []string{
+		filepath.Join(tempDir, "helm", "test-cluster", "argo-cd", "values.yaml"),
+	}, valuesPaths)
+}
+
+func TestOverlayValuesForChartIncludesAdditionalValuesWhenPresent(t *testing.T) {
+	tempDir := t.TempDir()
+	chartDir := filepath.Join(tempDir, "helm", "test-cluster", "argo-cd")
+	require.NoError(t, os.MkdirAll(chartDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(chartDir, "additional-values.yaml"), []byte("argo-cd: {}\n"), 0o644))
+
+	opts := &Options{
+		OverlayValues: tempDir,
+		ClusterName:   "test-cluster",
+	}
+
+	valuesPaths := overlayValuesForChart(opts, "argo-cd")
+
+	assert.Equal(t, []string{
+		filepath.Join(chartDir, "values.yaml"),
+		filepath.Join(chartDir, "additional-values.yaml"),
+	}, valuesPaths)
 }


### PR DESCRIPTION
## 📝 Summary
<!-- Please read first: https://github.com/kubara-io/kubara/blob/main/CONTRIBUTING.md -->

Direct `kubara bootstrap` now loads chart-local `additional-values.yaml` files when they exist. This aligns the bootstrap path with the generated Argo CD ApplicationSets, which already reference both `values.yaml` and `additional-values.yaml`.

Previously, bootstrap only passed `values.yaml` to Helm. As a result, overrides in `customer-service-catalog/helm/<cluster>/argo-cd/additional-values.yaml` were ignored unless Argo CD managed itself.

## 🧩 Type of change
- [x] 🔧 CLI / Go code
- [ ] 📦 Helm chart
- [ ] 🧱 Terraform module
- [x] 📝 Documentation
- [x] 🧪 Test or CI change
- [ ] ♻️ Refactor / cleanup

## ⚠️ Is this a breaking change?
- [ ] Yes, this change breaks existing functionality (explain in summary)

## 🧪 Testing
- [ ] CI passed
- [ ] Manually tested (local/dev cluster)
- [x] Unit tested
- [ ] Not tested (explain why below)

Ran:

```bash
cd src && go test ./internal/cmd/bootstrap
make docs-build
```

## 🔗 Related Issues / Tickets
<!-- e.g. Closes #42, Related to #99 -->

Related to the generated values overwrite behavior tracked separately.

## ✅ Checklist
- [ ] Code compiles and passes all tests
- [ ] Linting and style checks pass
- [x] Comments added for complex logic
- [x] Documentation updated (if applicable)

## 📎 Additional Context (optional)
<!-- Add logs, screenshots, diagrams, or design notes. -->

This PR intentionally only addresses direct bootstrap. It does not change `kubara generate --helm` overwrite behavior for generated `values.yaml` files.
