### PR TITLE
feat!: catalog versioning, packaging and caching

### DIFF
--- a/docs/content/1_getting_started/commands.md
+++ b/docs/content/1_getting_started/commands.md
@@ -40,9 +40,9 @@ kubara [command]
 
 **--base64**: Enable base64 encode/decode mode
 
-**--catalog**="": Path to external ServiceDefinition catalog directory.
+**--catalog**="": Path to an external catalog directory or an OCI reference in the form oci://registry/repository:x.y.z
 
-**--catalog-overwrite**: Allow external service definitions from --catalog to overwrite built-in definitions on name collisions.
+**--catalog-overwrite**: Allow external service definitions from --catalog to overwrite built-in definitions on name collisions
 
 **--check-update**: Check online for a newer kubara release
 
@@ -95,7 +95,7 @@ Shows a list of commands or help for one command
 
 Generate files from catalog templates
 
->kubara generate [--terraform|--helm] [--managed-catalog PATH --overlay-values PATH] [--catalog PATH [--catalog-overwrite]] [--dry-run]
+>kubara generate [--terraform|--helm] [--managed-catalog PATH --overlay-values PATH] [--catalog PATH_OR_OCI [--catalog-overwrite]] [--dry-run]
 
 **--dry-run**: Preview generation without creating files
 
@@ -147,7 +147,7 @@ Shows a list of commands or help for one command
 
 Generate a JSON schema for the config yaml structure
 
->kubara schema [--output PATH] [--catalog PATH [--catalog-overwrite]]
+>kubara schema [--output PATH] [--catalog PATH_OR_OCI [--catalog-overwrite]]
 
 **--help, -h**: show help
 
@@ -182,6 +182,42 @@ Shows a list of commands or help for one command
 Add a service definition to the current catalog
 
 >kubara catalog add SERVICE_NAME
+
+**--help, -h**: show help
+
+#### help, h
+
+Shows a list of commands or help for one command
+
+### list, ls
+
+List cached local and OCI-backed catalogs
+
+>kubara catalog list
+
+**--help, -h**: show help
+
+#### help, h
+
+Shows a list of commands or help for one command
+
+### package, pkg
+
+Package the current catalog directory into the local OCI cache with an OCI reference base
+
+>kubara catalog package [oci://registry/path/]
+
+**--help, -h**: show help
+
+#### help, h
+
+Shows a list of commands or help for one command
+
+### unpackage, unpkg
+
+Materialize a cached OCI catalog as an editable directory
+
+>kubara catalog unpackage oci://registry/repository:x.y.z [directory]
 
 **--help, -h**: show help
 

--- a/src/cmd/bootstrap.go
+++ b/src/cmd/bootstrap.go
@@ -263,7 +263,7 @@ func Run(ctx context.Context, o *bootstrap.Options) error {
 }
 
 func prepareBootstrapEnv(cluster *config.Cluster, envMap *envconfig.EnvMap, local bool) (*envconfig.EnvMap, error) {
-	if err := envMap.ValidateAll(); err != nil {
+	if err := envMap.Validate(); err != nil {
 		return nil, err
 	}
 

--- a/src/cmd/catalog/add.go
+++ b/src/cmd/catalog/add.go
@@ -2,9 +2,10 @@ package catalog
 
 import (
 	"context"
-	"github.com/urfave/cli/v3"
 
 	internal "github.com/kubara-io/kubara/internal/cmd/catalog"
+
+	"github.com/urfave/cli/v3"
 )
 
 func NewCatalogService() *cli.Command {

--- a/src/cmd/catalog/catalog.go
+++ b/src/cmd/catalog/catalog.go
@@ -9,13 +9,15 @@ func NewCatalogCommand() *cli.Command {
 		Name:        "catalog",
 		Usage:       "Manage custom catalogs and service definitions",
 		UsageText:   "kubara catalog [command]",
-		Description: "Provides commands to scaffold custom catalogs and add service definition manifests within them.",
+		Description: "Provides commands to scaffold, package, pull, push, list, and unpackage catalogs as local directories or OCI artifacts.",
 		Commands: []*cli.Command{
 			NewCatalogCreate(),
 			NewCatalogService(),
-			//NewCatalogList(),
 			//NewCatalogPull(),
 			//NewCatalogPush(),
+			NewCatalogList(),
+			NewCatalogPackage(),
+			NewCatalogUnpackage(),
 		},
 	}
 

--- a/src/cmd/catalog/create.go
+++ b/src/cmd/catalog/create.go
@@ -2,9 +2,10 @@ package catalog
 
 import (
 	"context"
-	"github.com/urfave/cli/v3"
 
 	internal "github.com/kubara-io/kubara/internal/cmd/catalog"
+
+	"github.com/urfave/cli/v3"
 )
 
 func NewCatalogCreate() *cli.Command {

--- a/src/cmd/catalog/helpers.go
+++ b/src/cmd/catalog/helpers.go
@@ -1,0 +1,16 @@
+package catalog
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/urfave/cli/v3"
+)
+
+func resolveCatalogCommandWorkingDir(cmd *cli.Command) (string, error) {
+	cwd, err := filepath.Abs(cmd.String("work-dir"))
+	if err != nil {
+		return "", fmt.Errorf("get working directory: %w", err)
+	}
+	return cwd, nil
+}

--- a/src/cmd/catalog/list.go
+++ b/src/cmd/catalog/list.go
@@ -1,0 +1,47 @@
+package catalog
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	internal "github.com/kubara-io/kubara/internal/catalog"
+	"github.com/rs/zerolog/log"
+
+	"github.com/urfave/cli/v3"
+)
+
+func NewCatalogList() *cli.Command {
+	return &cli.Command{
+		Name:        "list",
+		Aliases:     []string{"ls"},
+		Usage:       "List cached local and OCI-backed catalogs",
+		UsageText:   "kubara catalog list",
+		Description: "Lists cached catalogs from the local OCI cache, including local packages and cached OCI references.",
+		Action: func(ctx context.Context, cmd *cli.Command) error {
+			entries, err := internal.ListCachedCatalogs()
+			if err != nil {
+				return err
+			}
+			if len(entries) == 0 {
+				log.Info().Msg("No cached catalogs found")
+				return nil
+			}
+
+			writer := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+			_, _ = fmt.Fprintln(writer, "NAME\tVERSION\tREFERENCE\tDIGEST")
+			for _, entry := range entries {
+				_, _ = fmt.Fprintf(
+					writer,
+					"%s\t%s\t%s\t%s\n",
+					entry.CatalogName,
+					entry.CatalogVersion,
+					entry.Reference,
+					entry.ManifestDigest,
+				)
+			}
+			return writer.Flush()
+		},
+	}
+}

--- a/src/cmd/catalog/package.go
+++ b/src/cmd/catalog/package.go
@@ -1,0 +1,45 @@
+package catalog
+
+import (
+	"context"
+
+	internal "github.com/kubara-io/kubara/internal/catalog"
+	"github.com/rs/zerolog/log"
+
+	"github.com/urfave/cli/v3"
+)
+
+func NewCatalogPackage() *cli.Command {
+	return &cli.Command{
+		Name:        "package",
+		Aliases:     []string{"pkg"},
+		Usage:       "Package the current catalog directory into the local OCI cache with an OCI reference base",
+		UsageText:   "kubara catalog package [oci://registry/path/]",
+		Description: "Packages the current catalog directory into the local OCI cache using the catalog version from Catalog.yaml and derives the final OCI reference from the optional base. If omitted, kubara uses oci://localhost/.",
+		Action: func(ctx context.Context, cmd *cli.Command) error {
+			if cmd.Args().Len() > 1 {
+				cli.ShowSubcommandHelpAndExit(cmd, 1)
+			}
+			cwd, err := resolveCatalogCommandWorkingDir(cmd)
+			if err != nil {
+				return err
+			}
+			result, err := internal.PackageCatalog(internal.PackageOptions{
+				CatalogRoot:   cwd,
+				ReferenceBase: cmd.Args().First(),
+			})
+			if err != nil {
+				return err
+			}
+
+			log.Info().Msgf(
+				"Catalog %q version %q has been packaged in the local OCI cache as %s with digest %s",
+				result.Manifest.Metadata.Name,
+				result.Manifest.Spec.Version,
+				result.Reference,
+				result.Artifact.ManifestDigest,
+			)
+			return nil
+		},
+	}
+}

--- a/src/cmd/catalog/unpackage.go
+++ b/src/cmd/catalog/unpackage.go
@@ -1,0 +1,57 @@
+package catalog
+
+import (
+	"context"
+	"fmt"
+
+	internal "github.com/kubara-io/kubara/internal/catalog"
+	"github.com/kubara-io/kubara/internal/utils"
+	"github.com/rs/zerolog/log"
+
+	"github.com/urfave/cli/v3"
+)
+
+func NewCatalogUnpackage() *cli.Command {
+	return &cli.Command{
+		Name:        "unpackage",
+		Aliases:     []string{"unpkg"},
+		Usage:       "Materialize a cached OCI catalog as an editable directory",
+		UsageText:   "kubara catalog unpackage oci://registry/repository:x.y.z [directory]",
+		Description: "Copies a cached OCI catalog into an editable directory.",
+		Action: func(ctx context.Context, cmd *cli.Command) error {
+			if cmd.Args().Len() < 1 || cmd.Args().Len() > 2 {
+				cli.ShowSubcommandHelpAndExit(cmd, 1)
+			}
+
+			cwd, err := resolveCatalogCommandWorkingDir(cmd)
+			if err != nil {
+				return err
+			}
+
+			outputPath := ""
+			if cmd.Args().Len() == 2 {
+				outputPath, err = utils.GetFullPath(cmd.Args().Get(1), cwd)
+				if err != nil {
+					return fmt.Errorf("get output directory: %w", err)
+				}
+			}
+
+			result, err := internal.UnpackageCatalog(internal.UnpackageOptions{
+				Reference:  cmd.Args().First(),
+				OutputPath: outputPath,
+				WorkDir:    cwd,
+			})
+			if err != nil {
+				return err
+			}
+
+			log.Info().Msgf(
+				"Catalog %q version %q has been unpackaged to %s",
+				result.Artifact.CatalogName,
+				result.Artifact.CatalogVersion,
+				result.OutputPath,
+			)
+			return nil
+		},
+	}
+}

--- a/src/cmd/flags.go
+++ b/src/cmd/flags.go
@@ -111,13 +111,13 @@ func (flags *GlobalFlags) CLIFlags() []cli.Flag {
 		&cli.StringFlag{
 			Name:        "catalog",
 			Value:       flags.CatalogPath,
-			Usage:       "Path to external ServiceDefinition catalog directory.",
+			Usage:       "Path to an external catalog directory or an OCI reference in the form oci://registry/repository:x.y.z",
 			Destination: &flags.CatalogPath,
 		},
 		&cli.BoolFlag{
 			Name:        "catalog-overwrite",
 			Value:       flags.CatalogOverwrite,
-			Usage:       "Allow external service definitions from --catalog to overwrite built-in definitions on name collisions.",
+			Usage:       "Allow external service definitions from --catalog to overwrite built-in definitions on name collisions",
 			Destination: &flags.CatalogOverwrite,
 		},
 		&cli.BoolFlag{
@@ -179,9 +179,17 @@ func catalogLoadOptionsFromCommand(cmd *cli.Command) (catalog.LoadOptions, error
 	}
 
 	rawCatalogPath := strings.TrimSpace(cmd.String("catalog"))
+
 	if rawCatalogPath == "" {
 		return catalog.LoadOptions{
 			CatalogPath: "",
+			Overwrite:   cmd.Bool("catalog-overwrite"),
+		}, nil
+	}
+
+	if catalog.IsOCIReference(rawCatalogPath) {
+		return catalog.LoadOptions{
+			CatalogPath: rawCatalogPath,
 			Overwrite:   cmd.Bool("catalog-overwrite"),
 		}, nil
 	}
@@ -190,7 +198,6 @@ func catalogLoadOptionsFromCommand(cmd *cli.Command) (catalog.LoadOptions, error
 	if err != nil {
 		return catalog.LoadOptions{}, fmt.Errorf("get catalog path: %w", err)
 	}
-
 	return catalog.LoadOptions{
 		CatalogPath: absoluteCatalogPath,
 		Overwrite:   cmd.Bool("catalog-overwrite"),

--- a/src/cmd/generate.go
+++ b/src/cmd/generate.go
@@ -38,7 +38,7 @@ func NewGenerateCmd() *cli.Command {
 	cmd := &cli.Command{
 		Name:        "generate",
 		Usage:       "Generate files from catalog templates",
-		UsageText:   "kubara generate [--terraform|--helm] [--managed-catalog PATH --overlay-values PATH] [--catalog PATH [--catalog-overwrite]] [--dry-run]",
+		UsageText:   "kubara generate [--terraform|--helm] [--managed-catalog PATH --overlay-values PATH] [--catalog PATH_OR_OCI [--catalog-overwrite]] [--dry-run]",
 		Description: "Renders embedded Helm and Terraform templates using values from the config file. By default, it generates both template types.",
 		Action: func(c context.Context, cmd *cli.Command) error {
 			o, err := flags.ToOptions(cmd)

--- a/src/cmd/generate_test.go
+++ b/src/cmd/generate_test.go
@@ -59,7 +59,7 @@ func TestNewGenerateCmd(t *testing.T) {
 
 	assert.Equal(t, "generate", command.Name)
 	assert.Equal(t, "Generate files from catalog templates", command.Usage)
-	assert.Equal(t, "kubara generate [--terraform|--helm] [--managed-catalog PATH --overlay-values PATH] [--catalog PATH [--catalog-overwrite]] [--dry-run]", command.UsageText)
+	assert.Equal(t, "kubara generate [--terraform|--helm] [--managed-catalog PATH --overlay-values PATH] [--catalog PATH_OR_OCI [--catalog-overwrite]] [--dry-run]", command.UsageText)
 	assert.Equal(t, "Renders embedded Helm and Terraform templates using values from the config file. By default, it generates both template types.", command.Description)
 
 	// Check that flags are added

--- a/src/cmd/schema.go
+++ b/src/cmd/schema.go
@@ -35,7 +35,7 @@ func NewSchemaCmd() *cli.Command {
 	cmd := &cli.Command{
 		Name:        "schema",
 		Usage:       "Generate a JSON schema for the config yaml structure",
-		UsageText:   "kubara schema [--output PATH] [--catalog PATH [--catalog-overwrite]]",
+		UsageText:   "kubara schema [--output PATH] [--catalog PATH_OR_OCI [--catalog-overwrite]]",
 		Description: "Generates a JSON schema for the config yaml structure and catalog definitions to use for validation and editor autocompletion",
 		Action: func(c context.Context, cmd *cli.Command) error {
 			o, err := flags.ToOptions(cmd)

--- a/src/cmd/schema_test.go
+++ b/src/cmd/schema_test.go
@@ -26,7 +26,7 @@ func TestNewSchemaCmd(t *testing.T) {
 
 	assert.Equal(t, "schema", command.Name)
 	assert.Equal(t, "Generate a JSON schema for the config yaml structure", command.Usage)
-	assert.Equal(t, "kubara schema [--output PATH] [--catalog PATH [--catalog-overwrite]]", command.UsageText)
+	assert.Equal(t, "kubara schema [--output PATH] [--catalog PATH_OR_OCI [--catalog-overwrite]]", command.UsageText)
 	assert.Equal(t, "Generates a JSON schema for the config yaml structure and catalog definitions to use for validation and editor autocompletion", command.Description)
 
 	require.Len(t, command.Flags, 1)

--- a/src/go.mod
+++ b/src/go.mod
@@ -14,6 +14,8 @@ require (
 	github.com/knadh/koanf/providers/env/v2 v2.0.0
 	github.com/knadh/koanf/providers/file v1.2.1
 	github.com/knadh/koanf/v2 v2.3.5
+	github.com/opencontainers/go-digest v1.0.0
+	github.com/opencontainers/image-spec v1.1.1
 	github.com/rs/zerolog v1.35.1
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	github.com/stretchr/testify v1.11.1
@@ -25,6 +27,7 @@ require (
 	k8s.io/apiextensions-apiserver v0.36.2
 	k8s.io/apimachinery v0.36.2
 	k8s.io/client-go v0.36.2
+	oras.land/oras-go/v2 v2.6.0
 	sigs.k8s.io/yaml v1.6.0
 )
 

--- a/src/go.sum
+++ b/src/go.sum
@@ -175,6 +175,10 @@ github.com/onsi/ginkgo/v2 v2.28.0 h1:Rrf+lVLmtlBIKv6KrIGJCjyY8N36vDVcutbGJkyqjJc
 github.com/onsi/ginkgo/v2 v2.28.0/go.mod h1:ArE1D/XhNXBXCBkKOLkbsb2c81dQHCRcF5zwn/ykDRo=
 github.com/onsi/gomega v1.39.1 h1:1IJLAad4zjPn2PsnhH70V4DKRFlrCzGBNrNaru+Vf28=
 github.com/onsi/gomega v1.39.1/go.mod h1:hL6yVALoTOxeWudERyfppUcZXjMwIMLnuSfruD2lcfg=
+github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
+github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
+github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=
+github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
 github.com/pb33f/ordered-map/v2 v2.3.1 h1:5319HDO0aw4DA4gzi+zv4FXU9UlSs3xGZ40wcP1nBjY=
 github.com/pb33f/ordered-map/v2 v2.3.1/go.mod h1:qxFQgd0PkVUtOMCkTapqotNgzRhMPL7VvaHKbd1HnmQ=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
@@ -327,6 +331,8 @@ k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a h1:xCeOEAOoGYl2jnJoHkC3hk
 k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a/go.mod h1:uGBT7iTA6c6MvqUvSXIaYZo9ukscABYi2btjhvgKGZ0=
 k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2 h1:AZYQSJemyQB5eRxqcPky+/7EdBj0xi3g0ZcxxJ7vbWU=
 k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2/go.mod h1:xDxuJ0whA3d0I4mf/C4ppKHxXynQ+fxnkmQH0vTHnuk=
+oras.land/oras-go/v2 v2.6.0 h1:X4ELRsiGkrbeox69+9tzTu492FMUu7zJQW6eJU+I2oc=
+oras.land/oras-go/v2 v2.6.0/go.mod h1:magiQDfG6H1O9APp+rOsvCPcW1GD2MM7vgnKY0Y+u1o=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.34.0 h1:hSfpvjjTQXQY2Fol2CS0QHMNs/WI1MOSGzCm1KhM5ec=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.34.0/go.mod h1:Ve9uj1L+deCXFrPOk1LpFXqTg7LCFzFso6PA48q/XZw=
 sigs.k8s.io/controller-runtime v0.24.1 h1:miPEwrmirImAvgME1L9qebGHrOnGJoVmVdtOU9fRfo4=

--- a/src/internal/catalog/cache.go
+++ b/src/internal/catalog/cache.go
@@ -180,7 +180,9 @@ func copyFile(sourcePath, targetPath string, mode fs.FileMode) error {
 	if err != nil {
 		return fmt.Errorf("open cached catalog file %q: %w", sourcePath, err)
 	}
-	defer sourceFile.Close()
+	defer func() {
+		_ = sourceFile.Close()
+	}()
 
 	targetFile, err := os.OpenFile(targetPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, mode)
 	if err != nil {

--- a/src/internal/catalog/cache.go
+++ b/src/internal/catalog/cache.go
@@ -1,0 +1,220 @@
+package catalog
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/kubara-io/kubara/internal/utils"
+)
+
+type CachedCatalogEntry struct {
+	Reference      string
+	CatalogName    string
+	CatalogVersion string
+	ManifestDigest string
+}
+
+type UnpackageResult struct {
+	Artifact   CachedArtifact
+	OutputPath string
+}
+
+func ListCachedCatalogs() ([]CachedCatalogEntry, error) {
+	cacheRoot, err := defaultCatalogCacheRoot()
+	if err != nil {
+		return nil, err
+	}
+
+	entries := make(map[string]CachedCatalogEntry)
+	referencedDigests := make(map[string]struct{})
+
+	if err := collectReferenceEntries(filepath.Join(cacheRoot, "refs"), entries, referencedDigests); err != nil {
+		return nil, err
+	}
+
+	result := make([]CachedCatalogEntry, 0, len(entries))
+	for _, entry := range entries {
+		result = append(result, entry)
+	}
+
+	// Sort by name, then version and then source reference
+	slices.SortFunc(result, func(a, b CachedCatalogEntry) int {
+		if cmp := strings.Compare(a.CatalogName, b.CatalogName); cmp != 0 {
+			return cmp
+		}
+		if cmp := strings.Compare(a.CatalogVersion, b.CatalogVersion); cmp != 0 {
+			return cmp
+		}
+		return strings.Compare(a.Reference, b.Reference)
+	})
+
+	return result, nil
+}
+
+func UnpackageCatalog(options UnpackageOptions) (UnpackageResult, error) {
+	artifact, err := GetCachedArtifact(options.Reference)
+	if err != nil {
+		return UnpackageResult{}, err
+	}
+
+	outputPath := strings.TrimSpace(options.OutputPath)
+	if outputPath == "" {
+		outputPath, err = utils.GetFullPath(artifact.CatalogName, options.WorkDir)
+		if err != nil {
+			return UnpackageResult{}, fmt.Errorf("resolve default unpack directory: %w", err)
+		}
+	}
+
+	if _, err := os.Stat(outputPath); err == nil {
+		return UnpackageResult{}, fmt.Errorf("catalog output directory %q already exists", outputPath)
+	} else if !os.IsNotExist(err) {
+		return UnpackageResult{}, fmt.Errorf("stat catalog output directory %q: %w", outputPath, err)
+	}
+
+	if err := copyDirectory(artifactRootPath(artifact), outputPath); err != nil {
+		return UnpackageResult{}, err
+	}
+
+	return UnpackageResult{
+		Artifact:   artifact,
+		OutputPath: outputPath,
+	}, nil
+}
+
+func collectReferenceEntries(root string, entries map[string]CachedCatalogEntry, referencedDigests map[string]struct{}) error {
+	return filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil
+			}
+			return fmt.Errorf("walk cached catalog references: %w", err)
+		}
+		if d.IsDir() || filepath.Ext(path) != ".json" {
+			return nil
+		}
+
+		ref, err := readCachedReference(path)
+		if err != nil {
+			return err
+		}
+
+		entry := CachedCatalogEntry{
+			Reference:      firstNonEmpty(ref.Reference, remoteReferenceFromCachedReference(ref), defaultLocalCatalogReference(ref.CatalogName, ref.CatalogVersion), fmt.Sprintf("%s:%s", ref.CatalogName, ref.CatalogVersion)),
+			CatalogName:    ref.CatalogName,
+			CatalogVersion: ref.CatalogVersion,
+			ManifestDigest: ref.ManifestDigest,
+		}
+		entries[entry.Reference] = entry
+		referencedDigests[entry.ManifestDigest] = struct{}{}
+		return nil
+	})
+}
+
+func readCachedReference(path string) (cachedReference, error) {
+	var ref cachedReference
+	if err := readJSONFile(path, "cached catalog reference", &ref); err != nil {
+		return cachedReference{}, err
+	}
+	return ref, nil
+}
+
+func readCachedReferenceFile(path string) (cachedReference, bool, error) {
+	ref, err := readCachedReference(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return cachedReference{}, false, nil
+		}
+		return cachedReference{}, false, err
+	}
+	return ref, true, nil
+}
+
+func remoteReferenceFromCachedReference(ref cachedReference) string {
+	if ref.Registry == "" || ref.Repository == "" || ref.Tag == "" {
+		return ref.ManifestDigest
+	}
+	return fmt.Sprintf("oci://%s/%s:%s", ref.Registry, ref.Repository, ref.Tag)
+}
+
+func copyDirectory(sourceRoot, targetRoot string) error {
+	return filepath.WalkDir(sourceRoot, func(sourcePath string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return fmt.Errorf("walk cached catalog contents %q: %w", sourcePath, err)
+		}
+
+		relativePath, err := filepath.Rel(sourceRoot, sourcePath)
+		if err != nil {
+			return fmt.Errorf("build relative path for %q: %w", sourcePath, err)
+		}
+		targetPath := filepath.Join(targetRoot, relativePath)
+
+		info, err := entry.Info()
+		if err != nil {
+			return fmt.Errorf("read file info for %q: %w", sourcePath, err)
+		}
+
+		switch {
+		case entry.IsDir():
+			if err := os.MkdirAll(targetPath, info.Mode().Perm()); err != nil {
+				return fmt.Errorf("create catalog output directory %q: %w", targetPath, err)
+			}
+			return nil
+		case info.Mode()&os.ModeSymlink != 0:
+			return fmt.Errorf("cached catalog contains unsupported symlink %q", sourcePath)
+		case !info.Mode().IsRegular():
+			return fmt.Errorf("cached catalog contains unsupported file type %q", sourcePath)
+		default:
+			return copyFile(sourcePath, targetPath, info.Mode().Perm())
+		}
+	})
+}
+
+func copyFile(sourcePath, targetPath string, mode fs.FileMode) error {
+	sourceFile, err := os.Open(sourcePath)
+	if err != nil {
+		return fmt.Errorf("open cached catalog file %q: %w", sourcePath, err)
+	}
+	defer sourceFile.Close()
+
+	targetFile, err := os.OpenFile(targetPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, mode)
+	if err != nil {
+		return fmt.Errorf("create catalog output file %q: %w", targetPath, err)
+	}
+
+	if _, err := io.Copy(targetFile, sourceFile); err != nil {
+		if closeErr := targetFile.Close(); closeErr != nil {
+			return errors.Join(
+				fmt.Errorf("copy catalog file %q: %w", targetPath, err),
+				fmt.Errorf("close catalog output file %q after copy failure: %w", targetPath, closeErr),
+			)
+		}
+		return fmt.Errorf("copy catalog file %q: %w", targetPath, err)
+	}
+	if err := targetFile.Close(); err != nil {
+		return fmt.Errorf("close catalog output file %q: %w", targetPath, err)
+	}
+	return nil
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func defaultLocalCatalogReference(catalogName, version string) string {
+	ref, err := BuildCatalogReference(catalogName, version, "")
+	if err != nil {
+		return ""
+	}
+	return ref.Raw
+}

--- a/src/internal/catalog/cache_store.go
+++ b/src/internal/catalog/cache_store.go
@@ -81,13 +81,34 @@ func readJSONFile(path, label string, target any) error {
 	return nil
 }
 
+// writeJSONFile atomically writes files. Meaning if a file already exists
+// it guarantees that no partial overwrite can happen by first writting to
+// a temporary file and then overwriting the original by renaming
 func writeJSONFile(path, label string, value any) error {
 	raw, err := json.MarshalIndent(value, "", "  ")
 	if err != nil {
 		return fmt.Errorf("marshal %s: %w", label, err)
 	}
-	if err := os.WriteFile(path, raw, 0o600); err != nil {
-		return fmt.Errorf("write %s: %w", label, err)
+	dir := filepath.Dir(path)
+	f, err := os.CreateTemp(dir, ".tmp-*")
+	if err != nil {
+		return fmt.Errorf("create temp %s: %w", label, err)
+	}
+	tmp := f.Name()
+	defer func() { _ = os.Remove(tmp) }()
+
+	if _, err := f.Write(raw); err != nil {
+		_ = f.Close()
+		return fmt.Errorf("write temp %s: %w", label, err)
+	}
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("close temp %s: %w", label, err)
+	}
+	if err := os.Chmod(tmp, 0o600); err != nil {
+		return fmt.Errorf("chmod temp %s: %w", label, err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		return fmt.Errorf("replace %s: %w", label, err)
 	}
 	return nil
 }

--- a/src/internal/catalog/cache_store.go
+++ b/src/internal/catalog/cache_store.go
@@ -1,0 +1,232 @@
+package catalog
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/opencontainers/go-digest"
+)
+
+type UnpackageOptions struct {
+	Reference  string
+	OutputPath string
+	WorkDir    string
+}
+
+func defaultCatalogCacheRoot() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve user home directory: %w", err)
+	}
+	return filepath.Join(home, defaultCatalogCacheRel), nil
+}
+
+func newTempArtifactDir() (string, func(), error) {
+	cacheRoot, err := defaultCatalogCacheRoot()
+	if err != nil {
+		return "", nil, err
+	}
+	tempRoot := filepath.Join(cacheRoot, ".tmp")
+	if err := os.MkdirAll(tempRoot, 0o755); err != nil {
+		return "", nil, fmt.Errorf("create temporary catalog cache directory: %w", err)
+	}
+	tempArtifactDir, err := os.MkdirTemp(tempRoot, "artifact-*")
+	if err != nil {
+		return "", nil, fmt.Errorf("create temporary artifact directory: %w", err)
+	}
+	return tempArtifactDir, func() { _ = os.RemoveAll(tempArtifactDir) }, nil
+}
+
+func finalizeCachedArtifact(tempArtifactDir string, artifact CachedArtifact) error {
+	finalDir, err := artifactDirPath(artifact.ManifestDigest)
+	if err != nil {
+		return err
+	}
+
+	if err := writeArtifactMetadata(filepath.Join(tempArtifactDir, "metadata.json"), artifact); err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(filepath.Dir(finalDir), 0o755); err != nil {
+		return fmt.Errorf("create catalog artifact cache directory: %w", err)
+	}
+	if _, err := os.Stat(finalDir); err == nil {
+		return nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("stat catalog artifact cache directory %q: %w", finalDir, err)
+	}
+
+	if err := os.Rename(tempArtifactDir, finalDir); err != nil {
+		if _, statErr := os.Stat(finalDir); statErr == nil {
+			return nil
+		}
+		return fmt.Errorf("move catalog artifact into cache: %w", err)
+	}
+	return nil
+}
+
+func readJSONFile(path, label string, target any) error {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("read %s %q: %w", label, path, err)
+	}
+	if err := json.Unmarshal(content, target); err != nil {
+		return fmt.Errorf("unmarshal %s %q: %w", label, path, err)
+	}
+	return nil
+}
+
+func writeJSONFile(path, label string, value any) error {
+	raw, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal %s: %w", label, err)
+	}
+	if err := os.WriteFile(path, raw, 0o600); err != nil {
+		return fmt.Errorf("write %s: %w", label, err)
+	}
+	return nil
+}
+
+func writeArtifactMetadata(path string, artifact CachedArtifact) error {
+	return writeJSONFile(path, "cached artifact metadata", artifact)
+}
+
+func artifactDirPath(manifestDigest string) (string, error) {
+	cacheRoot, err := defaultCatalogCacheRoot()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(cacheRoot, "artifacts", digestPathComponent(manifestDigest)), nil
+}
+
+func artifactRootPath(artifact CachedArtifact) string {
+	dir, _ := artifactDirPath(artifact.ManifestDigest)
+	return filepath.Join(dir, "contents", artifact.RootDirectory)
+}
+
+func findArtifactByDigest(dgst digest.Digest) (CachedArtifact, bool, error) {
+	path, err := artifactDirPath(dgst.String())
+	if err != nil {
+		return CachedArtifact{}, false, err
+	}
+	artifact, found, err := readArtifactMetadata(path)
+	if err != nil {
+		return CachedArtifact{}, false, err
+	}
+	return artifact, found, nil
+}
+
+func findTagArtifact(ref OCIReference) (CachedArtifact, bool, error) {
+	refPath, err := tagReferencePath(ref)
+	if err != nil {
+		return CachedArtifact{}, false, err
+	}
+	cachedRef, found, err := readCachedReferenceFile(refPath)
+	if err != nil || !found {
+		return CachedArtifact{}, false, err
+	}
+
+	artifact, found, err := findArtifactByDigest(digest.Digest(cachedRef.ManifestDigest))
+	if err != nil || !found {
+		return CachedArtifact{}, false, err
+	}
+	return artifact, true, nil
+}
+
+func readArtifactMetadata(artifactDir string) (CachedArtifact, bool, error) {
+	path := filepath.Join(artifactDir, "metadata.json")
+	var artifact CachedArtifact
+	if err := readJSONFile(path, "cached artifact metadata", &artifact); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return CachedArtifact{}, false, nil
+		}
+		return CachedArtifact{}, false, err
+	}
+	if strings.TrimSpace(artifact.SchemaVersion) == "" {
+		return CachedArtifact{}, false, fmt.Errorf("cached artifact metadata %q is missing schemaVersion", path)
+	}
+	if strings.TrimSpace(artifact.CatalogName) == "" {
+		return CachedArtifact{}, false, fmt.Errorf("cached artifact metadata %q is missing catalogName", path)
+	}
+	if strings.TrimSpace(artifact.CatalogVersion) == "" {
+		return CachedArtifact{}, false, fmt.Errorf("cached artifact metadata %q is missing catalogVersion", path)
+	}
+	if strings.TrimSpace(artifact.ManifestDigest) == "" {
+		return CachedArtifact{}, false, fmt.Errorf("cached artifact metadata %q is missing manifestDigest", path)
+	}
+	if strings.TrimSpace(artifact.RootDirectory) == "" {
+		return CachedArtifact{}, false, fmt.Errorf("cached artifact metadata %q is missing rootDirectory", path)
+	}
+	if _, err := os.Stat(filepath.Join(artifactDir, "layout", "index.json")); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return CachedArtifact{}, false, nil
+		}
+		return CachedArtifact{}, false, fmt.Errorf("stat cached OCI layout for %q: %w", artifactDir, err)
+	}
+	if _, err := os.Stat(filepath.Join(artifactDir, "contents", artifact.RootDirectory, "Catalog.yaml")); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return CachedArtifact{}, false, nil
+		}
+		return CachedArtifact{}, false, fmt.Errorf("stat cached catalog contents for %q: %w", artifactDir, err)
+	}
+
+	return artifact, true, nil
+}
+
+func writeLocalReference(ref OCIReference, artifact CachedArtifact) error {
+	refPath, err := tagReferencePath(ref)
+	if err != nil {
+		return err
+	}
+	return writeReferenceFile(refPath, cachedReference{
+		SchemaVersion:  cacheSchemaVersion,
+		ManifestDigest: artifact.ManifestDigest,
+		CatalogName:    artifact.CatalogName,
+		CatalogVersion: artifact.CatalogVersion,
+		Reference:      ref.Raw,
+		Registry:       ref.Registry,
+		Repository:     ref.Repository,
+		Tag:            ref.Tag,
+		UpdatedAt:      time.Now().UTC().Format(time.RFC3339),
+	})
+}
+
+func writeReferenceFile(path string, ref cachedReference) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create cached catalog reference directory: %w", err)
+	}
+	return writeJSONFile(path, "cached catalog reference", ref)
+}
+
+func tagReferencePath(ref OCIReference) (string, error) {
+	cacheRoot, err := defaultCatalogCacheRoot()
+	if err != nil {
+		return "", err
+	}
+
+	repositoryParts := strings.Split(ref.Repository, "/")
+	pathParts := []string{cacheRoot, "refs", sanitizePathComponent(ref.Registry)}
+	for _, part := range repositoryParts {
+		pathParts = append(pathParts, sanitizePathComponent(part))
+	}
+	pathParts = append(pathParts, "tags", ref.Tag+".json")
+	return filepath.Join(pathParts...), nil
+}
+
+func sanitizePathComponent(value string) string {
+	replacer := strings.NewReplacer(":", "_", "@", "_", "\\", "_")
+	return replacer.Replace(value)
+}
+
+func digestPathComponent(manifestDigest string) string {
+	return strings.ReplaceAll(manifestDigest, ":", "-")
+}
+
+func isLocalhostReference(ref OCIReference) bool {
+	return ref.Registry == "localhost"
+}

--- a/src/internal/catalog/loader.go
+++ b/src/internal/catalog/loader.go
@@ -1,19 +1,16 @@
 package catalog
 
 import (
-	"errors"
 	"fmt"
 	"io/fs"
 	"os"
-	"path/filepath"
 	"sort"
 	"strings"
 
 	"sigs.k8s.io/yaml"
 )
 
-const servicesDirectory = "services"
-const builtInServicesDirectory = builtInRootDirectory + "/" + servicesDirectory
+const builtInServicesDirectory = builtInRootDirectory + "/" + string(ServicesDirectory)
 
 type LoadOptions struct {
 	CatalogPath string
@@ -34,14 +31,14 @@ func Load(options LoadOptions) (Catalog, error) {
 		return builtIn, nil
 	}
 
-	externalRoot, err := resolveServicesPath(options.CatalogPath)
+	source, err := ResolveSource(options.CatalogPath)
 	if err != nil {
-		return Catalog{}, fmt.Errorf("resolve catalog services path: %w", err)
+		return Catalog{}, fmt.Errorf("resolve catalog source: %w", err)
 	}
 
-	external, err := loadFromFS(os.DirFS(externalRoot), ".")
+	external, err := loadFromFS(os.DirFS(source.ServicesPath), ".")
 	if err != nil {
-		return Catalog{}, fmt.Errorf("load external catalog from %q: %w", externalRoot, err)
+		return Catalog{}, fmt.Errorf("load external catalog from %q: %w", source.ServicesPath, err)
 	}
 
 	merged := builtIn.Clone()
@@ -53,30 +50,6 @@ func Load(options LoadOptions) (Catalog, error) {
 	}
 
 	return merged, nil
-}
-
-func resolveServicesPath(catalogPath string) (string, error) {
-	cleaned := filepath.Clean(catalogPath)
-
-	rootInfo, err := os.Stat(cleaned)
-	if err != nil {
-		return "", fmt.Errorf("catalog directory %q does not exist: %w", cleaned, err)
-	}
-	if !rootInfo.IsDir() {
-		return "", fmt.Errorf("catalog path %q is not a directory", cleaned)
-	}
-
-	servicesDir := filepath.Join(cleaned, servicesDirectory)
-	if servicesInfo, err := os.Stat(servicesDir); err == nil {
-		if !servicesInfo.IsDir() {
-			return "", fmt.Errorf("catalog services path %q is not a directory", servicesDir)
-		}
-		return servicesDir, nil
-	}
-	if errors.Is(err, os.ErrNotExist) {
-		return cleaned, nil
-	}
-	return "", fmt.Errorf("stat catalog services path %q: %w", servicesDir, err)
 }
 
 func loadFromFS(fsys fs.FS, root string) (Catalog, error) {

--- a/src/internal/catalog/loader_test.go
+++ b/src/internal/catalog/loader_test.go
@@ -18,65 +18,40 @@ func TestLoadBuiltIn(t *testing.T) {
 	assert.Contains(t, cat.Services, "argocd")
 }
 
-func TestLoad_ExternalCollisionWithoutOverwrite(t *testing.T) {
+func TestLoad_ExternalCatalogOverwriteBehavior(t *testing.T) {
 	tempDir := t.TempDir()
-	servicesDir := filepath.Join(tempDir, "services")
-	require.NoError(t, os.MkdirAll(servicesDir, 0750))
-	require.NoError(t, os.WriteFile(filepath.Join(servicesDir, "argo-cd.yaml"), []byte(`
-apiVersion: kubara.io/v1alpha1
-kind: ServiceDefinition
-metadata:
-  name: argocd
-spec:
-  chartPath: argo-cd
-  status: enabled
-`), 0644))
+	writeLoaderServiceFixture(t, tempDir, "argocd", "custom-argo-cd")
 
 	_, err := Load(LoadOptions{CatalogPath: tempDir})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "already exists")
-}
-
-func TestLoad_ExternalCollisionWithOverwrite(t *testing.T) {
-	tempDir := t.TempDir()
-	servicesDir := filepath.Join(tempDir, "services")
-	require.NoError(t, os.MkdirAll(servicesDir, 0750))
-	require.NoError(t, os.WriteFile(filepath.Join(servicesDir, "argo-cd.yaml"), []byte(`
-apiVersion: kubara.io/v1alpha1
-kind: ServiceDefinition
-metadata:
-  name: argocd
-spec:
-  chartPath: custom-argo-cd
-  status: enabled
-`), 0644))
 
 	cat, err := Load(LoadOptions{CatalogPath: tempDir, Overwrite: true})
 	require.NoError(t, err)
 	assert.Equal(t, "custom-argo-cd", cat.Services["argocd"].Spec.ChartPath)
 }
 
-func TestLoad_InvalidAPIVersion(t *testing.T) {
+func TestLoad_MissingServicesDirectory(t *testing.T) {
 	tempDir := t.TempDir()
-	servicesDir := filepath.Join(tempDir, "services")
-	require.NoError(t, os.MkdirAll(servicesDir, 0750))
-	require.NoError(t, os.WriteFile(filepath.Join(servicesDir, "custom-service.yaml"), []byte(`
-apiVersion: kubara.io/v2
-kind: ServiceDefinition
-metadata:
-  name: custom-service
-spec:
-  chartPath: custom-service
-  status: enabled
-`), 0644))
 
 	_, err := Load(LoadOptions{CatalogPath: tempDir})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), `apiVersion must be "kubara.io/v1alpha1"`)
+	assert.Contains(t, err.Error(), `catalog services path`)
+	assert.Contains(t, err.Error(), `does not exist`)
 }
 
-func TestCanonicalServiceName(t *testing.T) {
-	assert.Equal(t, "cert-manager", CanonicalServiceName("certManager"))
-	assert.Equal(t, "metallb", CanonicalServiceName("metalLb"))
-	assert.Equal(t, "external-dns", CanonicalServiceName("external-dns"))
+func writeLoaderServiceFixture(t *testing.T, root, name, chartPath string) {
+	t.Helper()
+
+	servicesDir := filepath.Join(root, "services")
+	require.NoError(t, os.MkdirAll(servicesDir, 0o750))
+	require.NoError(t, os.WriteFile(filepath.Join(servicesDir, name+".yaml"), []byte(`
+apiVersion: kubara.io/v1alpha1
+kind: ServiceDefinition
+metadata:
+  name: `+name+`
+spec:
+  chartPath: `+chartPath+`
+  status: enabled
+`), 0o644))
 }

--- a/src/internal/catalog/oci_reference.go
+++ b/src/internal/catalog/oci_reference.go
@@ -1,0 +1,172 @@
+package catalog
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/opencontainers/go-digest"
+	"oras.land/oras-go/v2/registry"
+)
+
+const (
+	CatalogArtifactType    = "application/vnd.kubara.catalog.v1"
+	CatalogLayerMediaType  = "application/vnd.kubara.catalog.layer.v1.tar+gzip"
+	cacheSchemaVersion     = "v1"
+	defaultCatalogCacheRel = ".kubara/catalogs"
+	defaultLocalCatalogRef = "oci://localhost/"
+	ociScheme              = "oci://"
+)
+
+type OCIReference struct {
+	Raw        string
+	Registry   string
+	Repository string
+	Reference  string
+	Tag        string
+	Digest     digest.Digest
+	IsDigest   bool
+}
+
+type CachedArtifact struct {
+	SchemaVersion  string `json:"schemaVersion"`
+	CatalogName    string `json:"catalogName"`
+	CatalogVersion string `json:"catalogVersion"`
+	ManifestDigest string `json:"manifestDigest"`
+	RootDirectory  string `json:"rootDirectory"`
+}
+
+type cachedReference struct {
+	SchemaVersion  string `json:"schemaVersion"`
+	ManifestDigest string `json:"manifestDigest"`
+	CatalogName    string `json:"catalogName"`
+	CatalogVersion string `json:"catalogVersion"`
+	Reference      string `json:"reference,omitempty"`
+	Registry       string `json:"registry,omitempty"`
+	Repository     string `json:"repository,omitempty"`
+	Tag            string `json:"tag,omitempty"`
+	UpdatedAt      string `json:"updatedAt"`
+}
+
+func IsOCIReference(value string) bool {
+	return strings.HasPrefix(strings.ToLower(strings.TrimSpace(value)), ociScheme)
+}
+
+func GetCachedArtifact(reference string) (CachedArtifact, error) {
+	ref, err := ParseOCIReference(reference)
+	if err != nil {
+		return CachedArtifact{}, err
+	}
+
+	if ref.IsDigest {
+		if artifact, found, err := findArtifactByDigest(ref.Digest); err != nil {
+			return CachedArtifact{}, err
+		} else if found {
+			return artifact, nil
+		}
+		return CachedArtifact{}, fmt.Errorf("digest does not exist locally")
+	}
+
+	if artifact, found, err := findTagArtifact(ref); err != nil {
+		return CachedArtifact{}, err
+	} else if found {
+		return artifact, nil
+	}
+
+	if isLocalhostReference(ref) {
+		return CachedArtifact{}, fmt.Errorf("cached local catalog %q was not found; package it first with `kubara catalog package`", ref.Raw)
+	}
+
+	return CachedArtifact{}, fmt.Errorf("cached catalog %q was not found", ref.Raw)
+}
+
+func ParseOCIReference(raw string) (OCIReference, error) {
+	trimmed := strings.TrimSpace(raw)
+	if !IsOCIReference(trimmed) {
+		return OCIReference{}, fmt.Errorf("catalog reference %q must use the oci:// scheme", raw)
+	}
+
+	parsed, err := registry.ParseReference(strings.TrimPrefix(trimmed, ociScheme))
+	if err != nil {
+		return OCIReference{}, fmt.Errorf("parse OCI reference %q: %w", raw, err)
+	}
+	if strings.TrimSpace(parsed.Reference) == "" {
+		return OCIReference{}, fmt.Errorf("OCI reference %q must include either a tag or a digest", raw)
+	}
+
+	if err := parsed.ValidateReferenceAsDigest(); err == nil {
+		dgst, err := parsed.Digest()
+		if err != nil {
+			return OCIReference{}, fmt.Errorf("parse digest from %q: %w", raw, err)
+		}
+		return OCIReference{
+			Raw:        trimmed,
+			Registry:   parsed.Registry,
+			Repository: parsed.Repository,
+			Reference:  parsed.Reference,
+			Digest:     dgst,
+			IsDigest:   true,
+		}, nil
+	}
+
+	if err := parsed.ValidateReferenceAsTag(); err != nil {
+		return OCIReference{}, fmt.Errorf("invalid OCI tag in %q: %w", raw, err)
+	}
+	if !StrictCatalogVersion.MatchString(parsed.Reference) {
+		return OCIReference{}, fmt.Errorf(`OCI tag %q must match exact semantic version format "x.y.z" without a leading "v"`, parsed.Reference)
+	}
+
+	return OCIReference{
+		Raw:        trimmed,
+		Registry:   parsed.Registry,
+		Repository: parsed.Repository,
+		Reference:  parsed.Reference,
+		Tag:        parsed.Reference,
+		IsDigest:   false,
+	}, nil
+}
+
+func ParseOCIReferenceBase(raw string) (OCIReference, error) {
+	base := strings.TrimSpace(raw)
+	if base == "" {
+		base = defaultLocalCatalogRef
+	}
+	if !IsOCIReference(base) {
+		return OCIReference{}, fmt.Errorf("catalog reference base %q must use the oci:// scheme", raw)
+	}
+
+	normalized := base
+	if !strings.HasSuffix(normalized, "/") {
+		normalized += "/"
+	}
+
+	ociRef := strings.TrimSuffix(strings.TrimPrefix(normalized, ociScheme), "/")
+	if parsedBase, err := registry.ParseReference(ociRef); err == nil && strings.TrimSpace(parsedBase.Reference) != "" {
+		return OCIReference{}, fmt.Errorf("OCI reference base %q must not include a tag or digest", base)
+	}
+
+	placeholder := "kubara-placeholder"
+	validationRef := ociRef + "/" + placeholder + ":0.0.1"
+	parsed, err := registry.ParseReference(validationRef)
+	if err != nil {
+		return OCIReference{}, fmt.Errorf("parse OCI reference base %q: %w", base, err)
+	}
+
+	return OCIReference{
+		Raw:        normalized,
+		Registry:   parsed.Registry,
+		Repository: strings.TrimSuffix(strings.TrimSuffix(parsed.Repository, placeholder), "/"),
+	}, nil
+}
+
+func BuildCatalogReference(catalogName, version, rawBase string) (OCIReference, error) {
+	base, err := ParseOCIReferenceBase(rawBase)
+	if err != nil {
+		return OCIReference{}, err
+	}
+
+	repository := catalogName
+	if base.Repository != "" {
+		repository = fmt.Sprintf("%s/%s", base.Repository, catalogName)
+	}
+	return ParseOCIReference(fmt.Sprintf("oci://%s/%s:%s", base.Registry, repository, version))
+}

--- a/src/internal/catalog/package.go
+++ b/src/internal/catalog/package.go
@@ -1,0 +1,158 @@
+package catalog
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"oras.land/oras-go/v2"
+	"oras.land/oras-go/v2/content/file"
+	"oras.land/oras-go/v2/content/oci"
+)
+
+type PackageResult struct {
+	Manifest  CatalogManifest
+	Artifact  CachedArtifact
+	Reference string
+}
+
+type PackageOptions struct {
+	CatalogRoot   string
+	ReferenceBase string
+}
+
+func PackageCatalog(options PackageOptions) (PackageResult, error) {
+	manifest, err := LoadCatalogManifest(options.CatalogRoot)
+	if err != nil {
+		return PackageResult{}, err
+	}
+
+	ref, err := BuildCatalogReference(manifest.Metadata.Name, manifest.Spec.Version, options.ReferenceBase)
+	if err != nil {
+		return PackageResult{}, err
+	}
+
+	artifact, err := createCachedArtifact(manifest, options.CatalogRoot, CachedArtifact{
+		SchemaVersion:  cacheSchemaVersion,
+		CatalogName:    manifest.Metadata.Name,
+		CatalogVersion: manifest.Spec.Version,
+		RootDirectory:  manifest.Metadata.Name,
+	})
+	if err != nil {
+		return PackageResult{}, err
+	}
+
+	if err := writeLocalReference(ref, artifact); err != nil {
+		return PackageResult{}, err
+	}
+
+	return PackageResult{
+		Manifest:  manifest,
+		Artifact:  artifact,
+		Reference: ref.Raw,
+	}, nil
+}
+
+func createCachedArtifact(manifest CatalogManifest, catalogRoot string, artifact CachedArtifact) (CachedArtifact, error) {
+	tempArtifactDir, cleanup, err := newTempArtifactDir()
+	if err != nil {
+		return CachedArtifact{}, err
+	}
+	defer cleanup()
+
+	stagingRoot := filepath.Join(tempArtifactDir, "staging", manifest.Metadata.Name)
+	if err := stageCatalogPackageRoot(catalogRoot, stagingRoot); err != nil {
+		return CachedArtifact{}, fmt.Errorf("stage catalog package contents: %w", err)
+	}
+
+	ctx := context.Background()
+	fileStore, err := file.New(tempArtifactDir)
+	if err != nil {
+		return CachedArtifact{}, fmt.Errorf("create file store: %w", err)
+	}
+	defer fileStore.Close()
+	fileStore.TarReproducible = true
+
+	layerDescriptor, err := fileStore.Add(ctx, manifest.Metadata.Name, CatalogLayerMediaType, stagingRoot)
+	if err != nil {
+		return CachedArtifact{}, fmt.Errorf("package catalog directory: %w", err)
+	}
+
+	packOptions := oras.PackManifestOptions{
+		Layers: []v1.Descriptor{layerDescriptor},
+		ManifestAnnotations: map[string]string{
+			"io.kubara.catalog.name":    manifest.Metadata.Name,
+			"io.kubara.catalog.version": manifest.Spec.Version,
+		},
+	}
+	manifestDescriptor, err := oras.PackManifest(ctx, fileStore, oras.PackManifestVersion1_1, CatalogArtifactType, packOptions)
+	if err != nil {
+		return CachedArtifact{}, fmt.Errorf("pack catalog manifest: %w", err)
+	}
+	if err := fileStore.Tag(ctx, manifestDescriptor, manifest.Spec.Version); err != nil {
+		return CachedArtifact{}, fmt.Errorf("tag packaged catalog: %w", err)
+	}
+
+	layoutDir := filepath.Join(tempArtifactDir, "layout")
+	layoutStore, err := oci.New(layoutDir)
+	if err != nil {
+		return CachedArtifact{}, fmt.Errorf("create OCI layout store: %w", err)
+	}
+	if err := oras.CopyGraph(ctx, fileStore, layoutStore, manifestDescriptor, oras.DefaultCopyGraphOptions); err != nil {
+		return CachedArtifact{}, fmt.Errorf("copy packaged catalog into OCI layout: %w", err)
+	}
+	if err := layoutStore.Tag(ctx, manifestDescriptor, manifest.Spec.Version); err != nil {
+		return CachedArtifact{}, fmt.Errorf("tag OCI layout with %q: %w", manifest.Spec.Version, err)
+	}
+
+	contentsDir := filepath.Join(tempArtifactDir, "contents")
+	rootDir, err := extractCatalogContents(ctx, layoutStore, manifestDescriptor, contentsDir)
+	if err != nil {
+		return CachedArtifact{}, err
+	}
+
+	artifact.ManifestDigest = manifestDescriptor.Digest.String()
+	artifact.RootDirectory = filepath.Base(rootDir)
+
+	if err := finalizeCachedArtifact(tempArtifactDir, artifact); err != nil {
+		return CachedArtifact{}, err
+	}
+
+	return artifact, nil
+}
+
+func extractCatalogContents(ctx context.Context, layoutStore *oci.Store, desc v1.Descriptor, contentsDir string) (string, error) {
+	if err := os.MkdirAll(contentsDir, 0o755); err != nil {
+		return "", fmt.Errorf("create extracted catalog directory: %w", err)
+	}
+
+	fileStore, err := file.New(contentsDir)
+	if err != nil {
+		return "", fmt.Errorf("create extracted file store: %w", err)
+	}
+	defer fileStore.Close()
+
+	if err := oras.CopyGraph(ctx, layoutStore, fileStore, desc, oras.DefaultCopyGraphOptions); err != nil {
+		return "", fmt.Errorf("extract catalog contents: %w", err)
+	}
+
+	entries, err := os.ReadDir(contentsDir)
+	if err != nil {
+		return "", fmt.Errorf("read extracted catalog directory: %w", err)
+	}
+	if len(entries) != 1 || !entries[0].IsDir() {
+		return "", fmt.Errorf("expected packaged catalog to extract into a single root directory")
+	}
+
+	return filepath.Join(contentsDir, entries[0].Name()), nil
+}
+
+func stageCatalogPackageRoot(sourceRoot, targetRoot string) error {
+	if err := os.MkdirAll(filepath.Dir(targetRoot), 0o755); err != nil {
+		return fmt.Errorf("create staging directory %q: %w", filepath.Dir(targetRoot), err)
+	}
+
+	return copyDirectory(sourceRoot, targetRoot)
+}

--- a/src/internal/catalog/package.go
+++ b/src/internal/catalog/package.go
@@ -72,7 +72,9 @@ func createCachedArtifact(manifest CatalogManifest, catalogRoot string, artifact
 	if err != nil {
 		return CachedArtifact{}, fmt.Errorf("create file store: %w", err)
 	}
-	defer fileStore.Close()
+	defer func() {
+		_ = fileStore.Close()
+	}()
 	fileStore.TarReproducible = true
 
 	layerDescriptor, err := fileStore.Add(ctx, manifest.Metadata.Name, CatalogLayerMediaType, stagingRoot)
@@ -132,7 +134,9 @@ func extractCatalogContents(ctx context.Context, layoutStore *oci.Store, desc v1
 	if err != nil {
 		return "", fmt.Errorf("create extracted file store: %w", err)
 	}
-	defer fileStore.Close()
+	defer func() {
+		_ = fileStore.Close()
+	}()
 
 	if err := oras.CopyGraph(ctx, layoutStore, fileStore, desc, oras.DefaultCopyGraphOptions); err != nil {
 		return "", fmt.Errorf("extract catalog contents: %w", err)

--- a/src/internal/catalog/package.go
+++ b/src/internal/catalog/package.go
@@ -62,11 +62,6 @@ func createCachedArtifact(manifest CatalogManifest, catalogRoot string, artifact
 	}
 	defer cleanup()
 
-	stagingRoot := filepath.Join(tempArtifactDir, "staging", manifest.Metadata.Name)
-	if err := stageCatalogPackageRoot(catalogRoot, stagingRoot); err != nil {
-		return CachedArtifact{}, fmt.Errorf("stage catalog package contents: %w", err)
-	}
-
 	ctx := context.Background()
 	fileStore, err := file.New(tempArtifactDir)
 	if err != nil {
@@ -77,7 +72,7 @@ func createCachedArtifact(manifest CatalogManifest, catalogRoot string, artifact
 	}()
 	fileStore.TarReproducible = true
 
-	layerDescriptor, err := fileStore.Add(ctx, manifest.Metadata.Name, CatalogLayerMediaType, stagingRoot)
+	layerDescriptor, err := fileStore.Add(ctx, manifest.Metadata.Name, CatalogLayerMediaType, catalogRoot)
 	if err != nil {
 		return CachedArtifact{}, fmt.Errorf("package catalog directory: %w", err)
 	}
@@ -151,12 +146,4 @@ func extractCatalogContents(ctx context.Context, layoutStore *oci.Store, desc v1
 	}
 
 	return filepath.Join(contentsDir, entries[0].Name()), nil
-}
-
-func stageCatalogPackageRoot(sourceRoot, targetRoot string) error {
-	if err := os.MkdirAll(filepath.Dir(targetRoot), 0o755); err != nil {
-		return fmt.Errorf("create staging directory %q: %w", filepath.Dir(targetRoot), err)
-	}
-
-	return copyDirectory(sourceRoot, targetRoot)
 }

--- a/src/internal/catalog/package_test.go
+++ b/src/internal/catalog/package_test.go
@@ -1,0 +1,64 @@
+package catalog
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPackageCatalog_IncludesCatalogDirectoryContents(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+
+	workDir := t.TempDir()
+	catalogRoot := filepath.Join(t.TempDir(), "demo-catalog")
+	writeCatalogFixture(t, catalogRoot, "demo-catalog", "1.2.3")
+	require.NoError(t, os.MkdirAll(filepath.Join(catalogRoot, "customer-service-catalog", "helm"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(catalogRoot, "customer-service-catalog", "helm", "values.yaml"), []byte("foo: bar\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(catalogRoot, "notes.txt"), []byte("package me"), 0o600))
+	require.NoError(t, os.MkdirAll(filepath.Join(catalogRoot, "scratch"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(catalogRoot, "scratch", "debug.yaml"), []byte("debug: true\n"), 0o600))
+
+	result, err := PackageCatalog(PackageOptions{CatalogRoot: catalogRoot})
+	require.NoError(t, err)
+
+	unpackResult, err := UnpackageCatalog(UnpackageOptions{
+		Reference: result.Reference,
+		WorkDir:   workDir,
+	})
+	require.NoError(t, err)
+
+	assert.FileExists(t, filepath.Join(unpackResult.OutputPath, "Catalog.yaml"))
+	assert.FileExists(t, filepath.Join(unpackResult.OutputPath, "services", "demo-service.yaml"))
+	assert.FileExists(t, filepath.Join(unpackResult.OutputPath, "customer-service-catalog", "helm", "values.yaml"))
+	assert.FileExists(t, filepath.Join(unpackResult.OutputPath, "notes.txt"))
+	assert.FileExists(t, filepath.Join(unpackResult.OutputPath, "scratch", "debug.yaml"))
+}
+
+func writeCatalogFixture(t *testing.T, root, name, version string) {
+	t.Helper()
+
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "services"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "managed-service-catalog", "helm"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "customer-service-catalog", "helm"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "Catalog.yaml"), []byte(`
+apiVersion: kubara.io/v1alpha1
+kind: Catalog
+metadata:
+  name: `+name+`
+spec:
+  version: `+version+`
+`), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "services", "demo-service.yaml"), []byte(`
+apiVersion: kubara.io/v1alpha1
+kind: ServiceDefinition
+metadata:
+  name: demo-service
+spec:
+  chartPath: demo-service
+  status: enabled
+`), 0o600))
+}

--- a/src/internal/catalog/source_resolver.go
+++ b/src/internal/catalog/source_resolver.go
@@ -1,0 +1,151 @@
+package catalog
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"sigs.k8s.io/yaml"
+)
+
+type SourceKind string
+
+const (
+	SourceKindDirectory SourceKind = "directory"
+	SourceKindOCI       SourceKind = "oci"
+)
+
+type ResolvedSource struct {
+	Kind         SourceKind
+	RootPath     string
+	ServicesPath string
+	Manifest     *CatalogManifest
+	Artifact     *CachedArtifact
+}
+
+func ResolveSource(catalogPath string) (ResolvedSource, error) {
+	raw := strings.TrimSpace(catalogPath)
+	if raw == "" {
+		return ResolvedSource{}, nil
+	}
+
+	if !IsOCIReference(raw) {
+		return resolveDirectorySource(raw)
+	}
+
+	if _, err := ParseOCIReference(raw); err != nil {
+		return ResolvedSource{}, err
+	}
+
+	// TODO ensure we pull missing catalogs from remote
+	artifact, err := GetCachedArtifact(raw)
+	if err != nil {
+		return ResolvedSource{}, err
+	}
+
+	return resolvedSourceFromArtifact(artifact)
+}
+
+func requireDirectory(path, label string) (string, error) {
+	cleaned := filepath.Clean(path)
+	info, err := os.Stat(cleaned)
+	if err != nil {
+		return "", fmt.Errorf("%s %q does not exist: %w", label, cleaned, err)
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("%s %q is not a directory", label, cleaned)
+	}
+	return cleaned, nil
+}
+
+func resolveDirectorySource(catalogPath string) (ResolvedSource, error) {
+	cleaned, err := requireDirectory(catalogPath, "catalog path")
+	if err != nil {
+		return ResolvedSource{}, err
+	}
+	servicesPath, err := resolveServicesPath(cleaned)
+	if err != nil {
+		return ResolvedSource{}, err
+	}
+
+	source := ResolvedSource{
+		Kind:         SourceKindDirectory,
+		RootPath:     cleaned,
+		ServicesPath: servicesPath,
+	}
+
+	manifest, err := tryLoadCatalogManifest(cleaned)
+	if err != nil {
+		return ResolvedSource{}, err
+	}
+	source.Manifest = manifest
+
+	return source, nil
+}
+
+func resolvedSourceFromArtifact(artifact CachedArtifact) (ResolvedSource, error) {
+	rootPath := artifactRootPath(artifact)
+	servicesPath, err := resolveServicesPath(rootPath)
+	if err != nil {
+		return ResolvedSource{}, err
+	}
+
+	manifest, err := LoadCatalogManifest(rootPath)
+	if err != nil {
+		return ResolvedSource{}, err
+	}
+
+	return ResolvedSource{
+		Kind:         SourceKindOCI,
+		RootPath:     rootPath,
+		ServicesPath: servicesPath,
+		Manifest:     &manifest,
+		Artifact:     &artifact,
+	}, nil
+}
+
+func LoadCatalogManifest(root string) (CatalogManifest, error) {
+	path := filepath.Join(root, "Catalog.yaml")
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return CatalogManifest{}, fmt.Errorf("read %q: %w", path, err)
+	}
+
+	var manifest CatalogManifest
+	if err := yaml.Unmarshal(content, &manifest); err != nil {
+		return CatalogManifest{}, fmt.Errorf("unmarshal %q: %w", path, err)
+	}
+	if err := manifest.Validate(); err != nil {
+		return CatalogManifest{}, fmt.Errorf("invalid Catalog.yaml: %w", err)
+	}
+
+	return manifest, nil
+}
+
+func tryLoadCatalogManifest(root string) (*CatalogManifest, error) {
+	path := filepath.Join(root, "Catalog.yaml")
+	if _, err := os.Stat(path); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("stat %q: %w", path, err)
+	}
+
+	manifest, err := LoadCatalogManifest(root)
+	if err != nil {
+		return nil, err
+	}
+	return &manifest, nil
+}
+
+func resolveServicesPath(catalogPath string) (string, error) {
+	cleaned, err := requireDirectory(catalogPath, "catalog path")
+	if err != nil {
+		return "", err
+	}
+
+	servicesDir := filepath.Join(cleaned, string(ServicesDirectory))
+	return requireDirectory(servicesDir, "catalog services path")
+}

--- a/src/internal/catalog/types.go
+++ b/src/internal/catalog/types.go
@@ -17,7 +17,23 @@ var RFC1123Label = regexp.MustCompile(
 	`^[a-z](?:[a-z0-9-]{0,61}[a-z0-9])?$`,
 )
 
-// ServiceDefinitionAPIVersion is the supported ServiceDefinition apiVersion.
+var StrictCatalogVersion = regexp.MustCompile(`^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$`)
+
+// CatalogArtifactElement
+type CatalogArtifactElement string
+
+const (
+	CatalogDefinition               CatalogArtifactElement = "Catalog.yaml"
+	ServicesDirectory               CatalogArtifactElement = "services"
+	ManagedServiceCatalogDirectory  CatalogArtifactElement = "managed-service-catalog"
+	CustomerServiceCatalogDirectory CatalogArtifactElement = "customer-service-catalog"
+)
+
+// Support APIVersion for CatalogManifest
+const CatalogAPIVersion = "kubara.io/v1alpha1"
+const CatalogKind = "Catalog"
+
+// Support APIVersion for ServiceDefinition
 const ServiceDefinitionAPIVersion = "kubara.io/v1alpha1"
 const ServiceDefinitionKind = "ServiceDefinition"
 
@@ -53,6 +69,19 @@ type ServiceSpec struct {
 	ConfigSchema *apiextensionsv1.JSONSchemaProps `json:"configSchema,omitempty"`
 }
 
+// CatalogManifest describes a catalog root manifest.
+type CatalogManifest struct {
+	APIVersion string      `json:"apiVersion"`
+	Kind       string      `json:"kind"`
+	Metadata   Metadata    `json:"metadata"`
+	Spec       CatalogSpec `json:"spec"`
+}
+
+// CatalogSpec contains catalog-level settings.
+type CatalogSpec struct {
+	Version string `json:"version"`
+}
+
 // Catalog represents a set of service definitions keyed by canonical service name.
 type Catalog struct {
 	// Services maps canonical service names to definitions.
@@ -65,28 +94,52 @@ func (c Catalog) Clone() Catalog {
 	return out
 }
 
-func (d ServiceDefinition) Validate() error {
-	apiVersion := strings.TrimSpace(d.APIVersion)
+func validateApiObject(apiVersion, kind, name, expectedAPIVersion, expectedKind string) error {
+	apiVersion = strings.TrimSpace(apiVersion)
 	if apiVersion == "" {
 		return fmt.Errorf("missing apiVersion")
 	}
-	if apiVersion != ServiceDefinitionAPIVersion {
-		return fmt.Errorf("apiVersion must be %q", ServiceDefinitionAPIVersion)
+	if apiVersion != expectedAPIVersion {
+		return fmt.Errorf("apiVersion must be %q", expectedAPIVersion)
 	}
-	if strings.TrimSpace(d.Kind) != ServiceDefinitionKind {
-		return fmt.Errorf("kind must be %q", ServiceDefinitionKind)
+	if strings.TrimSpace(kind) != expectedKind {
+		return fmt.Errorf("kind must be %q", expectedKind)
 	}
-	if strings.TrimSpace(d.Metadata.Name) == "" {
+	name = strings.TrimSpace(name)
+	if name == "" {
 		return fmt.Errorf("missing metadata.name")
 	}
-	if !RFC1123Label.MatchString(d.Metadata.Name) {
+	if !RFC1123Label.MatchString(name) {
 		return fmt.Errorf("metadata.name must adhere to rfc 1123: must be 1-63 characters, start with a lowercase letter, contain only lowercase letters, digits, or '-', and end with a letter or digit")
+	}
+	return nil
+}
+
+func (d ServiceDefinition) Validate() error {
+	if err := validateApiObject(d.APIVersion, d.Kind, d.Metadata.Name, ServiceDefinitionAPIVersion, ServiceDefinitionKind); err != nil {
+		return err
 	}
 	if strings.TrimSpace(d.Spec.ChartPath) == "" {
 		return fmt.Errorf("missing spec.chartPath")
 	}
 	if d.Spec.Status != service.StatusEnabled && d.Spec.Status != service.StatusDisabled {
 		return fmt.Errorf(`spec.status must be either %q or %q`, service.StatusEnabled, service.StatusDisabled)
+	}
+
+	return nil
+}
+
+func (m CatalogManifest) Validate() error {
+	if err := validateApiObject(m.APIVersion, m.Kind, m.Metadata.Name, CatalogAPIVersion, CatalogKind); err != nil {
+		return err
+	}
+
+	version := strings.TrimSpace(m.Spec.Version)
+	if version == "" {
+		return fmt.Errorf("missing spec.version")
+	}
+	if !StrictCatalogVersion.MatchString(version) {
+		return fmt.Errorf(`spec.version must match exact semantic version format "x.y.z" without a leading "v"`)
 	}
 
 	return nil

--- a/src/internal/cmd/catalog/add.go
+++ b/src/internal/cmd/catalog/add.go
@@ -21,6 +21,9 @@ func CreateService(serviceName string) error {
 	if _, err := os.Stat("Catalog.yaml"); errors.Is(err, os.ErrNotExist) {
 		return fmt.Errorf("this directory is missing a Catalog.yaml")
 	}
+	if _, err := cat.LoadCatalogManifest("."); err != nil {
+		return err
+	}
 
 	servicePath := filepath.Join("services", fmt.Sprintf("%s.yaml", serviceName))
 	if _, err := os.Stat(servicePath); err == nil {

--- a/src/internal/cmd/catalog/create.go
+++ b/src/internal/cmd/catalog/create.go
@@ -38,7 +38,9 @@ func CreateCatalog(catalogName string) (err error) {
 	catalogYaml := fmt.Sprintf(`apiVersion: kubara.io/v1alpha1
 kind: Catalog
 metadata:
-  name: %s`, catalogName)
+  name: %s
+spec:
+  version: 0.1.0`, catalogName)
 
 	if err = os.WriteFile(filepath.Join(catalogName, "Catalog.yaml"), []byte(catalogYaml), 0o600); err != nil {
 		return fmt.Errorf("cannot create Catalog.yaml: %w", err)

--- a/src/internal/envconfig/env.go
+++ b/src/internal/envconfig/env.go
@@ -57,14 +57,6 @@ type EnvMap struct {
 	ArgocdHelmRepoUrl           string   `default:"" koanf:"ARGOCD_HELM_REPO_URL" optional:"true"`
 }
 
-// ValidateAll performs basic validation on the envMap.
-func (em *EnvMap) ValidateAll() error {
-	if err := em.Validate(); err != nil {
-		return err
-	}
-	return nil
-}
-
 // Validate performs basic validation on the envMap.
 // It looks at all fields but only raises an error if non optional fields are not set or set to default.
 func (em *EnvMap) Validate() error {

--- a/src/internal/envconfig/env_test.go
+++ b/src/internal/envconfig/env_test.go
@@ -169,53 +169,6 @@ func TestEnvMap_Validate(t *testing.T) {
 	}
 }
 
-func TestEnvMap_ValidateAll(t *testing.T) {
-	validEnvMap := func() *EnvMap {
-		return &EnvMap{
-			ProjectName:                 "test-project",
-			ProjectStage:                "dev",
-			ArgocdWizardAccountPassword: "password123",
-			ArgocdHelmRepoUsername:      "helm-user",
-			ArgocdHelmRepoPassword:      "helm-pass",
-			ArgocdHelmRepoUrl:           "https://helm.example.com",
-			ArgocdGitHttpsUrl:           "https://github.com/example/repo.git",
-			DomainName:                  "example.com",
-		}
-	}
-
-	tests := []struct {
-		name    string
-		envMap  *EnvMap
-		wantErr bool
-	}{
-		{
-			name:    "Valid EnvMap passes ValidateAll",
-			envMap:  validEnvMap(),
-			wantErr: false,
-		},
-		{
-			name: "Invalid EnvMap fails ValidateAll",
-			envMap: func() *EnvMap {
-				em := validEnvMap()
-				em.ProjectName = ""
-				return em
-			}(),
-			wantErr: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := tt.envMap.ValidateAll()
-			if tt.wantErr {
-				assert.Error(t, err)
-			} else {
-				assert.NoError(t, err)
-			}
-		})
-	}
-}
-
 func TestEnvMap_setDefaults(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/src/internal/render/render.go
+++ b/src/internal/render/render.go
@@ -123,9 +123,13 @@ func loadTemplateSources(options TemplateOptions) ([]templateSource, error) {
 		return sources, nil
 	}
 
+	source, err := catalog.ResolveSource(options.CatalogPath)
+	if err != nil {
+		return nil, fmt.Errorf("resolve external catalog source: %w", err)
+	}
 	external := templateSource{
 		name:     "external",
-		fsys:     os.DirFS(options.CatalogPath),
+		fsys:     os.DirFS(source.RootPath),
 		baseRoot: ".",
 		external: true,
 	}


### PR DESCRIPTION
## 📝 Summary
This PR introduces new kubara catalog management functionality by introducing three new CLI subcommands for listing, packaging, and unpackaging catalogs, with support for OCI (Open Container Initiative) references. The changes also introduces and enforces versioning for catalogs for better platform lifecycle management.

As this is just the first step of the catalog management, the documentation was intentionally not updated (besides the auto-generated command page) and we will wait until the next PR is ready for introducing pulling, pushing and login to remote registries before fully reworking the catalog pages.

**Breaking change:**
This PR introduces and enforces the catalog version to be set. Therefore if users already have created their own custom catalogs they will have to manually add a version field to their `Catalog.yaml`:

```yaml
apiVersion: kubara.io/v1alpha1
kind: Catalog
metadata:
  name: your-catalog
spec:
  version: 0.1.0
```


## 🧩 Type of change
- [X] 🔧 CLI / Go code
- [ ] 📦 Helm chart
- [ ] 🧱 Terraform module
- [X] 📝 Documentation
- [X] 🧪 Test or CI change
- [X] ♻️ Refactor / cleanup

## ⚠️ Is this a breaking change?
- [X] Yes, this change breaks existing functionality (explain in summary)

## 🧪 Testing
- [X] CI passed
- [X] Manually tested (local/dev cluster)
- [X] Unit tested
- [ ] Not tested (explain why below)
  
## 🔗 Related Issues / Tickets
<!-- e.g. Closes #42, Related to #99 -->

## ✅ Checklist
- [X] Code compiles and passes all tests
- [X] Linting and style checks pass
- [X] Comments added for complex logic
- [ ] Documentation updated (if applicable)
  
## 📎 Additional Context (optional)
<!-- Add logs, screenshots, diagrams, or design notes. -->
