### PR TITLE
fix(tcloud): misaligned kubeconfig naming scheme for terraform

### DIFF
--- a/docs/content/3_infrastructure/t-cloud-public.md
+++ b/docs/content/3_infrastructure/t-cloud-public.md
@@ -387,13 +387,13 @@ Export the kubeconfig:
 === "Terraform"
 
     ```bash
-    terraform output -raw kubeconfig_raw > $HOME/.kube/kubara.yaml
+    terraform output -raw kubeconfig > $HOME/.kube/kubara.yaml
     ```
 
 === "Tofu"
 
     ```bash
-    tofu output -raw kubeconfig_raw > $HOME/.kube/kubara.yaml
+    tofu output -raw kubeconfig > $HOME/.kube/kubara.yaml
     ```
 
 Keep this `kubara.yaml` local and do not commit it to Git.

--- a/src/internal/catalog/built-in/customer-service-catalog/terraform/providers/t-cloud-public/example/infrastructure/outputs.tf.tplt
+++ b/src/internal/catalog/built-in/customer-service-catalog/terraform/providers/t-cloud-public/example/infrastructure/outputs.tf.tplt
@@ -1,8 +1,8 @@
 {{ if (eq .cluster.terraform.kubernetesType "cce") }}
 ### Kubernetes Instance
-output "kubeconfig_raw" {
+output "kubeconfig" {
   description = "Raw admin kubeconfig."
-  value       = module.cce_cluster.kubeconfig_raw
+  value       = module.cce_cluster.kubeconfig
   sensitive   = true
 }
 

--- a/src/internal/catalog/built-in/customer-service-catalog/terraform/providers/t-cloud-public/example/infrastructure/terraform.tf.tplt
+++ b/src/internal/catalog/built-in/customer-service-catalog/terraform/providers/t-cloud-public/example/infrastructure/terraform.tf.tplt
@@ -52,7 +52,7 @@ provider "opentelekomcloud" {
 
 {{ if (eq .cluster.terraform.kubernetesType "cce") }}
 locals {
-  cce_kubeconfig = yamldecode(module.cce_cluster.kubeconfig_raw)
+  cce_kubeconfig = yamldecode(module.cce_cluster.kubeconfig)
 
   # OTC CCE returns three cluster entries in the generated kubeconfig when
   # an EIP is bound to the master:

--- a/src/internal/catalog/built-in/managed-service-catalog/terraform/providers/t-cloud-public/modules/cce-cluster/outputs.tf
+++ b/src/internal/catalog/built-in/managed-service-catalog/terraform/providers/t-cloud-public/modules/cce-cluster/outputs.tf
@@ -23,7 +23,7 @@ output "addons" {
   value       = opentelekomcloud_cce_addon_v3.this
 }
 
-output "kubeconfig_raw" {
+output "kubeconfig" {
   description = "Raw admin kubeconfig."
   value       = data.opentelekomcloud_cce_cluster_kubeconfig_v3.this.kubeconfig
   sensitive   = true


### PR DESCRIPTION
## 📝 Summary

## 🧩 Type of change
- [ ] 🔧 CLI / Go code
- [ ] 📦 Helm chart
- [X] 🧱 Terraform module
- [X] 📝 Documentation
- [ ] 🧪 Test or CI change
- [X] ♻️ Refactor / cleanup

