### PR TITLE
refactor!: standardize secret path layout

### DIFF
--- a/docs/content/1_getting_started/bootstrapping.md
+++ b/docs/content/1_getting_started/bootstrapping.md
@@ -272,6 +272,12 @@ spec:
       version: v2
 ```
 
+Kubara scopes secret paths by cluster and stage. Namespace-specific secrets use
+`<cluster-name>/<stage>/<namespace>/<secret>`, while cluster-wide secrets use
+`<cluster-name>/<stage>/<secret>`. For example, Grafana credentials for the
+`controlplane` production cluster live at
+`controlplane/production/kube-prometheus-stack/grafana_credentials`.
+
 ```bash
 kubara bootstrap <cluster-name-from-config-yaml> --with-es-crds --with-prometheus-crds
 ```

--- a/docs/content/1_getting_started/bootstrapping.md
+++ b/docs/content/1_getting_started/bootstrapping.md
@@ -274,7 +274,7 @@ spec:
 
 kubara scopes secret paths by cluster and stage. Namespace-specific secrets use
 `<cluster-name>/<stage>/<namespace>/<secret>`, while cluster-wide secrets use
-`<cluster-name>/<stage>/<secret>`. For example, Grafana credentials for the
+`<cluster-name>/<stage>/cluster_secrets/<secret>`. For example, Grafana credentials for the
 `controlplane` production cluster live at
 `controlplane/production/kube-prometheus-stack/grafana_credentials`.
 

--- a/docs/content/1_getting_started/bootstrapping.md
+++ b/docs/content/1_getting_started/bootstrapping.md
@@ -272,7 +272,7 @@ spec:
       version: v2
 ```
 
-Kubara scopes secret paths by cluster and stage. Namespace-specific secrets use
+kubara scopes secret paths by cluster and stage. Namespace-specific secrets use
 `<cluster-name>/<stage>/<namespace>/<secret>`, while cluster-wide secrets use
 `<cluster-name>/<stage>/<secret>`. For example, Grafana credentials for the
 `controlplane` production cluster live at

--- a/docs/content/2_managing_your_platform/add_spoke_cluster.md
+++ b/docs/content/2_managing_your_platform/add_spoke_cluster.md
@@ -178,7 +178,7 @@ bootstrapValues:
     - name: my-new-spoke-0
       project: hub-production
       remoteRef:
-        remoteKey: my_clusters
+        remoteKey: <hub-cluster-name>/<stage>/argocd/my_clusters
         remoteKeyProperty: k8s-spoke-0
       secretStoreRef:
         kind: ClusterSecretStore

--- a/docs/content/2_managing_your_platform/argocd/add_app_repository.md
+++ b/docs/content/2_managing_your_platform/argocd/add_app_repository.md
@@ -7,7 +7,8 @@ For more information check:
 https://argo-cd.readthedocs.io/en/stable/user-guide/private-repositories/
 
 ## **Add credentials to vault**
-Add the repository credentials to your vault. This can be a `password` or a `PAT`.
+Add the repository credentials to your vault at
+`<cluster-name>/<stage>/argocd/repo_pat`. This can be a `password` or a `PAT`.
 ```json
 {
   "repo_pat": {
@@ -23,7 +24,7 @@ repositories:
       projectScope: k8s-spoke-0
       # # This points to the secret in vault
       remoteRef:
-        remoteKey: repo_pat
+        remoteKey: <cluster-name>/<stage>/argocd/repo_pat
         remoteKeyProperty: pat
       repoType: git
       secretStoreRef:

--- a/docs/content/3_components/backup_and_recovery.md
+++ b/docs/content/3_components/backup_and_recovery.md
@@ -86,7 +86,7 @@ clusters:
 
 For STACKIT, `backupStorage.create: true` makes kubara generate the dedicated Object Storage bucket (`bucket-velero-<name>-<stage>`) and credentials group. The bucket region defaults to `eu01` and can be changed through `backupStorage.region`. Set `backupStorage.s3Url` to the matching S3 endpoint for that region.
 
-The generated Terraform writes the S3-compatible credentials into STACKIT Secrets Manager at path `velero_s3_credentials`, key `cloud`, in the form:
+The generated Terraform writes the S3-compatible credentials into STACKIT Secrets Manager at path `velero/velero_s3_credentials`, key `cloud`, in the form:
 
 ```toml
 [default]
@@ -107,7 +107,7 @@ config:
     s3Url: https://s3.example.com
 ```
 
-With `backupStorage.create: false`, kubara does not generate the Terraform bucket or credentials. Provide the S3-compatible credentials yourself in your secret backend at path `velero_s3_credentials`, key `cloud`, using the same format shown above.
+With `backupStorage.create: false`, kubara does not generate the Terraform bucket or credentials. Provide the S3-compatible credentials yourself in your secret backend at path `velero/velero_s3_credentials`, key `cloud`, using the same format shown above.
 
 Then:
 

--- a/docs/content/3_components/backup_and_recovery.md
+++ b/docs/content/3_components/backup_and_recovery.md
@@ -86,7 +86,7 @@ clusters:
 
 For STACKIT, `backupStorage.create: true` makes kubara generate the dedicated Object Storage bucket (`bucket-velero-<name>-<stage>`) and credentials group. The bucket region defaults to `eu01` and can be changed through `backupStorage.region`. Set `backupStorage.s3Url` to the matching S3 endpoint for that region.
 
-The generated Terraform writes the S3-compatible credentials into STACKIT Secrets Manager at path `velero/velero_s3_credentials`, key `cloud`, in the form:
+The generated Terraform writes the S3-compatible credentials into STACKIT Secrets Manager at path `<cluster-name>/<stage>/velero/velero_s3_credentials`, key `cloud`, in the form:
 
 ```toml
 [default]
@@ -107,7 +107,7 @@ config:
     s3Url: https://s3.example.com
 ```
 
-With `backupStorage.create: false`, kubara does not generate the Terraform bucket or credentials. Provide the S3-compatible credentials yourself in your secret backend at path `velero/velero_s3_credentials`, key `cloud`, using the same format shown above.
+With `backupStorage.create: false`, kubara does not generate the Terraform bucket or credentials. Provide the S3-compatible credentials yourself in your secret backend at path `<cluster-name>/<stage>/velero/velero_s3_credentials`, key `cloud`, using the same format shown above.
 
 Then:
 

--- a/src/internal/catalog/built-in/customer-service-catalog/helm/example/argo-cd/values.yaml.tplt
+++ b/src/internal/catalog/built-in/customer-service-catalog/helm/example/argo-cd/values.yaml.tplt
@@ -10,7 +10,7 @@ bootstrapValues:
         kind: ClusterSecretStore
         name: "{{ .cluster.name }}-{{ .cluster.stage }}"
       remoteRef:
-        remoteKey: docker_config
+        remoteKey: {{ .cluster.name }}/{{ .cluster.stage }}/docker_config
         remoteKeyProperty: pull-secret
   projects:
     {{ .cluster.name }}-{{ .cluster.stage }}:
@@ -74,7 +74,7 @@ externalSecrets:
     oauth2-credentials:
       secretStoreRef: {{ .cluster.name }}-{{ .cluster.stage }}
       dataFrom:
-        - remoteKey: argocd/argo_oauth2_credentials
+        - remoteKey: {{ .cluster.name }}/{{ .cluster.stage }}/argocd/argo_oauth2_credentials
 {{ end }}
 
 {{- $oauth2ProxyStatus := dig "cluster" "services" "oauth2-proxy" "status" "disabled" . -}}

--- a/src/internal/catalog/built-in/customer-service-catalog/helm/example/argo-cd/values.yaml.tplt
+++ b/src/internal/catalog/built-in/customer-service-catalog/helm/example/argo-cd/values.yaml.tplt
@@ -74,7 +74,7 @@ externalSecrets:
     oauth2-credentials:
       secretStoreRef: {{ .cluster.name }}-{{ .cluster.stage }}
       dataFrom:
-        - remoteKey: argo_oauth2_credentials
+        - remoteKey: argocd/argo_oauth2_credentials
 {{ end }}
 
 {{- $oauth2ProxyStatus := dig "cluster" "services" "oauth2-proxy" "status" "disabled" . -}}

--- a/src/internal/catalog/built-in/customer-service-catalog/helm/example/argo-cd/values.yaml.tplt
+++ b/src/internal/catalog/built-in/customer-service-catalog/helm/example/argo-cd/values.yaml.tplt
@@ -10,7 +10,7 @@ bootstrapValues:
         kind: ClusterSecretStore
         name: "{{ .cluster.name }}-{{ .cluster.stage }}"
       remoteRef:
-        remoteKey: {{ .cluster.name }}/{{ .cluster.stage }}/docker_config
+        remoteKey: {{ .cluster.name }}/{{ .cluster.stage }}/cluster_secrets/docker_config
         remoteKeyProperty: pull-secret
   projects:
     {{ .cluster.name }}-{{ .cluster.stage }}:

--- a/src/internal/catalog/built-in/customer-service-catalog/helm/example/external-dns/values.yaml.tplt
+++ b/src/internal/catalog/built-in/customer-service-catalog/helm/example/external-dns/values.yaml.tplt
@@ -12,10 +12,10 @@ externalSecrets:
     external-dns-webhook:
       secretStoreRef: {{ .cluster.name }}-{{ .cluster.stage }}
       data:
-        - remoteKey: dns_zone_admin
+        - remoteKey: external-dns/dns_zone_admin
           remoteKeyProperty: project_id
           secretKey: PROJECT_ID
-        - remoteKey: dns_zone_admin
+        - remoteKey: external-dns/dns_zone_admin
           remoteKeyProperty: sa_key_json
           secretKey: SA_KEY_JSON
 

--- a/src/internal/catalog/built-in/customer-service-catalog/helm/example/external-dns/values.yaml.tplt
+++ b/src/internal/catalog/built-in/customer-service-catalog/helm/example/external-dns/values.yaml.tplt
@@ -12,10 +12,10 @@ externalSecrets:
     external-dns-webhook:
       secretStoreRef: {{ .cluster.name }}-{{ .cluster.stage }}
       data:
-        - remoteKey: external-dns/dns_zone_admin
+        - remoteKey: {{ .cluster.name }}/{{ .cluster.stage }}/external-dns/dns_zone_admin
           remoteKeyProperty: project_id
           secretKey: PROJECT_ID
-        - remoteKey: external-dns/dns_zone_admin
+        - remoteKey: {{ .cluster.name }}/{{ .cluster.stage }}/external-dns/dns_zone_admin
           remoteKeyProperty: sa_key_json
           secretKey: SA_KEY_JSON
 

--- a/src/internal/catalog/built-in/customer-service-catalog/helm/example/kube-prometheus-stack/values.yaml.tplt
+++ b/src/internal/catalog/built-in/customer-service-catalog/helm/example/kube-prometheus-stack/values.yaml.tplt
@@ -248,13 +248,13 @@ externalSecrets:
     grafana-admin-credentials:
       secretStoreRef: {{ .cluster.name }}-{{ .cluster.stage }}
       dataFrom:
-        - remoteKey: kube-prometheus-stack/grafana_credentials
+        - remoteKey: {{ .cluster.name }}/{{ .cluster.stage }}/kube-prometheus-stack/grafana_credentials
 
     {{- if (eq (index .cluster.services "oauth2-proxy" "status") "enabled") }}
     oauth2-credentials:
       secretStoreRef: {{ .cluster.name }}-{{ .cluster.stage }}
       dataFrom:
-        - remoteKey: kube-prometheus-stack/grafana_oauth2_credentials
+        - remoteKey: {{ .cluster.name }}/{{ .cluster.stage }}/kube-prometheus-stack/grafana_oauth2_credentials
     {{- end }}
 
 namespace:

--- a/src/internal/catalog/built-in/customer-service-catalog/helm/example/kube-prometheus-stack/values.yaml.tplt
+++ b/src/internal/catalog/built-in/customer-service-catalog/helm/example/kube-prometheus-stack/values.yaml.tplt
@@ -248,13 +248,13 @@ externalSecrets:
     grafana-admin-credentials:
       secretStoreRef: {{ .cluster.name }}-{{ .cluster.stage }}
       dataFrom:
-        - remoteKey: grafana_credentials
+        - remoteKey: kube-prometheus-stack/grafana_credentials
 
     {{- if (eq (index .cluster.services "oauth2-proxy" "status") "enabled") }}
     oauth2-credentials:
       secretStoreRef: {{ .cluster.name }}-{{ .cluster.stage }}
       dataFrom:
-        - remoteKey: grafana_oauth2_credentials
+        - remoteKey: kube-prometheus-stack/grafana_oauth2_credentials
     {{- end }}
 
 namespace:

--- a/src/internal/catalog/built-in/customer-service-catalog/helm/example/oauth2-proxy/values.yaml.tplt
+++ b/src/internal/catalog/built-in/customer-service-catalog/helm/example/oauth2-proxy/values.yaml.tplt
@@ -24,7 +24,7 @@ externalSecrets:
     oauth2-credentials:
       secretStoreRef: {{ .cluster.name }}-{{ .cluster.stage }}
       dataFrom:
-        - remoteKey: oauth2_credentials
+        - remoteKey: oauth2-proxy/oauth2_credentials
 
 
 oauth2-proxy:

--- a/src/internal/catalog/built-in/customer-service-catalog/helm/example/oauth2-proxy/values.yaml.tplt
+++ b/src/internal/catalog/built-in/customer-service-catalog/helm/example/oauth2-proxy/values.yaml.tplt
@@ -24,7 +24,7 @@ externalSecrets:
     oauth2-credentials:
       secretStoreRef: {{ .cluster.name }}-{{ .cluster.stage }}
       dataFrom:
-        - remoteKey: oauth2-proxy/oauth2_credentials
+        - remoteKey: {{ .cluster.name }}/{{ .cluster.stage }}/oauth2-proxy/oauth2_credentials
 
 
 oauth2-proxy:

--- a/src/internal/catalog/built-in/customer-service-catalog/helm/example/velero/values.yaml.tplt
+++ b/src/internal/catalog/built-in/customer-service-catalog/helm/example/velero/values.yaml.tplt
@@ -20,7 +20,7 @@ externalSecrets:
       # other key names need to be specified in the backupStorageLocation
       data:
         - secretKey: cloud
-          remoteKey: velero/velero_s3_credentials
+          remoteKey: {{ .cluster.name }}/{{ .cluster.stage }}/velero/velero_s3_credentials
           remoteKeyProperty: cloud
 
 velero:

--- a/src/internal/catalog/built-in/customer-service-catalog/helm/example/velero/values.yaml.tplt
+++ b/src/internal/catalog/built-in/customer-service-catalog/helm/example/velero/values.yaml.tplt
@@ -20,7 +20,7 @@ externalSecrets:
       # other key names need to be specified in the backupStorageLocation
       data:
         - secretKey: cloud
-          remoteKey: velero_s3_credentials
+          remoteKey: velero/velero_s3_credentials
           remoteKeyProperty: cloud
 
 velero:

--- a/src/internal/catalog/built-in/customer-service-catalog/terraform/providers/stackit/example/infrastructure/secrets.tf-example.tplt
+++ b/src/internal/catalog/built-in/customer-service-catalog/terraform/providers/stackit/example/infrastructure/secrets.tf-example.tplt
@@ -41,7 +41,7 @@ variable "grafana_oauth2_client_id" {
 # Secrets for image pull secret
 resource "vault_kv_secret_v2" "image_pull_secret" {
   mount = module.secretsmanager.instance_id #"<your_vault_instance_id>", in this example it comes from a TF module, but you can also just place your instance ID here
-  name  = "${var.name}/${var.stage}/docker_config"
+  name  = "${var.name}/${var.stage}/cluster_secrets/docker_config"
   data_json = jsonencode({
     pull-secret = base64decode(var.image_pull_secret)
   })

--- a/src/internal/catalog/built-in/customer-service-catalog/terraform/providers/stackit/example/infrastructure/secrets.tf-example.tplt
+++ b/src/internal/catalog/built-in/customer-service-catalog/terraform/providers/stackit/example/infrastructure/secrets.tf-example.tplt
@@ -41,7 +41,7 @@ variable "grafana_oauth2_client_id" {
 # Secrets for image pull secret
 resource "vault_kv_secret_v2" "image_pull_secret" {
   mount = module.secretsmanager.instance_id #"<your_vault_instance_id>", in this example it comes from a TF module, but you can also just place your instance ID here
-  name  = "docker_config"
+  name  = "${var.name}/${var.stage}/docker_config"
   data_json = jsonencode({
     pull-secret = base64decode(var.image_pull_secret)
   })
@@ -56,7 +56,7 @@ resource "random_password" "oauth2_cookie_secret" {
 # Secrets for connecting the "landing page" Oauth2 App and configuring Oauth2 Proxy
 resource "vault_kv_secret_v2" "oauth2_creds" {
   mount = module.secretsmanager.instance_id #"<your_vault_instance_id>", in this example it comes from a TF module, but you can also just place your instance ID here
-  name  = "oauth2-proxy/oauth2_credentials"
+  name  = "${var.name}/${var.stage}/oauth2-proxy/oauth2_credentials"
   data_json = jsonencode({
     cookie-secret = random_password.oauth2_cookie_secret.result
     client-secret = var.oauth2_client_secret
@@ -67,7 +67,7 @@ resource "vault_kv_secret_v2" "oauth2_creds" {
 # Secrets for connecting ArgoCD Oauth2 App
 resource "vault_kv_secret_v2" "argo_oauth2_creds" {
   mount = module.secretsmanager.instance_id #"<your_vault_instance_id>", in this example it comes from a TF module, but you can also just place your instance ID here
-  name  = "argocd/argo_oauth2_credentials"
+  name  = "${var.name}/${var.stage}/argocd/argo_oauth2_credentials"
   data_json = jsonencode({
     client-secret = var.argo_oauth2_client_secret
     client-id     = var.argo_oauth2_client_id
@@ -77,7 +77,7 @@ resource "vault_kv_secret_v2" "argo_oauth2_creds" {
 # Secrets for connecting Grafana Oauth2 App
 resource "vault_kv_secret_v2" "grafana_oauth2_creds" {
   mount = module.secretsmanager.instance_id #"<your_vault_instance_id>", in this example it comes from a TF module, but you can also just place your instance ID here
-  name  = "kube-prometheus-stack/grafana_oauth2_credentials"
+  name  = "${var.name}/${var.stage}/kube-prometheus-stack/grafana_oauth2_credentials"
   data_json = jsonencode({
     client-secret = var.grafana_oauth2_client_secret
     client-id     = var.grafana_oauth2_client_id

--- a/src/internal/catalog/built-in/customer-service-catalog/terraform/providers/stackit/example/infrastructure/secrets.tf-example.tplt
+++ b/src/internal/catalog/built-in/customer-service-catalog/terraform/providers/stackit/example/infrastructure/secrets.tf-example.tplt
@@ -56,7 +56,7 @@ resource "random_password" "oauth2_cookie_secret" {
 # Secrets for connecting the "landing page" Oauth2 App and configuring Oauth2 Proxy
 resource "vault_kv_secret_v2" "oauth2_creds" {
   mount = module.secretsmanager.instance_id #"<your_vault_instance_id>", in this example it comes from a TF module, but you can also just place your instance ID here
-  name  = "oauth2_credentials"
+  name  = "oauth2-proxy/oauth2_credentials"
   data_json = jsonencode({
     cookie-secret = random_password.oauth2_cookie_secret.result
     client-secret = var.oauth2_client_secret
@@ -67,7 +67,7 @@ resource "vault_kv_secret_v2" "oauth2_creds" {
 # Secrets for connecting ArgoCD Oauth2 App
 resource "vault_kv_secret_v2" "argo_oauth2_creds" {
   mount = module.secretsmanager.instance_id #"<your_vault_instance_id>", in this example it comes from a TF module, but you can also just place your instance ID here
-  name  = "argo_oauth2_credentials"
+  name  = "argocd/argo_oauth2_credentials"
   data_json = jsonencode({
     client-secret = var.argo_oauth2_client_secret
     client-id     = var.argo_oauth2_client_id
@@ -77,7 +77,7 @@ resource "vault_kv_secret_v2" "argo_oauth2_creds" {
 # Secrets for connecting Grafana Oauth2 App
 resource "vault_kv_secret_v2" "grafana_oauth2_creds" {
   mount = module.secretsmanager.instance_id #"<your_vault_instance_id>", in this example it comes from a TF module, but you can also just place your instance ID here
-  name  = "grafana_oauth2_credentials"
+  name  = "kube-prometheus-stack/grafana_oauth2_credentials"
   data_json = jsonencode({
     client-secret = var.grafana_oauth2_client_secret
     client-id     = var.grafana_oauth2_client_id

--- a/src/internal/catalog/built-in/customer-service-catalog/terraform/providers/stackit/example/infrastructure/secrets.tf.tplt
+++ b/src/internal/catalog/built-in/customer-service-catalog/terraform/providers/stackit/example/infrastructure/secrets.tf.tplt
@@ -16,7 +16,7 @@ resource "vault_kv_secret_v2" "cluster_secrets" {
 
 resource "vault_kv_secret_v2" "dns_zone_admin" {
   mount = module.secretsmanager.instance_id
-  name  = "dns_zone_admin"
+  name  = "external-dns/dns_zone_admin"
   data_json = jsonencode({
     sa_key_json = module.iam.service_account_key_json
     project_id  = var.project_id
@@ -28,7 +28,7 @@ resource "vault_kv_secret_v2" "dns_zone_admin" {
 {{ if (and (eq (index .cluster.services "velero" "status") "enabled") (index .cluster.services "velero" "config" "backupStorage" "create")) -}}
 resource "vault_kv_secret_v2" "velero_s3_credentials" {
   mount = module.secretsmanager.instance_id
-  name  = "velero_s3_credentials"
+  name  = "velero/velero_s3_credentials"
 
   data_json = jsonencode({
     cloud = "[default]\naws_access_key_id=${module.velero_bucket.credential_access_key}\naws_secret_access_key=${module.velero_bucket.credential_secret_access_key}\n"
@@ -49,7 +49,7 @@ resource "random_password" "grafana_admin_password" {
 }
 resource "vault_kv_secret_v2" "grafana_admin_credentials" {
   mount = module.secretsmanager.instance_id #"<your_vault_instance_id>", in this example it comes from a TF module, but you can also just place your instance ID here
-  name  = "grafana_credentials"
+  name  = "kube-prometheus-stack/grafana_credentials"
   data_json = jsonencode({
     admin-user     = local.grafana_admin_user
     admin-password = local.grafana_admin_password

--- a/src/internal/catalog/built-in/customer-service-catalog/terraform/providers/stackit/example/infrastructure/secrets.tf.tplt
+++ b/src/internal/catalog/built-in/customer-service-catalog/terraform/providers/stackit/example/infrastructure/secrets.tf.tplt
@@ -1,6 +1,6 @@
 resource "vault_kv_secret_v2" "cluster_secrets" {
   mount = module.secretsmanager.instance_id
-  name  = "${var.name}/${var.stage}/cluster_secrets"
+  name  = "${var.name}/${var.stage}/cluster_secrets/vault_instance"
 
   data_json = jsonencode({
     vault_instance = {

--- a/src/internal/catalog/built-in/customer-service-catalog/terraform/providers/stackit/example/infrastructure/secrets.tf.tplt
+++ b/src/internal/catalog/built-in/customer-service-catalog/terraform/providers/stackit/example/infrastructure/secrets.tf.tplt
@@ -1,6 +1,6 @@
 resource "vault_kv_secret_v2" "cluster_secrets" {
   mount = module.secretsmanager.instance_id
-  name  = "cluster_secrets"
+  name  = "${var.name}/${var.stage}/cluster_secrets"
 
   data_json = jsonencode({
     vault_instance = {
@@ -16,7 +16,7 @@ resource "vault_kv_secret_v2" "cluster_secrets" {
 
 resource "vault_kv_secret_v2" "dns_zone_admin" {
   mount = module.secretsmanager.instance_id
-  name  = "external-dns/dns_zone_admin"
+  name  = "${var.name}/${var.stage}/external-dns/dns_zone_admin"
   data_json = jsonencode({
     sa_key_json = module.iam.service_account_key_json
     project_id  = var.project_id
@@ -28,7 +28,7 @@ resource "vault_kv_secret_v2" "dns_zone_admin" {
 {{ if (and (eq (index .cluster.services "velero" "status") "enabled") (index .cluster.services "velero" "config" "backupStorage" "create")) -}}
 resource "vault_kv_secret_v2" "velero_s3_credentials" {
   mount = module.secretsmanager.instance_id
-  name  = "velero/velero_s3_credentials"
+  name  = "${var.name}/${var.stage}/velero/velero_s3_credentials"
 
   data_json = jsonencode({
     cloud = "[default]\naws_access_key_id=${module.velero_bucket.credential_access_key}\naws_secret_access_key=${module.velero_bucket.credential_secret_access_key}\n"
@@ -49,7 +49,7 @@ resource "random_password" "grafana_admin_password" {
 }
 resource "vault_kv_secret_v2" "grafana_admin_credentials" {
   mount = module.secretsmanager.instance_id #"<your_vault_instance_id>", in this example it comes from a TF module, but you can also just place your instance ID here
-  name  = "kube-prometheus-stack/grafana_credentials"
+  name  = "${var.name}/${var.stage}/kube-prometheus-stack/grafana_credentials"
   data_json = jsonencode({
     admin-user     = local.grafana_admin_user
     admin-password = local.grafana_admin_password

--- a/src/internal/cmd/bootstrap/local.go
+++ b/src/internal/cmd/bootstrap/local.go
@@ -566,7 +566,7 @@ path "kv/metadata/*" {
 		if err != nil {
 			return fmt.Errorf("decode DOCKERCONFIG_BASE64 for local OpenBao: %w", err)
 		}
-		if err := writeOpenBaoKVSecret(ctx, kubeconfigPath, secretPathPrefix+"/docker_config", map[string]string{
+		if err := writeOpenBaoKVSecret(ctx, kubeconfigPath, secretPathPrefix+"/cluster_secrets/docker_config", map[string]string{
 			"pull-secret": dockerconfig,
 		}); err != nil {
 			return err

--- a/src/internal/cmd/bootstrap/local.go
+++ b/src/internal/cmd/bootstrap/local.go
@@ -155,7 +155,7 @@ Now start cloud-provider-kind in another terminal with: sudo cloud-provider-kind
 	log.Info().Msg("Configuring OpenBao for local external-secrets access")
 	// Intentianolly using the ArgoCD Wizard password for grafana as well. For convenience on the local evaluation
 	// environment and not requiring the user to fill out yet another variable during bootstrapping.
-	if err := configureLocalOpenBao(ctx, state.KubeconfigPath, opts.EnvMap.ArgocdWizardAccountPassword); err != nil {
+	if err := configureLocalOpenBao(ctx, state.KubeconfigPath, opts.EnvMap.ArgocdWizardAccountPassword, opts.EnvMap.DockerconfigBase64); err != nil {
 		return err
 	}
 	log.Info().
@@ -496,7 +496,7 @@ func writeLocalGenerateEnvFile(state *LocalState, envMap *envconfig.EnvMap) (str
 	return envPath, nil
 }
 
-func configureLocalOpenBao(ctx context.Context, kubeconfigPath, grafanaAdminPassword string) error {
+func configureLocalOpenBao(ctx context.Context, kubeconfigPath, grafanaAdminPassword, dockerconfigBase64 string) error {
 	if err := ensureOpenBaoSecretEngine(ctx, kubeconfigPath); err != nil {
 		return err
 	}
@@ -553,11 +553,23 @@ path "kv/metadata/*" {
 		return fmt.Errorf("configure OpenBao kubernetes role: %w", err)
 	}
 
-	if err := writeOpenBaoKVSecret(ctx, kubeconfigPath, "grafana_credentials", map[string]string{
+	if err := writeOpenBaoKVSecret(ctx, kubeconfigPath, "kube-prometheus-stack/grafana_credentials", map[string]string{
 		"admin-user":     "wizard",
 		"admin-password": grafanaAdminPassword,
 	}); err != nil {
 		return err
+	}
+
+	if envconfig.IsConfiguredEnvValue(dockerconfigBase64) {
+		dockerconfig, err := utils.DecodeB64(dockerconfigBase64)
+		if err != nil {
+			return fmt.Errorf("decode DOCKERCONFIG_BASE64 for local OpenBao: %w", err)
+		}
+		if err := writeOpenBaoKVSecret(ctx, kubeconfigPath, "docker_config", map[string]string{
+			"pull-secret": dockerconfig,
+		}); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/src/internal/cmd/bootstrap/local.go
+++ b/src/internal/cmd/bootstrap/local.go
@@ -155,7 +155,7 @@ Now start cloud-provider-kind in another terminal with: sudo cloud-provider-kind
 	log.Info().Msg("Configuring OpenBao for local external-secrets access")
 	// Intentianolly using the ArgoCD Wizard password for grafana as well. For convenience on the local evaluation
 	// environment and not requiring the user to fill out yet another variable during bootstrapping.
-	if err := configureLocalOpenBao(ctx, state.KubeconfigPath, opts.EnvMap.ArgocdWizardAccountPassword, opts.EnvMap.DockerconfigBase64); err != nil {
+	if err := configureLocalOpenBao(ctx, state.KubeconfigPath, opts.ClusterConfig, opts.EnvMap.ArgocdWizardAccountPassword, opts.EnvMap.DockerconfigBase64); err != nil {
 		return err
 	}
 	log.Info().
@@ -496,7 +496,7 @@ func writeLocalGenerateEnvFile(state *LocalState, envMap *envconfig.EnvMap) (str
 	return envPath, nil
 }
 
-func configureLocalOpenBao(ctx context.Context, kubeconfigPath, grafanaAdminPassword, dockerconfigBase64 string) error {
+func configureLocalOpenBao(ctx context.Context, kubeconfigPath string, cluster *config.Cluster, grafanaAdminPassword, dockerconfigBase64 string) error {
 	if err := ensureOpenBaoSecretEngine(ctx, kubeconfigPath); err != nil {
 		return err
 	}
@@ -553,7 +553,8 @@ path "kv/metadata/*" {
 		return fmt.Errorf("configure OpenBao kubernetes role: %w", err)
 	}
 
-	if err := writeOpenBaoKVSecret(ctx, kubeconfigPath, "kube-prometheus-stack/grafana_credentials", map[string]string{
+	secretPathPrefix := fmt.Sprintf("%s/%s", cluster.Name, cluster.Stage)
+	if err := writeOpenBaoKVSecret(ctx, kubeconfigPath, secretPathPrefix+"/kube-prometheus-stack/grafana_credentials", map[string]string{
 		"admin-user":     "wizard",
 		"admin-password": grafanaAdminPassword,
 	}); err != nil {
@@ -565,7 +566,7 @@ path "kv/metadata/*" {
 		if err != nil {
 			return fmt.Errorf("decode DOCKERCONFIG_BASE64 for local OpenBao: %w", err)
 		}
-		if err := writeOpenBaoKVSecret(ctx, kubeconfigPath, "docker_config", map[string]string{
+		if err := writeOpenBaoKVSecret(ctx, kubeconfigPath, secretPathPrefix+"/docker_config", map[string]string{
 			"pull-secret": dockerconfig,
 		}); err != nil {
 			return err

--- a/src/internal/render/render_test.go
+++ b/src/internal/render/render_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/kubara-io/kubara/internal/catalog"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 var testTemplatesFS = catalog.BuiltInFS()
@@ -70,49 +69,6 @@ func fullCatalogContext() map[string]any {
 			"longhorn":                map[string]any{"chartPath": "longhorn"},
 			"velero":                  map[string]any{"chartPath": "velero"},
 		},
-	}
-}
-
-func fullRenderContext(clusterName, stage string) map[string]any {
-	return map[string]any{
-		"var": map[string]any{
-			"project_id": "12345",
-			"name":       clusterName,
-			"stage":      stage,
-		},
-		"cluster": map[string]any{
-			"type":             "hub",
-			"name":             clusterName,
-			"stage":            stage,
-			"dnsName":          "test.example.com",
-			"ingressClassName": "traefik",
-			"ssoOrg":           "myorg",
-			"ssoTeam":          "myteam",
-			"terraform": map[string]any{
-				"kubernetesType": "ske",
-			},
-			"argocd": map[string]any{
-				"repo": map[string]any{
-					"https": map[string]any{
-						"managed": map[string]any{
-							"url":            "https://github.com/example/repo",
-							"path":           "managed-service-catalog/helm",
-							"targetRevision": "main",
-						},
-						"customer": map[string]any{
-							"url":            "https://github.com/example/repo",
-							"path":           "customer-service-catalog/helm",
-							"targetRevision": "main",
-						},
-					},
-				},
-				"helmRepo": map[string]any{
-					"url": "https://charts.example.com",
-				},
-			},
-			"services": fullServiceContext(),
-		},
-		"catalog": fullCatalogContext(),
 	}
 }
 
@@ -197,7 +153,46 @@ func TestTemplateFiles(t *testing.T) {
 		{
 			name:    "Success: Successfully template all files of type All",
 			tplType: All,
-			context: fullRenderContext("test-cluster", "dev"),
+			context: map[string]any{
+				"var": map[string]any{
+					"project_id": "12345",
+					"name":       "test-cluster",
+					"stage":      "dev",
+				},
+				"cluster": map[string]any{
+					"type":             "hub",
+					"name":             "test-cluster",
+					"stage":            "dev",
+					"dnsName":          "test.example.com",
+					"ingressClassName": "traefik",
+					"ssoOrg":           "myorg",
+					"ssoTeam":          "myteam",
+					"terraform": map[string]any{
+						"kubernetesType": "ske",
+					},
+					"argocd": map[string]any{
+						"repo": map[string]any{
+							"https": map[string]any{
+								"managed": map[string]any{
+									"url":            "https://github.com/example/repo",
+									"path":           "managed-service-catalog/helm",
+									"targetRevision": "main",
+								},
+								"customer": map[string]any{
+									"url":            "https://github.com/example/repo",
+									"path":           "customer-service-catalog/helm",
+									"targetRevision": "main",
+								},
+							},
+						},
+						"helmRepo": map[string]any{
+							"url": "https://charts.example.com",
+						},
+					},
+					"services": fullServiceContext(),
+				},
+				"catalog": fullCatalogContext(),
+			},
 			wantErr: false, // No errors expected with valid context
 			validate: func(t *testing.T, results []TemplateResult) {
 				assert.NotEmpty(t, results)
@@ -348,78 +343,4 @@ func TestTemplateFiles(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestTemplateFilesRendersClusterScopedSecretPaths(t *testing.T) {
-	cleanup := setupTestFS(t)
-	defer cleanup()
-
-	context := fullRenderContext("controlplane", "production")
-	cluster := context["cluster"].(map[string]any)
-	services := cluster["services"].(map[string]any)
-	services["oauth2-proxy"] = map[string]any{"status": "enabled"}
-	services["velero"] = map[string]any{
-		"status": "enabled",
-		"config": map[string]any{
-			"backupMode": "fs-backup",
-			"backupStorage": map[string]any{
-				"create": true,
-				"region": "eu01",
-				"s3Url":  "https://s3.eu01.stackit.cloud",
-			},
-		},
-	}
-
-	results, err := TemplateFiles(TemplateOptions{
-		Type:     All,
-		Provider: "stackit",
-		Data:     context,
-	})
-	require.NoError(t, err)
-
-	expectedByPath := map[string][]string{
-		"customer-service-catalog/helm/example/argo-cd/values.yaml.tplt": {
-			"remoteKey: controlplane/production/docker_config",
-			"remoteKey: controlplane/production/argocd/argo_oauth2_credentials",
-		},
-		"customer-service-catalog/helm/example/external-dns/values.yaml.tplt": {
-			"remoteKey: controlplane/production/external-dns/dns_zone_admin",
-		},
-		"customer-service-catalog/helm/example/kube-prometheus-stack/values.yaml.tplt": {
-			"remoteKey: controlplane/production/kube-prometheus-stack/grafana_credentials",
-			"remoteKey: controlplane/production/kube-prometheus-stack/grafana_oauth2_credentials",
-		},
-		"customer-service-catalog/helm/example/oauth2-proxy/values.yaml.tplt": {
-			"remoteKey: controlplane/production/oauth2-proxy/oauth2_credentials",
-		},
-		"customer-service-catalog/helm/example/velero/values.yaml.tplt": {
-			"remoteKey: controlplane/production/velero/velero_s3_credentials",
-		},
-		"customer-service-catalog/terraform/providers/stackit/example/infrastructure/secrets.tf.tplt": {
-			`name  = "${var.name}/${var.stage}/cluster_secrets"`,
-			`name  = "${var.name}/${var.stage}/external-dns/dns_zone_admin"`,
-			`name  = "${var.name}/${var.stage}/velero/velero_s3_credentials"`,
-			`name  = "${var.name}/${var.stage}/kube-prometheus-stack/grafana_credentials"`,
-		},
-		"customer-service-catalog/terraform/providers/stackit/example/infrastructure/secrets.tf-example.tplt": {
-			`name  = "${var.name}/${var.stage}/docker_config"`,
-			`name  = "${var.name}/${var.stage}/oauth2-proxy/oauth2_credentials"`,
-			`name  = "${var.name}/${var.stage}/argocd/argo_oauth2_credentials"`,
-			`name  = "${var.name}/${var.stage}/kube-prometheus-stack/grafana_oauth2_credentials"`,
-		},
-	}
-
-	for _, result := range results {
-		expected, ok := expectedByPath[result.Path]
-		if !ok {
-			continue
-		}
-		require.NoError(t, result.Error)
-		for _, value := range expected {
-			assert.Contains(t, result.Content, value)
-		}
-		delete(expectedByPath, result.Path)
-	}
-
-	assert.Empty(t, expectedByPath, "all secret path templates should be rendered")
 }

--- a/src/internal/render/render_test.go
+++ b/src/internal/render/render_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/kubara-io/kubara/internal/catalog"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var testTemplatesFS = catalog.BuiltInFS()
@@ -69,6 +70,49 @@ func fullCatalogContext() map[string]any {
 			"longhorn":                map[string]any{"chartPath": "longhorn"},
 			"velero":                  map[string]any{"chartPath": "velero"},
 		},
+	}
+}
+
+func fullRenderContext(clusterName, stage string) map[string]any {
+	return map[string]any{
+		"var": map[string]any{
+			"project_id": "12345",
+			"name":       clusterName,
+			"stage":      stage,
+		},
+		"cluster": map[string]any{
+			"type":             "hub",
+			"name":             clusterName,
+			"stage":            stage,
+			"dnsName":          "test.example.com",
+			"ingressClassName": "traefik",
+			"ssoOrg":           "myorg",
+			"ssoTeam":          "myteam",
+			"terraform": map[string]any{
+				"kubernetesType": "ske",
+			},
+			"argocd": map[string]any{
+				"repo": map[string]any{
+					"https": map[string]any{
+						"managed": map[string]any{
+							"url":            "https://github.com/example/repo",
+							"path":           "managed-service-catalog/helm",
+							"targetRevision": "main",
+						},
+						"customer": map[string]any{
+							"url":            "https://github.com/example/repo",
+							"path":           "customer-service-catalog/helm",
+							"targetRevision": "main",
+						},
+					},
+				},
+				"helmRepo": map[string]any{
+					"url": "https://charts.example.com",
+				},
+			},
+			"services": fullServiceContext(),
+		},
+		"catalog": fullCatalogContext(),
 	}
 }
 
@@ -153,46 +197,7 @@ func TestTemplateFiles(t *testing.T) {
 		{
 			name:    "Success: Successfully template all files of type All",
 			tplType: All,
-			context: map[string]any{
-				"var": map[string]any{
-					"project_id": "12345",
-					"name":       "test-cluster",
-					"stage":      "dev",
-				},
-				"cluster": map[string]any{
-					"type":             "hub",
-					"name":             "test-cluster",
-					"stage":            "dev",
-					"dnsName":          "test.example.com",
-					"ingressClassName": "traefik",
-					"ssoOrg":           "myorg",
-					"ssoTeam":          "myteam",
-					"terraform": map[string]any{
-						"kubernetesType": "ske",
-					},
-					"argocd": map[string]any{
-						"repo": map[string]any{
-							"https": map[string]any{
-								"managed": map[string]any{
-									"url":            "https://github.com/example/repo",
-									"path":           "managed-service-catalog/helm",
-									"targetRevision": "main",
-								},
-								"customer": map[string]any{
-									"url":            "https://github.com/example/repo",
-									"path":           "customer-service-catalog/helm",
-									"targetRevision": "main",
-								},
-							},
-						},
-						"helmRepo": map[string]any{
-							"url": "https://charts.example.com",
-						},
-					},
-					"services": fullServiceContext(),
-				},
-				"catalog": fullCatalogContext(),
-			},
+			context: fullRenderContext("test-cluster", "dev"),
 			wantErr: false, // No errors expected with valid context
 			validate: func(t *testing.T, results []TemplateResult) {
 				assert.NotEmpty(t, results)
@@ -343,4 +348,78 @@ func TestTemplateFiles(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestTemplateFilesRendersClusterScopedSecretPaths(t *testing.T) {
+	cleanup := setupTestFS(t)
+	defer cleanup()
+
+	context := fullRenderContext("controlplane", "production")
+	cluster := context["cluster"].(map[string]any)
+	services := cluster["services"].(map[string]any)
+	services["oauth2-proxy"] = map[string]any{"status": "enabled"}
+	services["velero"] = map[string]any{
+		"status": "enabled",
+		"config": map[string]any{
+			"backupMode": "fs-backup",
+			"backupStorage": map[string]any{
+				"create": true,
+				"region": "eu01",
+				"s3Url":  "https://s3.eu01.stackit.cloud",
+			},
+		},
+	}
+
+	results, err := TemplateFiles(TemplateOptions{
+		Type:     All,
+		Provider: "stackit",
+		Data:     context,
+	})
+	require.NoError(t, err)
+
+	expectedByPath := map[string][]string{
+		"customer-service-catalog/helm/example/argo-cd/values.yaml.tplt": {
+			"remoteKey: controlplane/production/docker_config",
+			"remoteKey: controlplane/production/argocd/argo_oauth2_credentials",
+		},
+		"customer-service-catalog/helm/example/external-dns/values.yaml.tplt": {
+			"remoteKey: controlplane/production/external-dns/dns_zone_admin",
+		},
+		"customer-service-catalog/helm/example/kube-prometheus-stack/values.yaml.tplt": {
+			"remoteKey: controlplane/production/kube-prometheus-stack/grafana_credentials",
+			"remoteKey: controlplane/production/kube-prometheus-stack/grafana_oauth2_credentials",
+		},
+		"customer-service-catalog/helm/example/oauth2-proxy/values.yaml.tplt": {
+			"remoteKey: controlplane/production/oauth2-proxy/oauth2_credentials",
+		},
+		"customer-service-catalog/helm/example/velero/values.yaml.tplt": {
+			"remoteKey: controlplane/production/velero/velero_s3_credentials",
+		},
+		"customer-service-catalog/terraform/providers/stackit/example/infrastructure/secrets.tf.tplt": {
+			`name  = "${var.name}/${var.stage}/cluster_secrets"`,
+			`name  = "${var.name}/${var.stage}/external-dns/dns_zone_admin"`,
+			`name  = "${var.name}/${var.stage}/velero/velero_s3_credentials"`,
+			`name  = "${var.name}/${var.stage}/kube-prometheus-stack/grafana_credentials"`,
+		},
+		"customer-service-catalog/terraform/providers/stackit/example/infrastructure/secrets.tf-example.tplt": {
+			`name  = "${var.name}/${var.stage}/docker_config"`,
+			`name  = "${var.name}/${var.stage}/oauth2-proxy/oauth2_credentials"`,
+			`name  = "${var.name}/${var.stage}/argocd/argo_oauth2_credentials"`,
+			`name  = "${var.name}/${var.stage}/kube-prometheus-stack/grafana_oauth2_credentials"`,
+		},
+	}
+
+	for _, result := range results {
+		expected, ok := expectedByPath[result.Path]
+		if !ok {
+			continue
+		}
+		require.NoError(t, result.Error)
+		for _, value := range expected {
+			assert.Contains(t, result.Content, value)
+		}
+		delete(expectedByPath, result.Path)
+	}
+
+	assert.Empty(t, expectedByPath, "all secret path templates should be rendered")
 }


### PR DESCRIPTION
## 📝 Summary
<!-- Please read first: https://github.com/kubara-io/kubara/blob/main/CONTRIBUTING.md -->

Scopes the built-in secret-manager path contract by cluster and stage so one secret backend can hold multiple clusters and stages without path collisions.

Namespace-specific secrets now use:

`<cluster-name>/<stage>/<namespace>/<secret>`

Cluster-wide secrets now use:

`<cluster-name>/<stage>/cluster_secrets/<secret>`

The shared Helm consumers and STACKIT Terraform producers now use the same paths, including:

- `<cluster-name>/<stage>/cluster_secrets/docker_config`
- `<cluster-name>/<stage>/cluster_secrets/vault_instance`
- `<cluster-name>/<stage>/oauth2-proxy/oauth2_credentials`
- `<cluster-name>/<stage>/argocd/argo_oauth2_credentials`
- `<cluster-name>/<stage>/kube-prometheus-stack/grafana_credentials`
- `<cluster-name>/<stage>/kube-prometheus-stack/grafana_oauth2_credentials`
- `<cluster-name>/<stage>/external-dns/dns_zone_admin`
- `<cluster-name>/<stage>/velero/velero_s3_credentials`

The local OpenBao setup writes Grafana credentials and optional Docker pull credentials to the same scoped paths. Documentation was updated to describe the new layout.

## 🧩 Type of change
- [x] 🔧 CLI / Go code
- [x] 📦 Helm chart
- [x] 🧱 Terraform module
- [x] 📝 Documentation
- [ ] 🧪 Test or CI change
- [x] ♻️ Refactor / cleanup

## ⚠️ Is this a breaking change?
- [x] Yes, this change breaks existing functionality (explain in summary)

Existing installations using the previous flat or namespace-only secret paths must move secrets to the new cluster/stage-scoped paths before deploying regenerated Helm values.

Terraform-managed STACKIT secrets are replaced at the new paths when the regenerated Terraform is applied. Copied Terraform files such as OAuth secret definitions must be updated to the new names before applying. Secrets created outside Terraform or OpenTofu must be recreated manually at the corresponding new path.

Apply the Terraform or OpenTofu changes before deploying the new Helm values so External Secrets can resolve the new remote keys.

## 🧪 Testing
- [ ] CI passed
- [ ] Manually tested (local/dev cluster)
- [x] Unit tested
- [ ] Not tested (explain why below)

Ran locally:

- `go test ./internal/render ./internal/cmd/bootstrap`
- `UV_PYTHON=3.14.5 make docs-validate`
- `git diff --check`

## 🔗 Related Issues / Tickets

- Preparatory split from #370
- Related to #391
- Related to #414

## ✅ Checklist
- [x] Code compiles and passes relevant tests
- [ ] Linting and style checks pass
- [ ] Comments added for complex logic
- [x] Documentation updated (if applicable)

## 📎 Additional Context (optional)

This PR is intentionally limited to the shared secret-path contract and local OpenBao parity. Namespace-scoped authorization and provider-specific `SecretStore` behavior remain separate concerns.

It can proceed in parallel with #391. The expected overlap is limited to the shared ExternalDNS values during the eventual rebase.
