### PR TITLE
refactor: make external-dns values provider-aware

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,12 @@ If docs and code diverge, treat code/tests as current behavior and update the ne
 - Prefer table-driven tests when extending test coverage.
 - Reuse existing structure under `src/cmd/` and `src/internal/`.
 
+## Catalog Boundary
+- Treat the catalog feature as the boundary between generic CLI logic and app-specific platform components.
+- Do not hard-code Helm application behavior, chart values, provider webhook details, or built-in app names in Go code unless the code is explicitly testing catalog loading, service aliases, or schema composition where those names are the behavior under test.
+- Keep app-specific behavior in catalog data, Helm/Terraform templates, service definitions, and docs. Go code should operate on generic catalog metadata, provider selectors, template paths, and service definitions.
+- When testing renderer or generator behavior, prefer synthetic catalog/template fixtures over assertions about concrete built-in Helm apps.
+
 ## Documentation
 - Docs live under `docs/content/`.
 - Keep changes aligned with `docs/mkdocs.yml` navigation.

--- a/docs/content/1_getting_started/catalogs.md
+++ b/docs/content/1_getting_started/catalogs.md
@@ -194,9 +194,11 @@ During `kubara generate`, kubara renders templates and writes them into your rep
 - `example` path segments with the current cluster name
 
 Provider-specific template variants are supported only below `terraform/providers/<provider>/`, for example `customer-service-catalog/terraform/providers/stackit/example/infrastructure/main.tf.tplt`.
-When `terraform.provider` matches the provider name, kubara strips the `providers/<provider>/` path segment and uses that provider-specific file for the generated output path. If a common template and a provider-specific template resolve to the same output path, the provider-specific template replaces the common one; kubara does not deep-merge template files.
+When `terraform.provider` matches a supported provider name, kubara strips the `providers/<provider>/` path segment and uses that provider-specific file for the generated output path. If a common template and a provider-specific template resolve to the same output path, the provider-specific template replaces the common one; kubara does not deep-merge template files.
 
-Helm provider directories such as `helm/providers/<provider>/` are not supported. Keep provider-specific Helm behavior in a common values template or in the Helm chart itself.
+If a cluster has no Terraform block or uses `terraform.provider: none`, the default `kubara generate` command skips Terraform templates for that cluster. `kubara generate --terraform` still requires a supported Terraform provider.
+
+Provider directories below Helm paths are not treated as provider-specific overrides. Keep provider-specific Helm behavior in a common values template or in the Helm chart itself.
 
 ## Creating your own catalog
 

--- a/docs/content/1_getting_started/catalogs.md
+++ b/docs/content/1_getting_started/catalogs.md
@@ -193,6 +193,11 @@ During `kubara generate`, kubara renders templates and writes them into your rep
 - `customer-service-catalog/` with the configured customer overlay output path
 - `example` path segments with the current cluster name
 
+Provider-specific template variants are supported only below `terraform/providers/<provider>/`, for example `customer-service-catalog/terraform/providers/stackit/example/infrastructure/main.tf.tplt`.
+When `terraform.provider` matches the provider name, kubara strips the `providers/<provider>/` path segment and uses that provider-specific file for the generated output path. If a common template and a provider-specific template resolve to the same output path, the provider-specific template replaces the common one; kubara does not deep-merge template files.
+
+Helm provider directories such as `helm/providers/<provider>/` are not supported. Keep provider-specific Helm behavior in a common values template or in the Helm chart itself.
+
 ## Creating your own catalog
 
 If you want to understand how to create a custom catalog for your multi cluster platform have a look at [How to create your own catalog](../2_managing_your_platform/create_catalog.md)

--- a/docs/content/3_components/backup_and_recovery.md
+++ b/docs/content/3_components/backup_and_recovery.md
@@ -146,6 +146,7 @@ When you use `backupMode: csi-snapshot` or `backupMode: csi-data-mover`, Velero 
 
 kubara writes `volumeSnapshotClass.k8sProvider` into the generated Velero values based on `terraform.provider`.
 If your environment is not covered by one of the built-in provider mappings, or if you need provider-specific fields that differ from the default, define your own `VolumeSnapshotClass` in `customer-service-catalog/helm/<cluster-name>/velero/additional-values.yaml`.
+When `terraform.provider` is `none`, kubara does not select a built-in `VolumeSnapshotClass` provider.
 
 `volumeSnapshotClass.customDefinition` takes precedence over the provider mapping, so this is the recommended way to supply a fully custom snapshot class.
 

--- a/src/cmd/generate_test.go
+++ b/src/cmd/generate_test.go
@@ -249,19 +249,7 @@ func TestGenerateCmd(t *testing.T) {
 				})
 
 				//dummy values
-				envPath := createTestEnv(t, tempDir, envconfig.EnvMap{
-					ProjectName:                 "project-name",
-					ProjectStage:                "project-stage",
-					DockerconfigBase64:          "DockerConfig",
-					ArgocdWizardAccountPassword: "wizardpassword",
-					ArgocdGitHttpsUrl:           "https://example.com",
-					ArgocdGitUsername:           "CoolCapybara",
-					ArgocdGitPatOrPassword:      "password",
-					ArgocdHelmRepoUrl:           "https://example.com",
-					ArgocdHelmRepoUsername:      "CoolCapybara",
-					ArgocdHelmRepoPassword:      "password",
-					DomainName:                  "example.com",
-				})
+				envPath := createDefaultGenerateTestEnv(t, tempDir)
 
 				// Add global flags
 				globalFlags := []string{
@@ -301,7 +289,7 @@ func TestGenerateCmd(t *testing.T) {
 	}
 }
 
-func TestGenerateCmd_MissingProviderUsesDefault(t *testing.T) {
+func TestGenerateCmd_MissingProviderDefaultsToNoneAndFailsForTerraform(t *testing.T) {
 	tempDir := t.TempDir()
 
 	configPath := createTestConfig(t, tempDir, config.Cluster{
@@ -328,47 +316,25 @@ func TestGenerateCmd_MissingProviderUsesDefault(t *testing.T) {
 	})
 
 	//dummy values
-	createTestEnv(t, tempDir, envconfig.EnvMap{
-		ProjectName:                 "project-name",
-		ProjectStage:                "project-stage",
-		DockerconfigBase64:          "DockerConfig",
-		ArgocdWizardAccountPassword: "wizardpassword",
-		ArgocdGitHttpsUrl:           "https://example.com",
-		ArgocdGitUsername:           "CoolCapybara",
-		ArgocdGitPatOrPassword:      "password",
-		ArgocdHelmRepoUrl:           "https://example.com",
-		ArgocdHelmRepoUsername:      "CoolCapybara",
-		ArgocdHelmRepoPassword:      "password",
-		DomainName:                  "example.com",
-	})
+	createDefaultGenerateTestEnv(t, tempDir)
 
 	app := createTestApp(NewGenerateCmd())
 	args := []string{"kubara", "--config-file", configPath, "--work-dir", tempDir, "generate", "--terraform"}
 	err := app.Run(context.Background(), args)
-	require.NoError(t, err)
-
-	terraformDir := filepath.Join(tempDir, "managed-service-catalog", "terraform")
-	entries, err := os.ReadDir(terraformDir)
-	require.NoError(t, err)
-	assert.NotEmpty(t, entries)
-
-	// Provider ske-cluster directory and main.tf exists
-	// as stackit is the default provider when none is specified.
-	_, err = os.Stat(filepath.Join(terraformDir, "modules", "ske-cluster", "main.tf"))
-	require.NoError(t, err)
-
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing terraform configuration")
 }
 
-func TestGenerateCmd_PlaceholderProviderFailsWithHint(t *testing.T) {
+func TestGenerateCmd_MissingProviderGeneratesOnlyHelmByDefault(t *testing.T) {
 	tempDir := t.TempDir()
 
 	configPath := createTestConfig(t, tempDir, config.Cluster{
-		Name:    "placeholder-provider-cluster",
+		Name:    "no-provider-cluster",
 		Stage:   "dev",
 		Type:    "hub",
 		DNSName: "test.example.com",
 		Terraform: &config.Terraform{
-			Provider:          "<provider>",
+			Provider:          "",
 			ProjectID:         "00000000-0000-0000-0000-000000000000",
 			KubernetesType:    "ske",
 			KubernetesVersion: "1.28.0",
@@ -385,28 +351,86 @@ func TestGenerateCmd_PlaceholderProviderFailsWithHint(t *testing.T) {
 		Services: createTestServices(),
 	})
 
-	app := createTestApp(NewGenerateCmd())
-
 	//dummy values
-	createTestEnv(t, tempDir, envconfig.EnvMap{
-		ProjectName:                 "project-name",
-		ProjectStage:                "project-stage",
-		DockerconfigBase64:          "DockerConfig",
-		ArgocdWizardAccountPassword: "wizardpassword",
-		ArgocdGitHttpsUrl:           "https://example.com",
-		ArgocdGitUsername:           "CoolCapybara",
-		ArgocdGitPatOrPassword:      "password",
-		ArgocdHelmRepoUrl:           "https://example.com",
-		ArgocdHelmRepoUsername:      "CoolCapybara",
-		ArgocdHelmRepoPassword:      "password",
-		DomainName:                  "example.com",
+	createDefaultGenerateTestEnv(t, tempDir)
+
+	app := createTestApp(NewGenerateCmd())
+	args := []string{"kubara", "--config-file", configPath, "--work-dir", tempDir, "generate"}
+	err := app.Run(context.Background(), args)
+	require.NoError(t, err)
+
+	helmDir := filepath.Join(tempDir, "managed-service-catalog", "helm")
+	entries, err := os.ReadDir(helmDir)
+	require.NoError(t, err)
+	assert.NotEmpty(t, entries)
+
+	_, err = os.Stat(filepath.Join(tempDir, "managed-service-catalog", "terraform"))
+	assert.ErrorIs(t, err, os.ErrNotExist)
+}
+
+func TestGenerateCmd_MissingTerraformGeneratesOnlyHelmByDefault(t *testing.T) {
+	tempDir := t.TempDir()
+
+	configPath := createTestConfig(t, tempDir, config.Cluster{
+		Name:    "helm-only-cluster",
+		Stage:   "dev",
+		Type:    "hub",
+		DNSName: "test.example.com",
+		ArgoCD: config.ArgoCD{
+			Repo: config.RepoProto{
+				HTTPS: &config.RepoType{
+					Customer: config.Repository{URL: "https://github.com/example/customer", TargetRevision: "main"},
+					Managed:  config.Repository{URL: "https://github.com/example/managed", TargetRevision: "main"},
+				},
+			},
+		},
+		Services: createTestServices(),
 	})
 
+	//dummy values
+	createDefaultGenerateTestEnv(t, tempDir)
+
+	app := createTestApp(NewGenerateCmd())
+	args := []string{"kubara", "--config-file", configPath, "--work-dir", tempDir, "generate"}
+	err := app.Run(context.Background(), args)
+	require.NoError(t, err)
+
+	helmDir := filepath.Join(tempDir, "managed-service-catalog", "helm")
+	entries, err := os.ReadDir(helmDir)
+	require.NoError(t, err)
+	assert.NotEmpty(t, entries)
+
+	_, err = os.Stat(filepath.Join(tempDir, "managed-service-catalog", "terraform"))
+	assert.ErrorIs(t, err, os.ErrNotExist)
+}
+
+func TestGenerateCmd_MissingTerraformFailsForTerraform(t *testing.T) {
+	tempDir := t.TempDir()
+
+	configPath := createTestConfig(t, tempDir, config.Cluster{
+		Name:    "missing-terraform-cluster",
+		Stage:   "dev",
+		Type:    "hub",
+		DNSName: "test.example.com",
+		ArgoCD: config.ArgoCD{
+			Repo: config.RepoProto{
+				HTTPS: &config.RepoType{
+					Customer: config.Repository{URL: "https://github.com/example/customer", TargetRevision: "main"},
+					Managed:  config.Repository{URL: "https://github.com/example/managed", TargetRevision: "main"},
+				},
+			},
+		},
+		Services: createTestServices(),
+	})
+
+	//dummy values
+	createDefaultGenerateTestEnv(t, tempDir)
+
+	app := createTestApp(NewGenerateCmd())
 	args := []string{"kubara", "--config-file", configPath, "--work-dir", tempDir, "generate", "--terraform", "--dry-run"}
 	err := app.Run(context.Background(), args)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "placeholder provider")
-	assert.Contains(t, err.Error(), "supported providers: \"stackit\"")
+	assert.Contains(t, err.Error(), "missing terraform configuration")
 }
 
 // Helper function
@@ -426,6 +450,24 @@ func createTestConfig(t *testing.T, dir string, clusters ...config.Cluster) stri
 	require.NoError(t, err)
 
 	return configPath
+}
+
+func createDefaultGenerateTestEnv(t *testing.T, dir string) string {
+	t.Helper()
+
+	return createTestEnv(t, dir, envconfig.EnvMap{
+		ProjectName:                 "project-name",
+		ProjectStage:                "project-stage",
+		DockerconfigBase64:          "DockerConfig",
+		ArgocdWizardAccountPassword: "wizardpassword",
+		ArgocdGitHttpsUrl:           "https://example.com",
+		ArgocdGitUsername:           "CoolCapybara",
+		ArgocdGitPatOrPassword:      "password",
+		ArgocdHelmRepoUrl:           "https://example.com",
+		ArgocdHelmRepoUsername:      "CoolCapybara",
+		ArgocdHelmRepoPassword:      "password",
+		DomainName:                  "example.com",
+	})
 }
 
 // createTestEnv writes an envMap to the file system

--- a/src/internal/catalog/built-in/customer-service-catalog/helm/example/external-dns/values.yaml.tplt
+++ b/src/internal/catalog/built-in/customer-service-catalog/helm/example/external-dns/values.yaml.tplt
@@ -1,3 +1,4 @@
+{{- if eq .cluster.terraform.provider "stackit" }}
 externalSecrets:
   secretStoreRef:
     kind: ClusterSecretStore
@@ -18,6 +19,7 @@ externalSecrets:
         - remoteKey: {{ .cluster.name }}/{{ .cluster.stage }}/external-dns/dns_zone_admin
           remoteKeyProperty: sa_key_json
           secretKey: SA_KEY_JSON
+{{- end }}
 
 namespace:
   labels:
@@ -46,6 +48,7 @@ external-dns:
         resources:
           - "namespaces"
         verbs: ["get", "watch", "list"]
+{{- if eq .cluster.terraform.provider "stackit" }}
   extraVolumes:
     - name: stackit-sa-authentication
       secret:
@@ -53,11 +56,13 @@ external-dns:
         items:
           - key: SA_KEY_JSON
             path: sa_key.json
+{{- end }}
   global:
     imagePullSecrets:
       - name: image-pull-secret
     security:
       allowInsecureImages: true
+{{- if eq .cluster.terraform.provider "stackit" }}
   provider:
     webhook:
       image:
@@ -76,6 +81,7 @@ external-dns:
             secretKeyRef:
               name: external-dns-webhook
               key: PROJECT_ID
+{{- end }}
   serviceMonitor:
     {{- if (eq (index .cluster.services "kube-prometheus-stack" "status") "enabled") }}
     enabled: true

--- a/src/internal/catalog/built-in/managed-service-catalog/helm/velero/templates/volumesnapshotclass.yaml
+++ b/src/internal/catalog/built-in/managed-service-catalog/helm/velero/templates/volumesnapshotclass.yaml
@@ -3,6 +3,7 @@
 {{ toYaml $volumeSnapshotClass.customDefinition }}
 {{- else }}
 {{- $providerName := $volumeSnapshotClass.k8sProvider -}}
+{{- if and $providerName (ne $providerName "none") }}
 {{- $providerConfig := index ($volumeSnapshotClass.providers | default dict) $providerName -}}
 {{- if not $providerConfig }}
 {{- fail (printf "volumeSnapshotClass.k8sProvider %q is not configured; define volumeSnapshotClass.providers.%s or volumeSnapshotClass.customDefinition" $providerName $providerName) }}
@@ -15,4 +16,5 @@ metadata:
   labels:
     velero.io/csi-volumesnapshot-class: "true"
 {{ toYaml $providerConfig }}
+{{- end }}
 {{- end }}

--- a/src/internal/cmd/generate/generator.go
+++ b/src/internal/cmd/generate/generator.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"sort"
 	"strings"
 
 	"github.com/kubara-io/kubara/internal/catalog"
@@ -54,11 +53,11 @@ func (o *Options) resolveOutputPath(result render.TemplateResult, clusterName st
 }
 
 func supportedProviderList() string {
-	providers := make([]string, 0, len(render.SupportedProviders))
-	for provider := range render.SupportedProviders {
-		providers = append(providers, provider)
+	supported := config.SupportedTerraformProviders()
+	providers := make([]string, 0, len(supported))
+	for _, provider := range supported {
+		providers = append(providers, string(provider))
 	}
-	sort.Strings(providers)
 	return strings.Join(providers, ", ")
 }
 
@@ -66,11 +65,11 @@ func resolveProvider(clusterBlock config.Cluster) (string, error) {
 	if clusterBlock.Terraform == nil {
 		return "", fmt.Errorf("cluster %q is missing terraform configuration", clusterBlock.Name)
 	}
-	provider := strings.ToLower(strings.TrimSpace(clusterBlock.Terraform.Provider))
+	provider := clusterBlock.Terraform.Provider
 	if provider == "" {
 		return "", fmt.Errorf("cluster %q has a terraform block but no provider specified", clusterBlock.Name)
 	}
-	if provider == "<provider>" {
+	if provider == config.TerraformProviderPlaceholder {
 		return "", fmt.Errorf(
 			"cluster %q still uses placeholder provider %q; supported providers: %q",
 			clusterBlock.Name,
@@ -78,10 +77,10 @@ func resolveProvider(clusterBlock config.Cluster) (string, error) {
 			supportedProviderList(),
 		)
 	}
-	if !render.SupportedProviders[provider] {
+	if !provider.IsSupported() {
 		return "", fmt.Errorf("unsupported provider %q for cluster %q; supported providers: %q", provider, clusterBlock.Name, supportedProviderList())
 	}
-	return provider, nil
+	return string(provider), nil
 }
 
 func resolveCatalog(cat catalog.Catalog) map[string]any {

--- a/src/internal/cmd/generate/generator.go
+++ b/src/internal/cmd/generate/generator.go
@@ -35,6 +35,11 @@ func buildTemplateContext(cluster config.Cluster, cat catalog.Catalog, em envcon
 	if err != nil {
 		return nil, fmt.Errorf("convert cluster config to map: %w", err)
 	}
+	if cluster.Terraform == nil {
+		clusterMap["terraform"] = map[string]any{
+			"provider": config.TerraformProviderNone,
+		}
+	}
 
 	return map[string]any{
 		"env":     em,
@@ -61,26 +66,27 @@ func supportedProviderList() string {
 	return strings.Join(providers, ", ")
 }
 
-func resolveProvider(clusterBlock config.Cluster) (string, error) {
+func resolveProvider(clusterBlock config.Cluster, requireTerraform bool) (string, bool, error) {
 	if clusterBlock.Terraform == nil {
-		return "", fmt.Errorf("cluster %q is missing terraform configuration", clusterBlock.Name)
+		if requireTerraform {
+			return "", false, fmt.Errorf("cluster %q is missing terraform configuration", clusterBlock.Name)
+		}
+		return "", false, nil
 	}
 	provider := clusterBlock.Terraform.Provider
-	if provider == "" {
-		return "", fmt.Errorf("cluster %q has a terraform block but no provider specified", clusterBlock.Name)
+	if provider == config.TerraformProviderNone {
+		if requireTerraform {
+			return "", false, fmt.Errorf("cluster %q has terraform provider %q; configure one of: %q", clusterBlock.Name, provider, supportedProviderList())
+		}
+		return "", false, nil
 	}
-	if provider == config.TerraformProviderPlaceholder {
-		return "", fmt.Errorf(
-			"cluster %q still uses placeholder provider %q; supported providers: %q",
-			clusterBlock.Name,
-			clusterBlock.Terraform.Provider,
-			supportedProviderList(),
-		)
+	if provider == "" {
+		return "", false, fmt.Errorf("cluster %q has a terraform block but no provider specified", clusterBlock.Name)
 	}
 	if !provider.IsSupported() {
-		return "", fmt.Errorf("unsupported provider %q for cluster %q; supported providers: %q", provider, clusterBlock.Name, supportedProviderList())
+		return "", false, fmt.Errorf("unsupported provider %q for cluster %q; supported providers: %q", provider, clusterBlock.Name, supportedProviderList())
 	}
-	return string(provider), nil
+	return string(provider), true, nil
 }
 
 func resolveCatalog(cat catalog.Catalog) map[string]any {
@@ -118,18 +124,34 @@ func toJSONMap(value any) (map[string]any, error) {
 	return out, nil
 }
 
-func (o *Options) cleanupOldFiles() error {
+func pathHasSegment(path, segment string) bool {
+	for _, part := range strings.Split(filepath.ToSlash(path), "/") {
+		if part == segment {
+			return true
+		}
+	}
+	return false
+}
+
+func (o *Options) cleanupOldFiles(results []render.TemplateResult) error {
 	if o.DryRun {
 		return nil
 	}
 
-	if o.TemplateType == render.All || o.TemplateType == render.Terraform {
+	cleanupTerraform := false
+	cleanupHelm := false
+	for _, result := range results {
+		cleanupTerraform = cleanupTerraform || pathHasSegment(result.Path, render.Terraform.String())
+		cleanupHelm = cleanupHelm || pathHasSegment(result.Path, render.Helm.String())
+	}
+
+	if cleanupTerraform {
 		deletePath := filepath.Join(o.ManagedCatalogPath, render.Terraform.String())
 		if err := os.RemoveAll(deletePath); err != nil {
 			return fmt.Errorf("removing directory %q: %w", deletePath, err)
 		}
 	}
-	if o.TemplateType == render.All || o.TemplateType == render.Helm {
+	if cleanupHelm {
 		deletePath := filepath.Join(o.ManagedCatalogPath, render.Helm.String())
 		if err := os.RemoveAll(deletePath); err != nil {
 			return fmt.Errorf("removing directory %q: %w", deletePath, err)
@@ -190,16 +212,31 @@ func (o *Options) processClusters() ([]render.TemplateResult, error) {
 		}
 
 		provider := ""
-		if o.TemplateType != render.Helm {
-			provider, err = resolveProvider(clusterBlock)
+		templateType := o.TemplateType
+		if o.TemplateType == render.Terraform {
+			var renderTerraform bool
+			provider, renderTerraform, err = resolveProvider(clusterBlock, true)
 			if err != nil {
 				return nil, fmt.Errorf("resolve provider for cluster %q: %w", clusterBlock.Name, err)
+			}
+			if !renderTerraform {
+				continue
+			}
+		}
+		if o.TemplateType == render.All {
+			var renderTerraform bool
+			provider, renderTerraform, err = resolveProvider(clusterBlock, false)
+			if err != nil {
+				return nil, fmt.Errorf("resolve provider for cluster %q: %w", clusterBlock.Name, err)
+			}
+			if !renderTerraform {
+				templateType = render.Helm
 			}
 		}
 
 		clusterTplResults, err := render.TemplateFiles(
 			render.TemplateOptions{
-				Type:        o.TemplateType,
+				Type:        templateType,
 				Provider:    provider,
 				CatalogPath: o.CatalogPath,
 				Overwrite:   o.CatalogOverwrite,
@@ -229,7 +266,7 @@ func (o *Options) Run() error {
 		return errProcess
 	}
 
-	if errCleanup := o.cleanupOldFiles(); errCleanup != nil {
+	if errCleanup := o.cleanupOldFiles(allResults); errCleanup != nil {
 		return fmt.Errorf("cleanup old files: %w", errCleanup)
 	}
 

--- a/src/internal/config/defaults_test.go
+++ b/src/internal/config/defaults_test.go
@@ -65,7 +65,7 @@ func TestApplyDefaults_NestedTerraformDefaults(t *testing.T) {
 	applyDefaults(cfg)
 
 	tf := cfg.Clusters[0].Terraform
-	assert.Equal(t, TerraformProviderStackit, tf.Provider, "Provider should default to stackit")
+	assert.Equal(t, TerraformProviderNone, tf.Provider, "Provider should default to none")
 	assert.Equal(t, "ske", tf.KubernetesType, "KubernetesType should default to ske")
 }
 

--- a/src/internal/config/defaults_test.go
+++ b/src/internal/config/defaults_test.go
@@ -65,7 +65,7 @@ func TestApplyDefaults_NestedTerraformDefaults(t *testing.T) {
 	applyDefaults(cfg)
 
 	tf := cfg.Clusters[0].Terraform
-	assert.Equal(t, "stackit", tf.Provider, "Provider should default to stackit")
+	assert.Equal(t, TerraformProviderStackit, tf.Provider, "Provider should default to stackit")
 	assert.Equal(t, "ske", tf.KubernetesType, "KubernetesType should default to ske")
 }
 

--- a/src/internal/config/factory.go
+++ b/src/internal/config/factory.go
@@ -45,7 +45,7 @@ func NewClusterFromEnvWithCatalog(e *envconfig.EnvMap, catalogOptions catalog.Lo
 		SSOTeam:          "<my-team>",
 		IngressClassName: "traefik",
 		Terraform: &Terraform{
-			Provider:          TerraformProviderPlaceholder,
+			Provider:          TerraformProviderNone,
 			ProjectID:         "<project-id>",
 			KubernetesType:    "<edge or ske>",
 			KubernetesVersion: "1.34",

--- a/src/internal/config/factory.go
+++ b/src/internal/config/factory.go
@@ -45,7 +45,7 @@ func NewClusterFromEnvWithCatalog(e *envconfig.EnvMap, catalogOptions catalog.Lo
 		SSOTeam:          "<my-team>",
 		IngressClassName: "traefik",
 		Terraform: &Terraform{
-			Provider:          "<provider>",
+			Provider:          TerraformProviderPlaceholder,
 			ProjectID:         "<project-id>",
 			KubernetesType:    "<edge or ske>",
 			KubernetesVersion: "1.34",

--- a/src/internal/config/factory_test.go
+++ b/src/internal/config/factory_test.go
@@ -48,7 +48,7 @@ func TestNewClusterFromEnv(t *testing.T) {
 		SSOTeam:          "<my-team>",
 		IngressClassName: "traefik",
 		Terraform: &Terraform{
-			Provider:          "<provider>",
+			Provider:          TerraformProviderNone,
 			ProjectID:         "<project-id>",
 			KubernetesType:    "<edge or ske>",
 			KubernetesVersion: "1.34",

--- a/src/internal/config/store.go
+++ b/src/internal/config/store.go
@@ -71,6 +71,7 @@ func (cs *ConfigStore) Load() error {
 	}
 
 	applyDefaults(cs.config)
+	normalizeDisabledTerraform(cs.config)
 	if err := cs.applyServiceCatalogDefaults(); err != nil {
 		return fmt.Errorf("apply service catalog defaults: %w", err)
 	}
@@ -86,6 +87,15 @@ func (cs *ConfigStore) Load() error {
 	}
 
 	return nil
+}
+
+func normalizeDisabledTerraform(cfg *Config) {
+	for idx := range cfg.Clusters {
+		terraform := cfg.Clusters[idx].Terraform
+		if terraform != nil && terraform.Provider == TerraformProviderNone {
+			cfg.Clusters[idx].Terraform = nil
+		}
+	}
 }
 
 func isLegacyConfig(raw map[string]any) bool {
@@ -328,11 +338,43 @@ func generateSchemaWithCatalog(cat catalog.Catalog) (map[string]any, error) {
 		return nil, fmt.Errorf("unmarshal schema: %w", err)
 	}
 	ensureServiceConfigDefinition(schemaDoc)
+	allowDisabledTerraformSchema(schemaDoc)
 	if err := composeServiceSchema(schemaDoc, cat); err != nil {
 		return nil, fmt.Errorf("compose service schema: %w", err)
 	}
 
 	return schemaDoc, nil
+}
+
+func allowDisabledTerraformSchema(schemaDoc map[string]any) {
+	defs, ok := schemaDoc["$defs"].(map[string]any)
+	if !ok {
+		return
+	}
+
+	terraform, ok := defs["Terraform"].(map[string]any)
+	if !ok {
+		return
+	}
+
+	required, ok := terraform["required"].([]any)
+	if !ok || len(required) == 0 {
+		return
+	}
+
+	terraform["anyOf"] = []any{
+		map[string]any{
+			"properties": map[string]any{
+				"provider": map[string]any{
+					"const": string(TerraformProviderNone),
+				},
+			},
+		},
+		map[string]any{
+			"required": required,
+		},
+	}
+	delete(terraform, "required")
 }
 
 // ensureServiceConfigDefinition ensures that for every service the

--- a/src/internal/config/store_test.go
+++ b/src/internal/config/store_test.go
@@ -647,6 +647,44 @@ func TestGenerateSchema(t *testing.T) {
 	}
 }
 
+func TestGenerateSchema_TerraformProviderNoneAllowsMissingTerraformDetails(t *testing.T) {
+	schemaDoc, err := GenerateSchemaWithCatalog(catalog.LoadOptions{})
+	require.NoError(t, err)
+
+	const schemaURL = "mem://config.schema.json"
+	c := schemaValidator.NewCompiler()
+	c.AssertFormat()
+	require.NoError(t, c.AddResource(schemaURL, schemaDoc))
+
+	compiled, err := c.Compile(schemaURL)
+	require.NoError(t, err)
+
+	validNoneConfig := configInstance(t, newValidTestConfig())
+	cluster := validNoneConfig["clusters"].([]any)[0].(map[string]any)
+	cluster["terraform"] = map[string]any{
+		"provider": "none",
+	}
+	assert.NoError(t, compiled.Validate(validNoneConfig))
+
+	invalidStackitConfig := configInstance(t, newValidTestConfig())
+	cluster = invalidStackitConfig["clusters"].([]any)[0].(map[string]any)
+	cluster["terraform"] = map[string]any{
+		"provider": "stackit",
+	}
+	assert.Error(t, compiled.Validate(invalidStackitConfig))
+}
+
+func configInstance(t *testing.T, cfg *Config) map[string]any {
+	t.Helper()
+
+	data, err := json.Marshal(cfg)
+	require.NoError(t, err)
+
+	var instance map[string]any
+	require.NoError(t, json.Unmarshal(data, &instance))
+	return instance
+}
+
 func TestGenerateSchema_ComposesCatalogServiceKeys(t *testing.T) {
 	schemaDoc, err := GenerateSchemaWithCatalog(catalog.LoadOptions{})
 	require.NoError(t, err)
@@ -713,4 +751,31 @@ clusters:
 	assert.Equal(t, "traefik", c.IngressClassName, "IngressClassName should be defaulted")
 
 	assert.NoError(t, cs.validate(), "Validate should pass after defaults are applied")
+}
+
+func TestLoadAndValidate_TerraformProviderNoneDisablesTerraform(t *testing.T) {
+	configYAML := `
+clusters:
+  - name: helm-only-cluster
+    dnsName: helm-only.example.com
+    terraform:
+      provider: none
+    argocd:
+      repo:
+        https:
+          customer:
+            url: "https://github.com/customer/repo.git"
+          managed:
+            url: "https://github.com/managed/repo.git"
+`
+
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, "config.yaml")
+	require.NoError(t, os.WriteFile(configPath, []byte(configYAML), 0644))
+
+	cs := NewConfigStoreWithCatalog(configPath, catalog.LoadOptions{})
+	require.NoError(t, cs.Load())
+
+	require.Len(t, cs.GetConfig().Clusters, 1)
+	assert.Nil(t, cs.GetConfig().Clusters[0].Terraform)
 }

--- a/src/internal/config/store_test.go
+++ b/src/internal/config/store_test.go
@@ -350,6 +350,11 @@ func TestConfigStore_Validate(t *testing.T) {
 	invalidConfigEnumMismatch := deepCopyConfig(validConfig)
 	invalidConfigEnumMismatch.Clusters[0].Type = "invalid-type"
 
+	invalidConfigProviderEnumMismatch := deepCopyConfig(validConfig)
+	clonedTerraformProvider := *invalidConfigProviderEnumMismatch.Clusters[0].Terraform
+	clonedTerraformProvider.Provider = TerraformProvider("unknown")
+	invalidConfigProviderEnumMismatch.Clusters[0].Terraform = &clonedTerraformProvider
+
 	// Test format validation (email)
 	invalidConfigFormatMismatch := deepCopyConfig(validConfig)
 	clonedTerraform := *invalidConfigFormatMismatch.Clusters[0].Terraform
@@ -405,6 +410,11 @@ func TestConfigStore_Validate(t *testing.T) {
 		{
 			name:    "invalid_config_should_fail_on_enum_mismatch",
 			config:  invalidConfigEnumMismatch,
+			wantErr: true,
+		},
+		{
+			name:    "invalid_config_should_fail_on_provider_enum_mismatch",
+			config:  invalidConfigProviderEnumMismatch,
 			wantErr: true,
 		},
 		{

--- a/src/internal/config/types.go
+++ b/src/internal/config/types.go
@@ -1,6 +1,10 @@
 package config
 
-import "github.com/kubara-io/kubara/internal/service"
+import (
+	"slices"
+
+	"github.com/kubara-io/kubara/internal/service"
+)
 
 const ConfigVersionV1Alpha1 = "v1alpha1"
 
@@ -8,8 +12,8 @@ const ConfigVersionV1Alpha1 = "v1alpha1"
 type TerraformProvider string
 
 const (
-	TerraformProviderPlaceholder TerraformProvider = "<provider>"
-	TerraformProviderStackit     TerraformProvider = "stackit"
+	TerraformProviderNone    TerraformProvider = "none"
+	TerraformProviderStackit TerraformProvider = "stackit"
 )
 
 var supportedTerraformProviders = [...]TerraformProvider{
@@ -18,12 +22,7 @@ var supportedTerraformProviders = [...]TerraformProvider{
 
 // IsSupported reports whether kubara ships Terraform templates for the provider.
 func (p TerraformProvider) IsSupported() bool {
-	for _, supported := range supportedTerraformProviders {
-		if p == supported {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(supportedTerraformProviders[:], p)
 }
 
 // SupportedTerraformProviders returns the providers with embedded Terraform templates.
@@ -58,7 +57,7 @@ type Cluster struct {
 }
 
 type Terraform struct {
-	Provider          TerraformProvider `json:"provider" yaml:"provider" jsonschema:"title=Cloud Provider,description=Infrastructure provider used for Terraform templates. Currently supported providers: stackit.,enum=<provider>,enum=stackit,default=stackit"`
+	Provider          TerraformProvider `json:"provider" yaml:"provider" jsonschema:"title=Cloud Provider,description=Infrastructure provider used for Terraform templates. Use none to skip Terraform generation. Currently supported providers: stackit.,enum=none,enum=stackit,default=none"`
 	ProjectID         string            `json:"projectId" yaml:"projectId" jsonschema:"required,title=Cloud Project ID,description=The cloud provider project or subscription identifier. Accepts various formats depending on the provider.,minLength=1"`
 	KubernetesType    string            `json:"kubernetesType" yaml:"kubernetesType" jsonschema:"title=Kubernetes Type,description=The type of Kubernetes cluster.,enum=edge,enum=ske,default=ske"`
 	KubernetesVersion string            `json:"kubernetesVersion" yaml:"kubernetesVersion" jsonschema:"required,title=Kubernetes Version,description=The Kubernetes version for the cluster.,example=1.34,pattern=^[0-9]\\.[0-9]+(\\.[0-9]+)?$"`

--- a/src/internal/config/types.go
+++ b/src/internal/config/types.go
@@ -4,6 +4,33 @@ import "github.com/kubara-io/kubara/internal/service"
 
 const ConfigVersionV1Alpha1 = "v1alpha1"
 
+// TerraformProvider identifies an infrastructure provider with embedded Terraform templates.
+type TerraformProvider string
+
+const (
+	TerraformProviderPlaceholder TerraformProvider = "<provider>"
+	TerraformProviderStackit     TerraformProvider = "stackit"
+)
+
+var supportedTerraformProviders = [...]TerraformProvider{
+	TerraformProviderStackit,
+}
+
+// IsSupported reports whether kubara ships Terraform templates for the provider.
+func (p TerraformProvider) IsSupported() bool {
+	for _, supported := range supportedTerraformProviders {
+		if p == supported {
+			return true
+		}
+	}
+	return false
+}
+
+// SupportedTerraformProviders returns the providers with embedded Terraform templates.
+func SupportedTerraformProviders() []TerraformProvider {
+	return append([]TerraformProvider(nil), supportedTerraformProviders[:]...)
+}
+
 // Config is the root of the configuration structure.
 type Config struct {
 	Version  string    `json:"version,omitempty" yaml:"version,omitempty" jsonschema:"title=Config Version,description=The schema version of this config file.,enum=v1alpha1,default=v1alpha1"`
@@ -31,11 +58,11 @@ type Cluster struct {
 }
 
 type Terraform struct {
-	Provider          string `json:"provider" yaml:"provider" jsonschema:"title=Cloud Provider,description=Infrastructure provider used for Terraform templates. Currently supported providers: stackit.,minLength=1,default=stackit"`
-	ProjectID         string `json:"projectId" yaml:"projectId" jsonschema:"required,title=Cloud Project ID,description=The cloud provider project or subscription identifier. Accepts various formats depending on the provider.,minLength=1"`
-	KubernetesType    string `json:"kubernetesType" yaml:"kubernetesType" jsonschema:"title=Kubernetes Type,description=The type of Kubernetes cluster.,enum=edge,enum=ske,default=ske"`
-	KubernetesVersion string `json:"kubernetesVersion" yaml:"kubernetesVersion" jsonschema:"required,title=Kubernetes Version,description=The Kubernetes version for the cluster.,example=1.34,pattern=^[0-9]\\.[0-9]+(\\.[0-9]+)?$"`
-	DNS               DNS    `json:"dns" yaml:"dns" jsonschema:"required,title=DNS Config,description=DNS Zone configuration"`
+	Provider          TerraformProvider `json:"provider" yaml:"provider" jsonschema:"title=Cloud Provider,description=Infrastructure provider used for Terraform templates. Currently supported providers: stackit.,enum=<provider>,enum=stackit,default=stackit"`
+	ProjectID         string            `json:"projectId" yaml:"projectId" jsonschema:"required,title=Cloud Project ID,description=The cloud provider project or subscription identifier. Accepts various formats depending on the provider.,minLength=1"`
+	KubernetesType    string            `json:"kubernetesType" yaml:"kubernetesType" jsonschema:"title=Kubernetes Type,description=The type of Kubernetes cluster.,enum=edge,enum=ske,default=ske"`
+	KubernetesVersion string            `json:"kubernetesVersion" yaml:"kubernetesVersion" jsonschema:"required,title=Kubernetes Version,description=The Kubernetes version for the cluster.,example=1.34,pattern=^[0-9]\\.[0-9]+(\\.[0-9]+)?$"`
+	DNS               DNS               `json:"dns" yaml:"dns" jsonschema:"required,title=DNS Config,description=DNS Zone configuration"`
 }
 
 type DNS struct {

--- a/src/internal/config/types_test.go
+++ b/src/internal/config/types_test.go
@@ -11,6 +11,6 @@ func TestTerraformProviderIsSupported(t *testing.T) {
 		assert.True(t, provider.IsSupported(), "listed provider %q must be supported", provider)
 	}
 
-	assert.False(t, TerraformProviderPlaceholder.IsSupported())
+	assert.False(t, TerraformProviderNone.IsSupported())
 	assert.False(t, TerraformProvider("unknown").IsSupported())
 }

--- a/src/internal/config/types_test.go
+++ b/src/internal/config/types_test.go
@@ -1,0 +1,16 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTerraformProviderIsSupported(t *testing.T) {
+	for _, provider := range SupportedTerraformProviders() {
+		assert.True(t, provider.IsSupported(), "listed provider %q must be supported", provider)
+	}
+
+	assert.False(t, TerraformProviderPlaceholder.IsSupported())
+	assert.False(t, TerraformProvider("unknown").IsSupported())
+}

--- a/src/internal/render/render.go
+++ b/src/internal/render/render.go
@@ -34,12 +34,6 @@ const (
 
 var templatesFSNew fs.FS = catalog.BuiltInFS()
 
-// SupportedProviders lists every provider that has embedded templates.
-// Add new entries here when introducing provider-specific template directories.
-var SupportedProviders = map[string]bool{
-	"stackit": true,
-}
-
 var templateName = map[TemplateType]string{
 	Terraform: "terraform",
 	Helm:      "helm",
@@ -50,6 +44,9 @@ func TemplateFiles(options TemplateOptions) ([]TemplateResult, error) {
 	fileList, err := getTemplateFiles(options)
 	if err != nil {
 		return nil, fmt.Errorf("get template files for provider %q: %w", options.Provider, err)
+	}
+	if err := rejectHelmProviderPaths(fileList); err != nil {
+		return nil, err
 	}
 
 	selected, err := selectTemplateFilesForProvider(fileList, options.Provider, options.Overwrite)
@@ -250,6 +247,25 @@ func normalizeProviderName(provider string) string {
 	return strings.ToLower(strings.TrimSpace(provider))
 }
 
+func isHelmProviderPath(relPath string) bool {
+	parts := strings.Split(filepath.ToSlash(relPath), "/")
+	for idx := 1; idx < len(parts); idx++ {
+		if parts[idx] == providerFolderName && parts[idx-1] == Helm.String() {
+			return true
+		}
+	}
+	return false
+}
+
+func rejectHelmProviderPaths(files []templateFile) error {
+	for _, file := range files {
+		if isHelmProviderPath(file.sourcePath) {
+			return fmt.Errorf("helm provider template directories are not supported: %q", file.sourcePath)
+		}
+	}
+	return nil
+}
+
 func splitProviderPath(relPath string) (string, string, bool) {
 	normalized := filepath.ToSlash(relPath)
 	parts := strings.Split(normalized, "/")
@@ -259,10 +275,10 @@ func splitProviderPath(relPath string) (string, string, bool) {
 		}
 
 		// Only treat this segment as a provider selector when it appears
-		// directly inside a template-type directory (terraform or helm).
+		// directly inside the Terraform template directory.
 		// This prevents stripping unrelated "providers/<x>" segments that
 		// may appear elsewhere in the path.
-		if idx == 0 || (parts[idx-1] != "terraform" && parts[idx-1] != "helm") {
+		if idx == 0 || parts[idx-1] != Terraform.String() {
 			continue
 		}
 
@@ -279,8 +295,8 @@ func splitProviderPath(relPath string) (string, string, bool) {
 	return normalized, "", false
 }
 
-// StripProviderPath removes a provider selector segment from a relative
-// template path (e.g. ".../providers/stackit/...") if present.
+// StripProviderPath removes a Terraform provider selector segment from a
+// relative template path (e.g. ".../terraform/providers/stackit/...") if present.
 func StripProviderPath(relPath string) string {
 	stripped, _, _ := splitProviderPath(relPath)
 	return stripped

--- a/src/internal/render/render.go
+++ b/src/internal/render/render.go
@@ -45,9 +45,6 @@ func TemplateFiles(options TemplateOptions) ([]TemplateResult, error) {
 	if err != nil {
 		return nil, fmt.Errorf("get template files for provider %q: %w", options.Provider, err)
 	}
-	if err := rejectHelmProviderPaths(fileList); err != nil {
-		return nil, err
-	}
 
 	selected, err := selectTemplateFilesForProvider(fileList, options.Provider, options.Overwrite)
 	if err != nil {
@@ -245,25 +242,6 @@ func getTemplateFiles(options TemplateOptions) ([]templateFile, error) {
 
 func normalizeProviderName(provider string) string {
 	return strings.ToLower(strings.TrimSpace(provider))
-}
-
-func isHelmProviderPath(relPath string) bool {
-	parts := strings.Split(filepath.ToSlash(relPath), "/")
-	for idx := 1; idx < len(parts); idx++ {
-		if parts[idx] == providerFolderName && parts[idx-1] == Helm.String() {
-			return true
-		}
-	}
-	return false
-}
-
-func rejectHelmProviderPaths(files []templateFile) error {
-	for _, file := range files {
-		if isHelmProviderPath(file.sourcePath) {
-			return fmt.Errorf("helm provider template directories are not supported: %q", file.sourcePath)
-		}
-	}
-	return nil
 }
 
 func splitProviderPath(relPath string) (string, string, bool) {

--- a/src/internal/render/render_test.go
+++ b/src/internal/render/render_test.go
@@ -129,7 +129,7 @@ func TestStripProviderPath(t *testing.T) {
 			want:  "managed-service-catalog/terraform/images/public-cloud-0.png",
 		},
 		{
-			name:  "does not strip providers/<name> outside terraform or helm context",
+			name:  "does not strip providers/<name> outside terraform context",
 			input: "some-catalog/providers/stackit/file.txt",
 			want:  "some-catalog/providers/stackit/file.txt",
 		},

--- a/src/internal/workflow/orchestrator.go
+++ b/src/internal/workflow/orchestrator.go
@@ -19,7 +19,9 @@ func CreateOrUpdateClusterFromEnvWithCatalog(cfg *config.Config, e *envconfig.En
 			// Apply the new values from the environment to the found cluster.
 			cfg.Clusters[i].Stage = e.ProjectStage
 			cfg.Clusters[i].DNSName = dnsName
-			cfg.Clusters[i].Terraform.DNS.Name = dnsName
+			if cfg.Clusters[i].Terraform != nil {
+				cfg.Clusters[i].Terraform.DNS.Name = dnsName
+			}
 			cfg.Clusters[i].ArgoCD.Repo.HTTPS.Managed.URL = e.ArgocdGitHttpsUrl
 			cfg.Clusters[i].ArgoCD.Repo.HTTPS.Customer.URL = e.ArgocdGitHttpsUrl
 			if envconfig.IsConfiguredEnvValue(e.ArgocdHelmRepoUrl) {

--- a/src/internal/workflow/orchestrator_test.go
+++ b/src/internal/workflow/orchestrator_test.go
@@ -63,6 +63,50 @@ func TestCreateOrUpdateClusterFromEnv_UpdatesExistingClusterIncludingHelmRepo(t 
 	assert.Equal(t, "https://charts.example.com", updated.ArgoCD.HelmRepo.URL)
 }
 
+func TestCreateOrUpdateClusterFromEnv_UpdatesExistingClusterWithoutTerraform(t *testing.T) {
+	cfg := &config.Config{
+		Clusters: []config.Cluster{
+			{
+				Name:      "kubara-test",
+				Stage:     "stage",
+				DNSName:   "kubara-test-stage.example.com",
+				Terraform: nil,
+				ArgoCD: config.ArgoCD{
+					Repo: config.RepoProto{
+						HTTPS: &config.RepoType{
+							Customer: config.Repository{
+								URL:            "https://github.com/old/repo.git",
+								TargetRevision: "main",
+							},
+							Managed: config.Repository{
+								URL:            "https://github.com/old/repo.git",
+								TargetRevision: "main",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	e := &envconfig.EnvMap{
+		ProjectName:       "kubara-test",
+		ProjectStage:      "dev",
+		DomainName:        "example.com",
+		ArgocdGitHttpsUrl: "https://github.com/new/repo.git",
+	}
+
+	err := CreateOrUpdateClusterFromEnvWithCatalog(cfg, e, catalog.LoadOptions{})
+	require.NoError(t, err)
+
+	require.Len(t, cfg.Clusters, 1)
+	updated := cfg.Clusters[0]
+	assert.Equal(t, "dev", updated.Stage)
+	assert.Equal(t, "kubara-test-dev.example.com", updated.DNSName)
+	assert.Nil(t, updated.Terraform)
+	assert.Equal(t, "https://github.com/new/repo.git", updated.ArgoCD.Repo.HTTPS.Managed.URL)
+	assert.Equal(t, "https://github.com/new/repo.git", updated.ArgoCD.Repo.HTTPS.Customer.URL)
+}
+
 func TestCreateOrUpdateClusterFromEnv_CreatesNewClusterWithHelmRepo(t *testing.T) {
 	cfg := &config.Config{}
 	e := &envconfig.EnvMap{


### PR DESCRIPTION
## 📝 Summary
<!-- Please read first: https://github.com/kubara-io/kubara/blob/main/CONTRIBUTING.md -->

Prepares the first small split from #370 by refactoring the built-in ExternalDNS Helm values for provider-specific configuration.

The existing Stackit-specific ExternalDNS settings are now rendered conditionally from `terraform.provider`, while provider-independent values remain shared. This establishes the supported pattern for adding further provider-specific ExternalDNS configuration without duplicating complete Helm values files.

Additional changes made while preparing this split and addressing review feedback:
- Treat provider-specific template directories only under `terraform/providers/<provider>/`; Helm provider behavior stays in shared values templates or charts.
- Introduce a dedicated `TerraformProvider` type and centralize supported Terraform provider validation.
- Introduce `terraform.provider: none` as the default to support clusters without Terraform-managed infrastructure.
- Skip Terraform template generation for clusters without Terraform config during default `kubara generate`.
- Keep `kubara generate --terraform` strict and require a supported Terraform provider.
- Avoid rendering a provider-derived Velero `VolumeSnapshotClass` when Terraform is disabled.
- Handle existing clusters without Terraform during `kubara init --overwrite`.
- Document the Terraform-only provider template layout and the catalog boundary for app-specific behavior.

## 🧩 Type of change
- [x] 🔧 CLI / Go code
- [x] 📦 Helm chart
- [ ] 🧱 Terraform module
- [x] 📝 Documentation
- [x] 🧪 Test or CI change
- [x] ♻️ Refactor / cleanup

## ⚠️ Is this a breaking change?
- [ ] Yes, this change breaks existing functionality (explain in summary)

No intended breaking changes to supported behavior. Existing Stackit ExternalDNS values are preserved when `terraform.provider: stackit` is configured.

Clusters without Terraform config, or with `terraform.provider: none`, can now use the default `kubara generate` flow without forcing `--helm`.

## 🧪 Testing
- [x] CI passed
- [ ] Manually tested (local/dev cluster)
- [x] Unit tested
- [ ] Not tested (explain why below)

Ran locally:
- `cd src && make test`
- `cd src && go test ./internal/workflow ./cmd ./internal/config ./internal/render -count=1`
- `make docs-validate`
- `git diff --check`

## 🔗 Related Issues / Tickets
- First preparatory split from #370
- Follow-up to #167

## ✅ Checklist
- [x] Code compiles and passes all tests
- [x] Linting and style checks pass
- [x] Comments added for complex logic
- [x] Documentation updated (if applicable)

## 📎 Additional Context (optional)
This PR intentionally covers the ExternalDNS values preparation plus the provider handling needed to make `terraform.provider: none` a valid no-Terraform state.

It does not include T Cloud Public provider registration, OpenBao integration, Terraform modules, or the remaining provider-specific Helm changes from #370.
