### PR TITLE
feat!: add namespaced SecretStore support (stores now keyed by map)

### DIFF
--- a/docs/content/2_managing_your_platform/add_spoke_cluster.md
+++ b/docs/content/2_managing_your_platform/add_spoke_cluster.md
@@ -149,7 +149,7 @@ Example:
 
 ```yaml
 clusterSecretStores:
-  - name: workload-0-dev
+  workload-0-dev:
     labels:
       argocd.argoproj.io/instance: workload-0-external-secrets
     provider:

--- a/src/internal/catalog/built-in/managed-service-catalog/helm/argo-cd/templates/secret-store.yaml
+++ b/src/internal/catalog/built-in/managed-service-catalog/helm/argo-cd/templates/secret-store.yaml
@@ -1,1 +1,1 @@
-{{- include "templateLibrary.externalSecrets.secretStore" . }}
+{{- include "templateLibrary.externalSecrets.secretStores" . }}

--- a/src/internal/catalog/built-in/managed-service-catalog/helm/argo-cd/templates/secret-store.yaml
+++ b/src/internal/catalog/built-in/managed-service-catalog/helm/argo-cd/templates/secret-store.yaml
@@ -1,0 +1,1 @@
+{{- include "templateLibrary.externalSecrets.secretStore" . }}

--- a/src/internal/catalog/built-in/managed-service-catalog/helm/external-dns/templates/secret-store.yaml
+++ b/src/internal/catalog/built-in/managed-service-catalog/helm/external-dns/templates/secret-store.yaml
@@ -1,1 +1,1 @@
-{{- include "templateLibrary.externalSecrets.secretStore" . }}
+{{- include "templateLibrary.externalSecrets.secretStores" . }}

--- a/src/internal/catalog/built-in/managed-service-catalog/helm/external-dns/templates/secret-store.yaml
+++ b/src/internal/catalog/built-in/managed-service-catalog/helm/external-dns/templates/secret-store.yaml
@@ -1,0 +1,1 @@
+{{- include "templateLibrary.externalSecrets.secretStore" . }}

--- a/src/internal/catalog/built-in/managed-service-catalog/helm/external-secrets/templates/clusterSecretStore.yaml
+++ b/src/internal/catalog/built-in/managed-service-catalog/helm/external-secrets/templates/clusterSecretStore.yaml
@@ -1,1 +1,1 @@
-{{- include "templateLibrary.externalSecrets.clusterSecretStore" . }}
+{{- include "templateLibrary.externalSecrets.clusterSecretStores" . }}

--- a/src/internal/catalog/built-in/managed-service-catalog/helm/kube-prometheus-stack/templates/secret-store.yaml
+++ b/src/internal/catalog/built-in/managed-service-catalog/helm/kube-prometheus-stack/templates/secret-store.yaml
@@ -1,1 +1,1 @@
-{{- include "templateLibrary.externalSecrets.secretStore" . }}
+{{- include "templateLibrary.externalSecrets.secretStores" . }}

--- a/src/internal/catalog/built-in/managed-service-catalog/helm/kube-prometheus-stack/templates/secret-store.yaml
+++ b/src/internal/catalog/built-in/managed-service-catalog/helm/kube-prometheus-stack/templates/secret-store.yaml
@@ -1,0 +1,1 @@
+{{- include "templateLibrary.externalSecrets.secretStore" . }}

--- a/src/internal/catalog/built-in/managed-service-catalog/helm/oauth2-proxy/templates/secret-store.yaml
+++ b/src/internal/catalog/built-in/managed-service-catalog/helm/oauth2-proxy/templates/secret-store.yaml
@@ -1,1 +1,1 @@
-{{- include "templateLibrary.externalSecrets.secretStore" . }}
+{{- include "templateLibrary.externalSecrets.secretStores" . }}

--- a/src/internal/catalog/built-in/managed-service-catalog/helm/oauth2-proxy/templates/secret-store.yaml
+++ b/src/internal/catalog/built-in/managed-service-catalog/helm/oauth2-proxy/templates/secret-store.yaml
@@ -1,0 +1,1 @@
+{{- include "templateLibrary.externalSecrets.secretStore" . }}

--- a/src/internal/catalog/built-in/managed-service-catalog/helm/template-library/templates/external-secrets/_externalSecrets.clusterSecretStore.tpl
+++ b/src/internal/catalog/built-in/managed-service-catalog/helm/template-library/templates/external-secrets/_externalSecrets.clusterSecretStore.tpl
@@ -1,10 +1,9 @@
-{{- define "templateLibrary.externalSecrets.clusterSecretStore" }}
-{{- range $idx, $data := .Values.clusterSecretStores }}
-{{- $storeName := default (printf "store-%d" $idx ) (default $data.storeName $data.name) }}
+{{- define "templateLibrary.externalSecrets.clusterSecretStores" }}
+{{- range $name, $data := .Values.clusterSecretStores }}
 apiVersion: external-secrets.io/v1
 kind: ClusterSecretStore
 metadata:
-  name: {{ $storeName }}
+  name: {{ $name }}
   {{- with $data.labels }}
   labels:
     {{- toYaml . | nindent 4 }}
@@ -12,10 +11,6 @@ metadata:
 spec:
   provider:
     {{- toYaml $data.provider | nindent 4 }}
-  {{- with $data.retrySettings }}
-  retrySettings:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
 ---
 {{- end }}
 {{- end }}

--- a/src/internal/catalog/built-in/managed-service-catalog/helm/template-library/templates/external-secrets/_externalSecrets.secretStore.tpl
+++ b/src/internal/catalog/built-in/managed-service-catalog/helm/template-library/templates/external-secrets/_externalSecrets.secretStore.tpl
@@ -1,0 +1,22 @@
+{{- define "templateLibrary.externalSecrets.secretStore" }}
+{{- range $idx, $data := .Values.namespacedSecretStores }}
+{{- $storeName := default (printf "store-%d" $idx) (default $data.storeName $data.name) }}
+apiVersion: external-secrets.io/v1
+kind: SecretStore
+metadata:
+  name: {{ $storeName }}
+  namespace: {{ $.Release.Namespace }}
+  {{- with $data.labels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  provider:
+    {{- toYaml $data.provider | nindent 4 }}
+  {{- with $data.retrySettings }}
+  retrySettings:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+---
+{{- end }}
+{{- end }}

--- a/src/internal/catalog/built-in/managed-service-catalog/helm/template-library/templates/external-secrets/_externalSecrets.secretStore.tpl
+++ b/src/internal/catalog/built-in/managed-service-catalog/helm/template-library/templates/external-secrets/_externalSecrets.secretStore.tpl
@@ -1,10 +1,9 @@
-{{- define "templateLibrary.externalSecrets.secretStore" }}
-{{- range $idx, $data := .Values.namespacedSecretStores }}
-{{- $storeName := default (printf "store-%d" $idx) (default $data.storeName $data.name) }}
+{{- define "templateLibrary.externalSecrets.secretStores" }}
+{{- range $name, $data := .Values.namespacedSecretStores }}
 apiVersion: external-secrets.io/v1
 kind: SecretStore
 metadata:
-  name: {{ $storeName }}
+  name: {{ $name }}
   namespace: {{ $.Release.Namespace }}
   {{- with $data.labels }}
   labels:
@@ -13,10 +12,6 @@ metadata:
 spec:
   provider:
     {{- toYaml $data.provider | nindent 4 }}
-  {{- with $data.retrySettings }}
-  retrySettings:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
 ---
 {{- end }}
 {{- end }}

--- a/src/internal/catalog/built-in/managed-service-catalog/helm/velero/templates/secret-store.yaml
+++ b/src/internal/catalog/built-in/managed-service-catalog/helm/velero/templates/secret-store.yaml
@@ -1,1 +1,1 @@
-{{- include "templateLibrary.externalSecrets.secretStore" . }}
+{{- include "templateLibrary.externalSecrets.secretStores" . }}

--- a/src/internal/catalog/built-in/managed-service-catalog/helm/velero/templates/secret-store.yaml
+++ b/src/internal/catalog/built-in/managed-service-catalog/helm/velero/templates/secret-store.yaml
@@ -1,0 +1,1 @@
+{{- include "templateLibrary.externalSecrets.secretStore" . }}


### PR DESCRIPTION
## 📝 Summary

Adds provider-neutral chart support for **namespaced** External Secrets `SecretStore` resources, and aligns the existing cluster-scoped helper to the same shape.

- New helper `templateLibrary.externalSecrets.secretStores` renders one `SecretStore` (scoped to the release namespace) per entry in `.Values.namespacedSecretStores`, wired into the `argo-cd`, `external-dns`, `kube-prometheus-stack`, `oauth2-proxy` and `velero` charts.
- Both `namespacedSecretStores` and `clusterSecretStores` are now keyed by a **map** (the key is the store name) instead of a list, dropping the synthetic `store-<index>` fallback. This addresses review feedback and keeps the two helpers symmetric.
- Dropped the unused `retrySettings` passthrough from both helpers. Nothing sets it, and omitting it just uses ExternalSecrets' built-in retry defaults.

First extracted PR from the split of #370.

## 🧩 Type of change
- [ ] 🔧 CLI / Go code
- [x] 📦 Helm chart
- [ ] 🧱 Terraform module
- [x] 📝 Documentation
- [ ] 🧪 Test or CI change
- [x] ♻️ Refactor / cleanup

## ⚠️ Is this a breaking change?
- [x] Yes, this change breaks existing functionality (explain in summary)

`clusterSecretStores` (and the new `namespacedSecretStores`) values are now keyed by a map instead of a list. Existing user `additional-values.yaml` files that define `clusterSecretStores` as a list (e.g. the stackit spoke-cluster setup) must migrate to the map shape. See the migration below; the spoke-cluster docs are updated in this PR.

## 🧪 Testing
- [ ] CI passed
- [x] Manually tested (local/dev cluster)
- [x] Unit tested
- [ ] Not tested (explain why below)

- `go build ./...` and full `make test` pass.
- `helm template` smoke test: map values render valid `SecretStore`/`ClusterSecretStore` resources (key used as the name, no `store-<index>`, no `retrySettings`); empty `{}` values render nothing.

## 🔗 Related Issues / Tickets
Part of the split of #370.

## ✅ Checklist
- [x] Code compiles and passes all tests
- [ ] Linting and style checks pass
- [x] Comments added for complex logic
- [x] Documentation updated (if applicable)

## 📎 Additional Context (optional)

**Migration.** Convert list entries to map keys:

```yaml
# before
clusterSecretStores:
  - name: workload-0-dev
    provider: { ... }

# after
clusterSecretStores:
  workload-0-dev:
    provider: { ... }
```

The same applies to `namespacedSecretStores`. The T Cloud Public values in #370 are moved to the map shape as well.
