### PR TITLE
feat: remove dns configuration from .env 

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -263,7 +263,6 @@ jobs:
       KUBARA_ARGOCD_GIT_HTTPS_URL: "https://kubara.io/kubara.git"
       KUBARA_ARGOCD_GIT_PAT_OR_PASSWORD: "000000"
       KUBARA_ARGOCD_GIT_USERNAME: "git"
-      KUBARA_DOMAIN_NAME: "stackit.run"
 
       # config.yaml updates
       KUBARA_DNS_NAME: "kubara-tst.stackit.run"

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -266,6 +266,7 @@ jobs:
       KUBARA_DOMAIN_NAME: "stackit.run"
 
       # config.yaml updates
+      KUBARA_DNS_NAME: "kubara-tst.stackit.run"
       KUBARA_STACKIT_PROJECT_ID: "00000000-0000-0000-0000-000000000000"
       KUBARA_TERRAFORM_PROVIDER: "stackit"
       KUBARA_CLUSTER_TYPE: "hub"

--- a/.scripts/kubara-config-update.sh
+++ b/.scripts/kubara-config-update.sh
@@ -46,5 +46,7 @@ apply_yaml_if_set KUBARA_TERRAFORM_PROVIDER  ".clusters[0].terraform.provider"
 apply_yaml_if_set KUBARA_STACKIT_PROJECT_ID  ".clusters[0].terraform.projectId"
 apply_yaml_if_set KUBARA_KUBERNETES_TYPE     ".clusters[0].terraform.kubernetesType"
 apply_yaml_if_set KUBARA_KUBERNETES_VERSION  ".clusters[0].terraform.kubernetesVersion"
+apply_yaml_if_set KUBARA_DNS_NAME            ".clusters[0].dnsName"
+apply_yaml_if_set KUBARA_DNS_NAME            ".clusters[0].terraform.dns.name"
 
 log "✅ config.yaml updated"

--- a/.scripts/kubara-env-update.sh
+++ b/.scripts/kubara-env-update.sh
@@ -35,7 +35,6 @@ log "Updating .env (strict mode, no secret output): $ENV_FILE"
 # --- KUBARA_* -> .env KEY ---
 apply_if_set KUBARA_PROJECT_NAME           PROJECT_NAME
 apply_if_set KUBARA_PROJECT_STAGE          PROJECT_STAGE
-apply_if_set KUBARA_DOMAIN_NAME            DOMAIN_NAME
 
 apply_if_set KUBARA_DOCKERCONFIG_BASE64    DOCKERCONFIG_BASE64
 

--- a/src/cmd/bootstrap.go
+++ b/src/cmd/bootstrap.go
@@ -12,7 +12,6 @@ import (
 	"github.com/kubara-io/kubara/internal/cmd/bootstrap"
 	"github.com/kubara-io/kubara/internal/config"
 	"github.com/kubara-io/kubara/internal/envconfig"
-	"github.com/kubara-io/kubara/internal/localmode"
 	"github.com/kubara-io/kubara/internal/render"
 	"github.com/kubara-io/kubara/internal/utils"
 
@@ -282,9 +281,6 @@ func prepareBootstrapEnv(cluster *config.Cluster, envMap *envconfig.EnvMap, loca
 	}
 	if !envconfig.IsConfiguredEnvValue(prepared.ProjectStage) {
 		prepared.ProjectStage = cluster.Stage
-	}
-	if !envconfig.IsConfiguredEnvValue(prepared.DomainName) {
-		prepared.DomainName = localmode.DomainName
 	}
 
 	return &prepared, nil

--- a/src/cmd/testutil/testutil.go
+++ b/src/cmd/testutil/testutil.go
@@ -86,7 +86,6 @@ func CreateDefaultGenerateTestEnv(t *testing.T, dir string) string {
 		ArgocdHelmRepoUrl:           "https://example.com",
 		ArgocdHelmRepoUsername:      "CoolCapybara",
 		ArgocdHelmRepoPassword:      "password",
-		DomainName:                  "example.com",
 	})
 }
 

--- a/src/internal/config/factory.go
+++ b/src/internal/config/factory.go
@@ -9,7 +9,7 @@ import (
 )
 
 func NewClusterFromEnvWithCatalog(e *envconfig.EnvMap, catalogOptions catalog.LoadOptions) (Cluster, error) {
-	dnsName := e.ProjectName + "-" + e.ProjectStage + "." + e.DomainName
+	dnsName := e.ProjectName + "." + e.DomainName
 	services, err := createServicesFromCatalogWithOptions(catalogOptions, "")
 	if err != nil {
 		return Cluster{}, fmt.Errorf("create services from catalog: %w", err)

--- a/src/internal/config/factory.go
+++ b/src/internal/config/factory.go
@@ -9,7 +9,6 @@ import (
 )
 
 func NewClusterFromEnvWithCatalog(e *envconfig.EnvMap, catalogOptions catalog.LoadOptions) (Cluster, error) {
-	dnsName := e.ProjectName + "." + e.DomainName
 	services, err := createServicesFromCatalogWithOptions(catalogOptions, "")
 	if err != nil {
 		return Cluster{}, fmt.Errorf("create services from catalog: %w", err)
@@ -40,7 +39,7 @@ func NewClusterFromEnvWithCatalog(e *envconfig.EnvMap, catalogOptions catalog.Lo
 		Name:             e.ProjectName,
 		Stage:            e.ProjectStage,
 		Type:             "<hub or spoke>",
-		DNSName:          dnsName,
+		DNSName:          "<for example project.my-domain.com>",
 		SSOOrg:           "<my-org>",
 		SSOTeam:          "<my-team>",
 		IngressClassName: "traefik",

--- a/src/internal/config/factory.go
+++ b/src/internal/config/factory.go
@@ -49,7 +49,7 @@ func NewClusterFromEnvWithCatalog(e *envconfig.EnvMap, catalogOptions catalog.Lo
 			KubernetesType:    "<edge, ske or cce>",
 			KubernetesVersion: "1.34",
 			DNS: DNS{
-				Name:  dnsName,
+				Name:  "<same as DNSName above>",
 				Email: "my-test@nowhere.com",
 			},
 		},

--- a/src/internal/config/factory.go
+++ b/src/internal/config/factory.go
@@ -39,7 +39,7 @@ func NewClusterFromEnvWithCatalog(e *envconfig.EnvMap, catalogOptions catalog.Lo
 		Name:             e.ProjectName,
 		Stage:            e.ProjectStage,
 		Type:             "<hub or spoke>",
-		DNSName:          "<for example project.my-domain.com>",
+		DNSName:          "<subdomain.my-domain.com>",
 		SSOOrg:           "<my-org>",
 		SSOTeam:          "<my-team>",
 		IngressClassName: "traefik",
@@ -49,7 +49,7 @@ func NewClusterFromEnvWithCatalog(e *envconfig.EnvMap, catalogOptions catalog.Lo
 			KubernetesType:    "<edge, ske or cce>",
 			KubernetesVersion: "1.34",
 			DNS: DNS{
-				Name:  "<same as DNSName above>",
+				Name:  "<subdomain.my-domain.com>",
 				Email: "my-test@nowhere.com",
 			},
 		},

--- a/src/internal/config/factory_test.go
+++ b/src/internal/config/factory_test.go
@@ -18,20 +18,17 @@ func TestNewClusterFromEnv(t *testing.T) {
 	sampleEnvMap := &envconfig.EnvMap{
 		ProjectName:       "kubara-test",
 		ProjectStage:      "dev",
-		DomainName:        "example.com",
 		ArgocdGitHttpsUrl: "https://github.com/org/repo.git",
 		ArgocdHelmRepoUrl: "https://charts.example.com",
 	}
 	sampleEnvMapWithoutHelmRepo := &envconfig.EnvMap{
 		ProjectName:       "kubara-test",
 		ProjectStage:      "dev",
-		DomainName:        "example.com",
 		ArgocdGitHttpsUrl: "https://github.com/org/repo.git",
 	}
 	sampleEnvMapWithOCIHelmRepo := &envconfig.EnvMap{
 		ProjectName:       "kubara-test",
 		ProjectStage:      "dev",
-		DomainName:        "example.com",
 		ArgocdGitHttpsUrl: "https://github.com/org/repo.git",
 		ArgocdHelmRepoUrl: "oci://registry-1.docker.io/bitnamicharts",
 	}
@@ -162,7 +159,6 @@ func TestNewClusterFromEnvWithCatalog_ReturnsErrorWhenCatalogLoadFails(t *testin
 	sampleEnvMap := &envconfig.EnvMap{
 		ProjectName:       "kubara-test",
 		ProjectStage:      "dev",
-		DomainName:        "example.com",
 		ArgocdGitHttpsUrl: "https://github.com/org/repo.git",
 	}
 

--- a/src/internal/config/factory_test.go
+++ b/src/internal/config/factory_test.go
@@ -38,7 +38,7 @@ func TestNewClusterFromEnv(t *testing.T) {
 
 	// 2. Manually construct the expected Cluster struct based on the sampleEnvMap.
 	// This is what we expect the function to return.
-	expectedDNSName := "kubara-test-dev.example.com"
+	expectedDNSName := "<subdomain.my-domain.com>"
 	expectedCluster := Cluster{
 		Name:             "kubara-test",
 		Stage:            "dev",

--- a/src/internal/envconfig/env.go
+++ b/src/internal/envconfig/env.go
@@ -34,9 +34,6 @@ type EnvMap struct {
 	_                           struct{} `doc:"\n# Project related values"`
 	ProjectName                 string   `default:"<...>" koanf:"PROJECT_NAME"`
 	ProjectStage                string   `default:"<...>" koanf:"PROJECT_STAGE"`
-	_                           struct{} `doc:"\n# DNS Name/Zones related value"`
-	_                           struct{} `doc:"# the value should be looking like 'stackit.zone' eg. 'yourDomain.com'"`
-	DomainName                  string   `default:"<...>" koanf:"DOMAIN_NAME"`
 	_                           struct{} `doc:"\n# Argo CD related values"`
 	_                           struct{} `doc:"# Initial Admin Account Password for Argo CD."`
 	ArgocdWizardAccountPassword string   `default:"<...>" koanf:"ARGOCD_WIZARD_ACCOUNT_PASSWORD"`

--- a/src/internal/envconfig/env.go
+++ b/src/internal/envconfig/env.go
@@ -34,9 +34,7 @@ type EnvMap struct {
 	_                           struct{} `doc:"\n# Project related values"`
 	ProjectName                 string   `default:"<...>" koanf:"PROJECT_NAME"`
 	ProjectStage                string   `default:"<...>" koanf:"PROJECT_STAGE"`
-	_                           struct{} `doc:"\n# DNS Name/Zones related values"`
-	_                           struct{} `doc:"# The Domain name under which your dns-entries will be added."`
-	_                           struct{} `doc:"# The resulting dnsName name will be a concatenation of <PROJECT_NAME>.<DOMAIN_NAME> and will be used in clusters[].dnsName and clusters[].terraform.dns.name in config.yaml"`
+	_                           struct{} `doc:"\n# DNS Name/Zones related value"`
 	_                           struct{} `doc:"# the value should be looking like 'stackit.zone' eg. 'yourDomain.com'"`
 	DomainName                  string   `default:"<...>" koanf:"DOMAIN_NAME"`
 	_                           struct{} `doc:"\n# Argo CD related values"`

--- a/src/internal/envconfig/env.go
+++ b/src/internal/envconfig/env.go
@@ -36,7 +36,7 @@ type EnvMap struct {
 	ProjectStage                string   `default:"<...>" koanf:"PROJECT_STAGE"`
 	_                           struct{} `doc:"\n# DNS Name/Zones related values"`
 	_                           struct{} `doc:"# The Domain name under which your dns-entries will be added."`
-	_                           struct{} `doc:"# The resulting dnsZone name will be a concatenation of <PROJECT_NAME>-<PROJECT_STAGE>.<DOMAIN_NAME>"`
+	_                           struct{} `doc:"# The resulting dnsName name will be a concatenation of <PROJECT_NAME>.<DOMAIN_NAME> and will be used in clusters[].dnsName and clusters[].terraform.dns.name in config.yaml"`
 	_                           struct{} `doc:"# the value should be looking like 'stackit.zone' eg. 'yourDomain.com'"`
 	DomainName                  string   `default:"<...>" koanf:"DOMAIN_NAME"`
 	_                           struct{} `doc:"\n# Argo CD related values"`

--- a/src/internal/envconfig/env_test.go
+++ b/src/internal/envconfig/env_test.go
@@ -91,7 +91,6 @@ func TestEnvMap_Validate(t *testing.T) {
 			ArgocdHelmRepoPassword:      "helm-pass",
 			ArgocdHelmRepoUrl:           "https://helm.example.com",
 			ArgocdGitHttpsUrl:           "https://github.com/example/repo.git",
-			DomainName:                  "example.com",
 		}
 	}
 
@@ -146,7 +145,6 @@ func TestEnvMap_Validate(t *testing.T) {
 				em := validEnvMap()
 				em.ProjectName = ""
 				em.ProjectStage = ""
-				em.DomainName = ""
 				return em
 			}(),
 			wantErr: true,
@@ -187,15 +185,6 @@ func TestEnvMap_setDefaults(t *testing.T) {
 			fieldName:     "ProjectName",
 		},
 		{
-			name:   "Sets default for DomainName when empty",
-			envMap: &EnvMap{},
-			checkField: func(em *EnvMap) string {
-				return em.DomainName
-			},
-			expectedValue: "<...>",
-			fieldName:     "DomainName",
-		},
-		{
 			name: "Does not overwrite existing value",
 			envMap: &EnvMap{
 				ProjectName: "existing-project",
@@ -233,7 +222,6 @@ func TestEnvMap_setDefaults_AllFields(t *testing.T) {
 		assert.Equal(t, "<...>", em.ArgocdGitHttpsUrl)
 		assert.Equal(t, "", em.ArgocdGitPatOrPassword)
 		assert.Equal(t, "", em.ArgocdGitUsername)
-		assert.Equal(t, "<...>", em.DomainName)
 	})
 }
 
@@ -266,7 +254,7 @@ func TestEnvMap_Validate_ErrorMessages(t *testing.T) {
 			// Only set some required fields, leave others empty
 			ProjectName:  "test",
 			ProjectStage: "dev",
-			// Leave DomainName and others empty
+			// Leave others empty
 		}
 
 		err := em.Validate()
@@ -275,7 +263,7 @@ func TestEnvMap_Validate_ErrorMessages(t *testing.T) {
 		var envMapErr *ErrorEnvMap
 		require.True(t, errors.As(err, &envMapErr))
 		assert.Contains(t, envMapErr.Message, "Vars not set:")
-		assert.Contains(t, envMapErr.Message, "DOMAIN_NAME")
+		assert.Contains(t, envMapErr.Message, "ARGOCD_GIT_HTTPS_URL")
 	})
 
 	t.Run("Error message contains field names for default values", func(t *testing.T) {
@@ -287,7 +275,6 @@ func TestEnvMap_Validate_ErrorMessages(t *testing.T) {
 			ArgocdHelmRepoPassword:      "test",
 			ArgocdHelmRepoUrl:           "test",
 			ArgocdGitHttpsUrl:           "test",
-			DomainName:                  "test",
 		}
 
 		err := em.Validate()

--- a/src/internal/envconfig/store_test.go
+++ b/src/internal/envconfig/store_test.go
@@ -94,7 +94,6 @@ func TestEnvStore_SetDefaults(t *testing.T) {
 		// Verify that defaults were set
 		assert.Equal(t, "<...>", es.envMap.ProjectName)
 		assert.Equal(t, "<...>", es.envMap.ProjectStage)
-		assert.Equal(t, "<...>", es.envMap.DomainName)
 	})
 }
 
@@ -112,7 +111,6 @@ ARGOCD_HELM_REPO_URL='https://helm.example.com'
 ARGOCD_GIT_HTTPS_URL='https://github.com/example/repo.git'
 ARGOCD_GIT_PAT_OR_PASSWORD='github-token'
 ARGOCD_GIT_USERNAME='git-user'
-DOMAIN_NAME='example.com'
 `
 
 	validFilepath := filepath.Join(tempDir, "valid.env")
@@ -138,7 +136,6 @@ PROJECT_STAGE='dev'`
 			checkFunc: func(t *testing.T, em *EnvMap) {
 				assert.Equal(t, "test-project", em.ProjectName)
 				assert.Equal(t, "dev", em.ProjectStage)
-				assert.Equal(t, "example.com", em.DomainName)
 			},
 		},
 		{
@@ -189,8 +186,7 @@ func TestEnvStore_Load_EnvironmentOverride(t *testing.T) {
 
 		// Create a file with initial values
 		fileContent := `PROJECT_NAME='file-project'
-PROJECT_STAGE='dev'
-DOMAIN_NAME='file-domain.com'`
+PROJECT_STAGE='dev'`
 		filepath := filepath.Join(tempDir, "test.env")
 		require.NoError(t, os.WriteFile(filepath, []byte(fileContent), 0644))
 
@@ -245,7 +241,6 @@ func TestEnvStore_Validate(t *testing.T) {
 				ArgocdGitHttpsUrl:           "url",
 				ArgocdGitPatOrPassword:      "token",
 				ArgocdGitUsername:           "user",
-				DomainName:                  "example.com",
 			},
 			wantErr: false,
 		},
@@ -292,7 +287,6 @@ func TestEnvStore_GenerateEnvExample(t *testing.T) {
 				// Check that all required fields are present with default values
 				assert.Contains(t, outputStr, "PROJECT_NAME='<...>'")
 				assert.Contains(t, outputStr, "PROJECT_STAGE='<...>'")
-				assert.Contains(t, outputStr, "DOMAIN_NAME='<...>'")
 				assert.Contains(t, outputStr, "DOCKERCONFIG_BASE64=''")
 				assert.Contains(t, outputStr, "ARGOCD_WIZARD_ACCOUNT_PASSWORD='<...>'")
 				assert.Contains(t, outputStr, "ARGOCD_GIT_PAT_OR_PASSWORD=''")

--- a/src/internal/localmode/localmode.go
+++ b/src/internal/localmode/localmode.go
@@ -40,9 +40,6 @@ func PopulateInitEnv(env *envconfig.EnvMap) {
 	if !envconfig.IsConfiguredEnvValue(env.ProjectStage) {
 		env.ProjectStage = DefaultProjectStage
 	}
-	if !envconfig.IsConfiguredEnvValue(env.DomainName) {
-		env.DomainName = DomainName
-	}
 	if !envconfig.IsConfiguredEnvValue(env.ArgocdGitHttpsUrl) {
 		env.ArgocdGitHttpsUrl = ExampleGitRepoURL
 	}

--- a/src/internal/workflow/orchestrator.go
+++ b/src/internal/workflow/orchestrator.go
@@ -2,6 +2,7 @@ package workflow
 
 import (
 	"fmt"
+
 	"github.com/kubara-io/kubara/internal/catalog"
 	"github.com/kubara-io/kubara/internal/config"
 	"github.com/kubara-io/kubara/internal/envconfig"
@@ -9,7 +10,6 @@ import (
 
 func CreateOrUpdateClusterFromEnvWithCatalog(cfg *config.Config, e *envconfig.EnvMap, catalogOptions catalog.LoadOptions) error {
 	clusterName := e.ProjectName
-	dnsName := e.ProjectName + "-" + e.ProjectStage + "." + e.DomainName
 
 	// Attempt to find the cluster to update
 	for i := range cfg.Clusters {
@@ -18,10 +18,6 @@ func CreateOrUpdateClusterFromEnvWithCatalog(cfg *config.Config, e *envconfig.En
 
 			// Apply the new values from the environment to the found cluster.
 			cfg.Clusters[i].Stage = e.ProjectStage
-			cfg.Clusters[i].DNSName = dnsName
-			if cfg.Clusters[i].Terraform != nil {
-				cfg.Clusters[i].Terraform.DNS.Name = dnsName
-			}
 			cfg.Clusters[i].ArgoCD.Repo.HTTPS.Managed.URL = e.ArgocdGitHttpsUrl
 			cfg.Clusters[i].ArgoCD.Repo.HTTPS.Customer.URL = e.ArgocdGitHttpsUrl
 			if envconfig.IsConfiguredEnvValue(e.ArgocdHelmRepoUrl) {

--- a/src/internal/workflow/orchestrator_test.go
+++ b/src/internal/workflow/orchestrator_test.go
@@ -44,7 +44,6 @@ func TestCreateOrUpdateClusterFromEnv_UpdatesExistingClusterIncludingHelmRepo(t 
 	e := &envconfig.EnvMap{
 		ProjectName:       "kubara-test",
 		ProjectStage:      "dev",
-		DomainName:        "example.com",
 		ArgocdGitHttpsUrl: "https://github.com/new/repo.git",
 		ArgocdHelmRepoUrl: "https://charts.example.com",
 	}
@@ -91,7 +90,6 @@ func TestCreateOrUpdateClusterFromEnv_UpdatesExistingClusterWithoutTerraform(t *
 	e := &envconfig.EnvMap{
 		ProjectName:       "kubara-test",
 		ProjectStage:      "dev",
-		DomainName:        "example.com",
 		ArgocdGitHttpsUrl: "https://github.com/new/repo.git",
 	}
 
@@ -112,7 +110,6 @@ func TestCreateOrUpdateClusterFromEnv_CreatesNewClusterWithHelmRepo(t *testing.T
 	e := &envconfig.EnvMap{
 		ProjectName:       "kubara-test",
 		ProjectStage:      "dev",
-		DomainName:        "example.com",
 		ArgocdGitHttpsUrl: "https://github.com/new/repo.git",
 		ArgocdHelmRepoUrl: "https://charts.example.com",
 	}
@@ -163,7 +160,6 @@ func TestCreateOrUpdateClusterFromEnv_DoesNotOverrideHelmRepoWhenEnvMissing(t *t
 	e := &envconfig.EnvMap{
 		ProjectName:       "kubara-test",
 		ProjectStage:      "dev",
-		DomainName:        "example.com",
 		ArgocdGitHttpsUrl: "https://github.com/new/repo.git",
 	}
 
@@ -181,7 +177,6 @@ func TestCreateOrUpdateClusterFromEnv_CreatesNewClusterWithoutHelmRepoWhenEnvMis
 	e := &envconfig.EnvMap{
 		ProjectName:       "kubara-test",
 		ProjectStage:      "dev",
-		DomainName:        "example.com",
 		ArgocdGitHttpsUrl: "https://github.com/new/repo.git",
 	}
 
@@ -198,7 +193,6 @@ func TestCreateOrUpdateClusterFromEnv_NormalizesOCIHelmRepoURL(t *testing.T) {
 	e := &envconfig.EnvMap{
 		ProjectName:       "kubara-test",
 		ProjectStage:      "dev",
-		DomainName:        "example.com",
 		ArgocdGitHttpsUrl: "https://github.com/new/repo.git",
 		ArgocdHelmRepoUrl: "oci://registry-1.docker.io/bitnamicharts",
 	}
@@ -217,7 +211,6 @@ func TestCreateOrUpdateClusterFromEnvWithCatalog_ReturnsErrorWhenCatalogLoadFail
 	e := &envconfig.EnvMap{
 		ProjectName:       "kubara-test",
 		ProjectStage:      "dev",
-		DomainName:        "example.com",
 		ArgocdGitHttpsUrl: "https://github.com/new/repo.git",
 	}
 

--- a/src/internal/workflow/orchestrator_test.go
+++ b/src/internal/workflow/orchestrator_test.go
@@ -55,8 +55,8 @@ func TestCreateOrUpdateClusterFromEnv_UpdatesExistingClusterIncludingHelmRepo(t 
 	require.Len(t, cfg.Clusters, 1)
 	updated := cfg.Clusters[0]
 	assert.Equal(t, "dev", updated.Stage)
-	assert.Equal(t, "kubara-test-dev.example.com", updated.DNSName)
-	assert.Equal(t, "kubara-test-dev.example.com", updated.Terraform.DNS.Name)
+	assert.Equal(t, "kubara-test-stage.example.com", updated.DNSName)
+	assert.Equal(t, "kubara-test-stage.example.com", updated.Terraform.DNS.Name)
 	assert.Equal(t, "https://github.com/new/repo.git", updated.ArgoCD.Repo.HTTPS.Managed.URL)
 	assert.Equal(t, "https://github.com/new/repo.git", updated.ArgoCD.Repo.HTTPS.Customer.URL)
 	require.NotNil(t, updated.ArgoCD.HelmRepo)
@@ -101,7 +101,7 @@ func TestCreateOrUpdateClusterFromEnv_UpdatesExistingClusterWithoutTerraform(t *
 	require.Len(t, cfg.Clusters, 1)
 	updated := cfg.Clusters[0]
 	assert.Equal(t, "dev", updated.Stage)
-	assert.Equal(t, "kubara-test-dev.example.com", updated.DNSName)
+	assert.Equal(t, "kubara-test-stage.example.com", updated.DNSName)
 	assert.Nil(t, updated.Terraform)
 	assert.Equal(t, "https://github.com/new/repo.git", updated.ArgoCD.Repo.HTTPS.Managed.URL)
 	assert.Equal(t, "https://github.com/new/repo.git", updated.ArgoCD.Repo.HTTPS.Customer.URL)


### PR DESCRIPTION
## 📝 Summary
<!-- Please read first: https://github.com/kubara-io/kubara/blob/main/CONTRIBUTING.md -->
  
<!-- What does this PR do? e.g. "Adds Terraform module for SKE setup" -->

We wanted to change the default behaviour for dns-names which generated a name from .env values by appending project-name.stage.domain.

Now it will be manually configured in config.yaml both for "clusters[].dnsName" and "clusters[].terraform.dns.name"
Pipeline will also set the value manually and not assume there is some logic generating these fields.

## 🧩 Type of change
- [x] 🔧 CLI / Go code
- [ ] 📦 Helm chart
- [ ] 🧱 Terraform module
- [ ] 📝 Documentation
- [x] 🧪 Test or CI change
- [x] ♻️ Refactor / cleanup

## ⚠️ Is this a breaking change?
- [ ] Yes, this change breaks existing functionality (explain in summary)

## 🧪 Testing
- [ ] CI passed
- [x] Manually tested (local/dev cluster)
- [ ] Unit tested
- [ ] Not tested (explain why below)
  
## 🔗 Related Issues / Tickets
<!-- e.g. Closes #42, Related to #99 -->

## ✅ Checklist
- [x] Code compiles and passes all tests
- [x] Linting and style checks pass
- [ ] Comments added for complex logic
- [ ] Documentation updated (if applicable)
  
## 📎 Additional Context (optional)
<!-- Add logs, screenshots, diagrams, or design notes. -->
