### PR TITLE
fix: restore in-body llms.txt discovery hint for coding agents

### DIFF
--- a/docs/content/stylesheets/extra.css
+++ b/docs/content/stylesheets/extra.css
@@ -58,5 +58,6 @@ blockquote[data-agent-docs-index="true"] {
   overflow: hidden;
   white-space: nowrap;
   clip: rect(0, 0, 0, 0);
+  clip-path: inset(50%);
   border: 0;
 }

--- a/docs/content/stylesheets/extra.css
+++ b/docs/content/stylesheets/extra.css
@@ -47,3 +47,16 @@
 .mermaid {
     text-align: center;
 }
+/* Visually hide the agent documentation-index hint while keeping it in the
+   rendered text (so coding agents that read the body still find it). */
+blockquote[data-agent-docs-index="true"] {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  white-space: nowrap;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}

--- a/docs/hooks/agent_docs.py
+++ b/docs/hooks/agent_docs.py
@@ -51,13 +51,15 @@ def on_post_page(output, page, config):
 
     # In-body hint for coding agents: they fetch the page and read the body
     # text, dropping <head> — so the discovery pointer must live in the body to
-    # be found. Visually hidden (not display:none, so it stays in the extracted
-    # text); no aria-hidden, so the link isn't an unannounced keyboard tab stop.
-    # href is relative, so it resolves under mike's /<version>/ deploys.
+    # be found. This is machine-only content, so it is inert for humans:
+    # visually hidden (not display:none, so it stays in the extracted text),
+    # aria-hidden from assistive tech, and the link is tabindex="-1" so it is
+    # not a keyboard tab stop. href is relative, so it resolves under mike's
+    # /<version>/ deploys.
     block = (
-        '<blockquote class="sr-only" data-agent-docs-index="true">\n'
+        '<blockquote data-agent-docs-index="true" aria-hidden="true">\n'
         "  <h2>Documentation Index</h2>\n"
-        f'  <p>Fetch the complete documentation index at: <a href="{href}">{href}</a></p>\n'
+        f'  <p>Fetch the complete documentation index at: <a href="{href}" tabindex="-1">{href}</a></p>\n'
         "  <p>Use this file to discover all available pages before exploring further.</p>\n"
         "</blockquote>"
     )

--- a/docs/hooks/agent_docs.py
+++ b/docs/hooks/agent_docs.py
@@ -17,6 +17,7 @@ stub, so it is generated in CI after ``mike set-default`` — see
 ``docs/scripts/build_root_llms.py``.
 """
 
+import re
 import shutil
 from pathlib import Path, PurePosixPath
 from urllib.parse import quote
@@ -24,6 +25,7 @@ from urllib.parse import quote
 from mkdocs.utils import get_relative_url
 
 LLMS_TXT = "llms.txt"
+_BODY_RE = re.compile(r"(<body\b[^>]*>)", re.IGNORECASE)
 
 # Key under which the rendered llms.txt is stashed on the config between the
 # on_nav (where the nav tree is available) and on_post_build (where the site
@@ -39,11 +41,27 @@ def on_nav(nav, config, files):
 
 def on_post_page(output, page, config):
     href = get_relative_url(LLMS_TXT, page.url)
+
+    # <head> hint for structured crawlers that parse alternate representations.
     link = (
         '<link rel="alternate" type="text/plain" '
         f'title="LLM-friendly documentation index" href="{href}">'
     )
-    return output.replace("</head>", f"{link}\n</head>", 1)
+    output = output.replace("</head>", f"{link}\n</head>", 1)
+
+    # In-body hint for coding agents: they fetch the page and read the body
+    # text, dropping <head> — so the discovery pointer must live in the body to
+    # be found. Visually hidden (not display:none, so it stays in the extracted
+    # text); no aria-hidden, so the link isn't an unannounced keyboard tab stop.
+    # href is relative, so it resolves under mike's /<version>/ deploys.
+    block = (
+        '<blockquote class="sr-only" data-agent-docs-index="true">\n'
+        "  <h2>Documentation Index</h2>\n"
+        f'  <p>Fetch the complete documentation index at: <a href="{href}">{href}</a></p>\n'
+        "  <p>Use this file to discover all available pages before exploring further.</p>\n"
+        "</blockquote>"
+    )
+    return _BODY_RE.sub(lambda m: f"{m.group(1)}\n{block}", output, count=1)
 
 
 def on_post_build(config):


### PR DESCRIPTION
## 📝 Summary

Follow-up to #462. Coding agents (e.g. Copilot) fetch a docs page and read the **body** text, dropping `<head>` — so the `<link rel="alternate">` head pointer from #462 isn't surfaced, and they crawl individual pages instead of fetching `llms.txt`.

This restores the in-body discovery hint (a visually-hidden block linking the index) so agents find it, with two fixes over the original #462 version:
- **relative href** instead of root `/llms.txt` — correct under mike's `/<version>/` deploys (root `/llms.txt` 404s there);
- **a11y-clean** — the hint is machine-only, so it's `aria-hidden` and the link is `tabindex="-1"` (a clipped but focusable link would otherwise be an invisible keyboard tab stop). The misleading `sr-only` class is dropped.

The `<head>` `<link rel="alternate">` stays as a bonus for structured crawlers.

## 🧩 Type of change
- [x] 📝 Documentation

## ⚠️ Is this a breaking change?
- [ ] Yes, this change breaks existing functionality

No.

## 🧪 Testing
- [x] Manually tested (local/dev cluster)

`mkdocs build --strict` passes; verified the hint renders on every page with a relative href (`../../llms.txt` by depth, `llms.txt` on home), `aria-hidden`, and `tabindex="-1"`. Docs-only change, no cluster involved.

## 🔗 Related Issues / Tickets
Follow-up to #462.

## ✅ Checklist
- [x] Code compiles and passes all tests
- [x] Linting and style checks pass
- [x] Comments added for complex logic
- [x] Documentation updated (if applicable)
