### PR TITLE
chore(stackit): correct Edge Cloud guide and default the example host to g2i.4

### DIFF
--- a/docs/content/3_infrastructure/stackit_edge_cloud.md
+++ b/docs/content/3_infrastructure/stackit_edge_cloud.md
@@ -147,10 +147,23 @@ terraform output edge_host_metadata
 
 Use the selected host public IP for DNS `A` records (for example your ingress hostname).
 
-For the STACKIT VM-based single-node example, set these values in your `config.yaml` before running `kubara generate --helm`:
+For the STACKIT VM-based single-node example, set these values in the `metallb` service config in your `config.yaml` before running `kubara generate --helm`:
 
-* `clusters[].publicLoadBalancerIP`: the STACKIT public IP assigned to the VM. Generated ingress annotations use this as `external-dns` target.
-* `clusters[].privateLoadBalancerIP`: the private IP of the same VM on the STACKIT network. Generated MetalLB customer values use this as pool address (`/32`).
+```yaml
+clusters:
+  - # ...
+    services:
+      metallb:
+        status: enabled
+        config:
+          # the STACKIT public IP assigned to the VM; generated ingress
+          # annotations use this as external-dns target
+          publicLoadBalancerIPs: "<public-ip>"
+          # the private IP of the same VM on the STACKIT network; MetalLB
+          # allocates from this pool
+          loadBalancerAddressPool:
+            - "<private-ip>/32"
+```
 
 This works because the STACKIT public IP is routed/NATed to the selected VM, while MetalLB exposes the Kubernetes `LoadBalancer` service on the VM's private network address.
 Do not use this as a production multi-node ingress design. For multi-node setups, plan a dedicated ingress architecture, for example a STACKIT Network Load Balancer in front of the nodes.
@@ -254,11 +267,14 @@ Read more in the official STACKIT guide: [Using extensions](https://docs.stackit
       talosVersion: v1.12.5-stackit.v1.7.1
     ```
 
-    Apply it and wait until STEC has generated the artifacts:
+    Apply it and wait until STEC has generated the artifacts.
+    The `EdgeImage` reports readiness through the boolean `status.ready`
+    field (it does not set a `Ready` condition, so `--for=condition=Ready`
+    would never complete):
 
     ```bash
     kubectl apply -f edge-image.yaml
-    kubectl wait EdgeImage/kubara-edge-image --namespace default --for=condition=Ready --timeout=60m
+    kubectl wait EdgeImage/kubara-edge-image --namespace default --for=jsonpath='{.status.ready}'=true --timeout=60m
     ```
 
     If you are not using Longhorn, keep only the extensions you actually need.

--- a/src/internal/catalog/built-in/customer-service-catalog/terraform/providers/stackit/example/infrastructure/env.auto.tfvars.tplt
+++ b/src/internal/catalog/built-in/customer-service-catalog/terraform/providers/stackit/example/infrastructure/env.auto.tfvars.tplt
@@ -83,7 +83,7 @@ edge_hosts = {
     {
       name                     = "edge-cp-1"
       role                     = "controlplane"
-      flavor                   = "g2i.8"
+      flavor                   = "g2i.4"
       volume_size              = 40
       volume_performance_class = "storage_premium_perf1"
       availability_zone        = "eu01-1"


### PR DESCRIPTION
## 📝 Summary

Fixes two outdated spots in the Edge Cloud provisioning guide, both verified against a live STEC instance:

- `kubectl wait EdgeImage ... --for=condition=Ready` never completes: the `EdgeImage` reports readiness through the boolean `status.ready` field (matching the official STACKIT docs) and does not set a `Ready` condition. Replaced with `--for=jsonpath='{.status.ready}'=true`.
- The load balancer IP example still used the removed cluster-level fields `publicLoadBalancerIP`/`privateLoadBalancerIP`. Since #433 these live in the `metallb` service config (`publicLoadBalancerIPs`, `loadBalancerAddressPool`); updated the example to the current schema.

- The single-node Edge example defaulted to a `g2i.8` host (8 vCPU / 32 GB). The example platform fits comfortably in `g2i.4` (4 vCPU / 16 GB), so the example now defaults to the smaller, cheaper flavor; a larger host stays a one-line change.

## 🧩 Type of change
- [ ] 🔧 CLI / Go code
- [ ] 📦 Helm chart
- [x] 🧱 Terraform module
- [x] 📝 Documentation
- [ ] 🧪 Test or CI change
- [ ] ♻️ Refactor / cleanup

## ⚠️ Is this a breaking change?
- [ ] Yes, this change breaks existing functionality (explain in summary)

## 🧪 Testing
- [ ] CI passed
- [x] Manually tested (local/dev cluster)
- [ ] Unit tested
- [ ] Not tested (explain why below)

Both corrected commands/fields were exercised against a live STEC instance; `make docs-validate` passes.

## 🔗 Related Issues / Tickets
Related to #433

## ✅ Checklist
- [ ] Code compiles and passes all tests
- [x] Linting and style checks pass
- [ ] Comments added for complex logic
- [x] Documentation updated (if applicable)

## 📎 Additional Context (optional)
