### PR TITLE
feat: add argocd managed namespaces support and user token auth for cluster secrets

### DIFF
--- a/docs/content/4_building_your_platform/add_spoke_cluster.md
+++ b/docs/content/4_building_your_platform/add_spoke_cluster.md
@@ -60,6 +60,22 @@ The config expects the kubeconfig to be reachable under:
 <cluster-name>/<cluster-stage>/argocd/<spoke-name>-<spoke-stage>
 And the secret itself simply be named `kubeconfig`.
 
+By default kubara keeps the original client-certificate based Argo CD cluster config.
+If your kubeconfig should be used with bearer token auth in addition to the certificates, set
+`bootstrapValues.cluster[].authMethod: token` in your Argo CD values. Note that `authMethod` must be exactly `token` or `clientCertificate` (defaults to `clientCertificate`); any other value will trigger a template rendering error.
+
+If Argo CD should only manage selected namespaces on the spoke cluster, set `bootstrapValues.cluster[].namespaces` to the allowed list of namespaces in your Argo CD values (as a YAML list):
+
+```yaml
+bootstrapValues:
+  cluster:
+    - name: spoke-dev
+      namespaces:
+        - team-a
+        - team-b
+```
+
+
 
 ## 4. Prepare external-secrets credentials on the spoke cluster
 

--- a/src/internal/catalog/built-in/platform-components/helm/argo-cd/CHANGELOG.md
+++ b/src/internal/catalog/built-in/platform-components/helm/argo-cd/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.0] - 2026-07-10
+### Changed
+- Bump template-library dependency to 0.2.0 for bearerToken authentication support
+
 ## [1.1.0] - 2026-07-10
 ### Changed
 - Updated chart dependency version: argo-cd 10.0.0 → 10.1.3

--- a/src/internal/catalog/built-in/platform-components/helm/argo-cd/Chart.yaml
+++ b/src/internal/catalog/built-in/platform-components/helm/argo-cd/Chart.yaml
@@ -3,11 +3,11 @@ apiVersion: v2
 name: argocd
 description: Umbrella Chart for argo-cd
 type: application
-version: 1.1.0
+version: 1.2.0
 dependencies:
   - name: template-library
     repository: file://../template-library
-    version: 0.1.0
+    version: 0.2.0
   # https://artifacthub.io/packages/helm/argo/argo-cd
   - name: argo-cd
     repository: https://argoproj.github.io/argo-helm

--- a/src/internal/catalog/built-in/platform-components/helm/cert-manager/CHANGELOG.md
+++ b/src/internal/catalog/built-in/platform-components/helm/cert-manager/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2026-07-10
+### Changed
+- Bump template-library dependency to 0.2.0
+
 ## [0.4.0] - 2026-07-10
 ### Changed
 - Updated chart dependency version: cert-manager v1.20.3 → v1.21.0

--- a/src/internal/catalog/built-in/platform-components/helm/cert-manager/Chart.yaml
+++ b/src/internal/catalog/built-in/platform-components/helm/cert-manager/Chart.yaml
@@ -7,7 +7,7 @@ version: 0.4.0
 dependencies:
   - name: template-library
     repository: file://../template-library
-    version: 0.1.0
+    version: 0.2.0
   - name: cert-manager
     version: v1.21.0
     repository: https://charts.jetstack.io

--- a/src/internal/catalog/built-in/platform-components/helm/cert-manager/Chart.yaml
+++ b/src/internal/catalog/built-in/platform-components/helm/cert-manager/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: cert-manager
 description: Umbrella Chart for cert-manager
 type: application
-version: 0.4.0
+version: 0.5.0
 dependencies:
   - name: template-library
     repository: file://../template-library

--- a/src/internal/catalog/built-in/platform-components/helm/external-dns/CHANGELOG.md
+++ b/src/internal/catalog/built-in/platform-components/helm/external-dns/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2026-07-10
+### Changed
+- Bump template-library dependency to 0.2.0
+
 ## [0.2.1] - 2026-05-18
 ### Fixed
 - Align STACKIT webhook port configuration with the external-dns chart defaults.

--- a/src/internal/catalog/built-in/platform-components/helm/external-dns/Chart.yaml
+++ b/src/internal/catalog/built-in/platform-components/helm/external-dns/Chart.yaml
@@ -7,7 +7,7 @@ version: 0.2.1
 dependencies:
   - name: template-library
     repository: file://../template-library
-    version: 0.1.0
+    version: 0.2.0
   - name: external-dns
     repository: https://kubernetes-sigs.github.io/external-dns/
     version: 1.21.1

--- a/src/internal/catalog/built-in/platform-components/helm/external-dns/Chart.yaml
+++ b/src/internal/catalog/built-in/platform-components/helm/external-dns/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: external-dns
 description: Umbrella Chart for external-dns
 type: application
-version: 0.2.1
+version: 0.3.0
 dependencies:
   - name: template-library
     repository: file://../template-library

--- a/src/internal/catalog/built-in/platform-components/helm/external-secrets/CHANGELOG.md
+++ b/src/internal/catalog/built-in/platform-components/helm/external-secrets/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.0] - 2026-07-10
+### Changed
+- Bump template-library dependency to 0.2.0
+
 ## [0.12.0] - 2026-06-29
 ### Changed
 - Updated chart dependency version: external-secrets 2.6.0 → 2.7.0

--- a/src/internal/catalog/built-in/platform-components/helm/external-secrets/Chart.yaml
+++ b/src/internal/catalog/built-in/platform-components/helm/external-secrets/Chart.yaml
@@ -7,7 +7,7 @@ version: 0.12.0
 dependencies:
   - name: template-library
     repository: file://../template-library
-    version: 0.1.0
+    version: 0.2.0
   - name: external-secrets
     repository: https://charts.external-secrets.io/
     version: 2.7.0  # https://artifacthub.io/packages/helm/external-secrets-operator/external-secrets

--- a/src/internal/catalog/built-in/platform-components/helm/external-secrets/Chart.yaml
+++ b/src/internal/catalog/built-in/platform-components/helm/external-secrets/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: externalSecrets
 description: Umbrella Chart for external-secrets
 type: application
-version: 0.12.0
+version: 0.13.0
 dependencies:
   - name: template-library
     repository: file://../template-library

--- a/src/internal/catalog/built-in/platform-components/helm/homer-dashboard/CHANGELOG.md
+++ b/src/internal/catalog/built-in/platform-components/helm/homer-dashboard/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.0] - 2026-07-10
+### Changed
+- Bump template-library dependency to 0.2.0
+
 ## [0.0.4] - 2026-02-05
 ### Changed
 - Updated chart dependency version: template-library 0.0.4 → 0.0.5

--- a/src/internal/catalog/built-in/platform-components/helm/homer-dashboard/Chart.yaml
+++ b/src/internal/catalog/built-in/platform-components/helm/homer-dashboard/Chart.yaml
@@ -7,4 +7,4 @@ version: 0.0.4
 dependencies:
   - name: template-library
     repository: file://../template-library
-    version: 0.1.0
+    version: 0.2.0

--- a/src/internal/catalog/built-in/platform-components/helm/homer-dashboard/Chart.yaml
+++ b/src/internal/catalog/built-in/platform-components/helm/homer-dashboard/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: homer-dashboard
 description: homer-dashboard
 type: application
-version: 0.0.4
+version: 0.1.0
 dependencies:
   - name: template-library
     repository: file://../template-library

--- a/src/internal/catalog/built-in/platform-components/helm/kube-prometheus-stack/CHANGELOG.md
+++ b/src/internal/catalog/built-in/platform-components/helm/kube-prometheus-stack/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.0] - 2026-07-10
+### Changed
+- Bump template-library dependency to 0.2.0
+
 ## [2.2.0] - 2026-07-10
 ### Changed
 - Updated chart dependency version: prometheus-blackbox-exporter 11.13.0 → 11.15.1

--- a/src/internal/catalog/built-in/platform-components/helm/kube-prometheus-stack/Chart.yaml
+++ b/src/internal/catalog/built-in/platform-components/helm/kube-prometheus-stack/Chart.yaml
@@ -7,7 +7,7 @@ version: 2.2.0
 dependencies:
   - name: template-library
     repository: file://../template-library
-    version: 0.1.0
+    version: 0.2.0
   - name: kube-prometheus-stack
     repository: https://prometheus-community.github.io/helm-charts
     version: 87.12.3

--- a/src/internal/catalog/built-in/platform-components/helm/kube-prometheus-stack/Chart.yaml
+++ b/src/internal/catalog/built-in/platform-components/helm/kube-prometheus-stack/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: kube-prometheus-stack
 description: Umbrella Chart for kube-prometheus-stack
 type: application
-version: 2.2.0
+version: 2.3.0
 dependencies:
   - name: template-library
     repository: file://../template-library

--- a/src/internal/catalog/built-in/platform-components/helm/kyverno-policy-reporter/CHANGELOG.md
+++ b/src/internal/catalog/built-in/platform-components/helm/kyverno-policy-reporter/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2026-07-10
+### Changed
+- Bump template-library dependency to 0.2.0
+
 ## [0.3.0] - 2026-07-10
 ### Changed
 - Updated chart dependency version: policy-reporter 3.7.4 → 3.8.1

--- a/src/internal/catalog/built-in/platform-components/helm/kyverno-policy-reporter/Chart.yaml
+++ b/src/internal/catalog/built-in/platform-components/helm/kyverno-policy-reporter/Chart.yaml
@@ -7,7 +7,7 @@ version: 0.3.0
 dependencies:
   - name: template-library
     repository: file://../template-library
-    version: 0.1.0
+    version: 0.2.0
   - name: policy-reporter
     repository: https://kyverno.github.io/policy-reporter
     version: 3.8.1

--- a/src/internal/catalog/built-in/platform-components/helm/kyverno-policy-reporter/Chart.yaml
+++ b/src/internal/catalog/built-in/platform-components/helm/kyverno-policy-reporter/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: kyverno-policy-reporter
 description: Umbrella Chart for kyverno-policy-reporter
 type: application
-version: 0.3.0
+version: 0.4.0
 dependencies:
   - name: template-library
     repository: file://../template-library

--- a/src/internal/catalog/built-in/platform-components/helm/kyverno/CHANGELOG.md
+++ b/src/internal/catalog/built-in/platform-components/helm/kyverno/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2026-07-10
+### Changed
+- Bump template-library dependency to 0.2.0
+
 ## [0.3.2] - 2026-07-10
 ### Changed
 - Updated chart dependency version: kyverno 3.8.1 → 3.8.2

--- a/src/internal/catalog/built-in/platform-components/helm/kyverno/Chart.yaml
+++ b/src/internal/catalog/built-in/platform-components/helm/kyverno/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: kyverno
 description: Umbrella Chart for kyverno
 type: application
-version: 0.3.2
+version: 0.4.0
 dependencies:
   - name: template-library
     repository: file://../template-library

--- a/src/internal/catalog/built-in/platform-components/helm/kyverno/Chart.yaml
+++ b/src/internal/catalog/built-in/platform-components/helm/kyverno/Chart.yaml
@@ -7,7 +7,7 @@ version: 0.3.2
 dependencies:
   - name: template-library
     repository: file://../template-library
-    version: 0.1.0
+    version: 0.2.0
   - name: kyverno
     repository: https://kyverno.github.io/kyverno
     version: 3.8.2

--- a/src/internal/catalog/built-in/platform-components/helm/loki/CHANGELOG.md
+++ b/src/internal/catalog/built-in/platform-components/helm/loki/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.0] - 2026-07-10
+### Changed
+- Bump template-library dependency to 0.2.0
+
 ## [1.4.0] - 2026-06-15
 ### Changed
 - Updated chart dependency version: alloy 1.9.0 → 1.10.0

--- a/src/internal/catalog/built-in/platform-components/helm/loki/Chart.yaml
+++ b/src/internal/catalog/built-in/platform-components/helm/loki/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: loki
 description: Umbrella Chart for loki
 type: application
-version: 1.4.0
+version: 1.5.0
 dependencies:
   - name: template-library
     repository: file://../template-library

--- a/src/internal/catalog/built-in/platform-components/helm/loki/Chart.yaml
+++ b/src/internal/catalog/built-in/platform-components/helm/loki/Chart.yaml
@@ -7,7 +7,7 @@ version: 1.4.0
 dependencies:
   - name: template-library
     repository: file://../template-library
-    version: 0.1.0
+    version: 0.2.0
   - name: loki
     repository: https://grafana.github.io/helm-charts
     version: 7.0.0

--- a/src/internal/catalog/built-in/platform-components/helm/longhorn/CHANGELOG.md
+++ b/src/internal/catalog/built-in/platform-components/helm/longhorn/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2026-07-10
+### Changed
+- Bump template-library dependency to 0.2.0
+
 ## [0.3.0] - 2026-06-12
 ### Changed
 - Updated chart dependency version: longhorn 1.11.2 → 1.12.0

--- a/src/internal/catalog/built-in/platform-components/helm/longhorn/Chart.yaml
+++ b/src/internal/catalog/built-in/platform-components/helm/longhorn/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: longhorn
 description: Umbrella Chart for longhorn
 type: application
-version: 0.3.0
+version: 0.4.0
 dependencies:
   - name: template-library
     repository: file://../template-library

--- a/src/internal/catalog/built-in/platform-components/helm/longhorn/Chart.yaml
+++ b/src/internal/catalog/built-in/platform-components/helm/longhorn/Chart.yaml
@@ -7,7 +7,7 @@ version: 0.3.0
 dependencies:
   - name: template-library
     repository: file://../template-library
-    version: 0.1.0
+    version: 0.2.0
   # https://artifacthub.io/packages/helm/argo/argo-cd
   - name: longhorn
     repository: https://charts.longhorn.io

--- a/src/internal/catalog/built-in/platform-components/helm/metallb/CHANGELOG.md
+++ b/src/internal/catalog/built-in/platform-components/helm/metallb/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2026-07-10
+### Changed
+- Bump template-library dependency to 0.2.0
+
 ## [0.1.1] - 2026-06-01
 ### Changed
 - Updated chart dependency version: metallb 0.16.0 → 0.16.1

--- a/src/internal/catalog/built-in/platform-components/helm/metallb/Chart.yaml
+++ b/src/internal/catalog/built-in/platform-components/helm/metallb/Chart.yaml
@@ -7,7 +7,7 @@ version: 0.1.1
 dependencies:
   - name: template-library
     repository: file://../template-library
-    version: 0.1.0
+    version: 0.2.0
   # https://artifacthub.io/packages/helm/argo/argo-cd
   - name: metallb
     repository: https://metallb.github.io/metallb

--- a/src/internal/catalog/built-in/platform-components/helm/metallb/Chart.yaml
+++ b/src/internal/catalog/built-in/platform-components/helm/metallb/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: metallb
 description: Umbrella Chart for metalb
 type: application
-version: 0.1.1
+version: 0.2.0
 dependencies:
   - name: template-library
     repository: file://../template-library

--- a/src/internal/catalog/built-in/platform-components/helm/metrics-server/CHANGELOG.md
+++ b/src/internal/catalog/built-in/platform-components/helm/metrics-server/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.0] - 2026-07-10
+### Changed
+- Bump template-library dependency to 0.2.0
+
 ## [0.0.5] - 2026-06-12
 ### Changed
 - Updated chart dependency version: metrics-server 3.13.0 → 3.13.1

--- a/src/internal/catalog/built-in/platform-components/helm/metrics-server/Chart.yaml
+++ b/src/internal/catalog/built-in/platform-components/helm/metrics-server/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: metrics-server
 description: Umbrella Chart for metrics-server
 type: application
-version: 0.0.5
+version: 0.1.0
 dependencies:
   - name: template-library
     repository: file://../template-library

--- a/src/internal/catalog/built-in/platform-components/helm/metrics-server/Chart.yaml
+++ b/src/internal/catalog/built-in/platform-components/helm/metrics-server/Chart.yaml
@@ -7,7 +7,7 @@ version: 0.0.5
 dependencies:
   - name: template-library
     repository: file://../template-library
-    version: 0.1.0
+    version: 0.2.0
   - name: metrics-server
     repository: https://kubernetes-sigs.github.io/metrics-server
     version: 3.13.1

--- a/src/internal/catalog/built-in/platform-components/helm/oauth2-proxy/CHANGELOG.md
+++ b/src/internal/catalog/built-in/platform-components/helm/oauth2-proxy/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.0] - 2026-07-10
+### Changed
+- Bump template-library dependency to 0.2.0
+
 ## [0.8.0] - 2026-06-12
 ### Changed
 - Updated chart dependency version: oauth2-proxy 10.6.0 → 10.7.0

--- a/src/internal/catalog/built-in/platform-components/helm/oauth2-proxy/Chart.yaml
+++ b/src/internal/catalog/built-in/platform-components/helm/oauth2-proxy/Chart.yaml
@@ -10,4 +10,4 @@ dependencies:
     version: 10.7.0
   - name: template-library
     repository: file://../template-library
-    version: 0.1.0
+    version: 0.2.0

--- a/src/internal/catalog/built-in/platform-components/helm/oauth2-proxy/Chart.yaml
+++ b/src/internal/catalog/built-in/platform-components/helm/oauth2-proxy/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: oauth2-proxy
 description: Umbrella Chart for oauth2-proxy
 type: application
-version: 0.8.0
+version: 0.9.0
 dependencies:
   - name: oauth2-proxy
     repository: https://oauth2-proxy.github.io/manifests

--- a/src/internal/catalog/built-in/platform-components/helm/template-library/CHANGELOG.md
+++ b/src/internal/catalog/built-in/platform-components/helm/template-library/CHANGELOG.md
@@ -4,9 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2026-07-10
+### Added
+- Support `bearerToken` with `authMethod: token` and `clientCertificate` for cluster authentication in ArgoCD
+
 ## [0.1.0] - 2026-07-08
 ### Added
-- TODO
+- Support for additional values files that follow the pattern `values-*.yaml`
+- Fixed refresh issue for customer-service-catalog/platform-configs based value file changes
 
 ## [0.0.5] - 2026-02-11
 ### Added

--- a/src/internal/catalog/built-in/platform-components/helm/template-library/Chart.yaml
+++ b/src/internal/catalog/built-in/platform-components/helm/template-library/Chart.yaml
@@ -3,4 +3,4 @@ apiVersion: v2
 name: template-library
 description: A library chart that provides templates for kubernetes resources.
 type: library
-version: 0.1.0
+version: 0.2.0

--- a/src/internal/catalog/built-in/platform-components/helm/template-library/templates/external-secrets/_externalSecret.es.argo.cluster.tpl
+++ b/src/internal/catalog/built-in/platform-components/helm/template-library/templates/external-secrets/_externalSecret.es.argo.cluster.tpl
@@ -1,4 +1,5 @@
 {{- define "templateLibrary.argocd.cluster" }}
+{{- $authMethod := default "clientCertificate" .authMethod -}}
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
@@ -28,8 +29,17 @@ spec:
         {{- if .project }}
         project: {{ .project }}
         {{- end }}
+        {{- if .namespaces }}
+        namespaces: {{ .namespaces | join "," }}
+        {{- end }}
         server: "{{ `{{ $k8sconfig := .config | fromYaml }}{{- $cluster := (index $k8sconfig.clusters 0) -}}{{ $cluster.cluster.server }}` }}"
+        {{- if eq $authMethod "token" }}
+        config: "{{ `{{ $k8sconfig := .config | fromYaml }}{{- $cluster := (index $k8sconfig.clusters 0) -}}{{- $user := (index $k8sconfig.users 0) -}}{{ printf \"{\\\"bearerToken\\\":%s,\\\"tlsClientConfig\\\":{\\\"caData\\\":%s,\\\"certData\\\":%s,\\\"insecure\\\":%s,\\\"keyData\\\":%s}}\" (index $user.user \"token\" | toJson) (index $cluster.cluster \"certificate-authority-data\" | toJson) (index $user.user \"client-certificate-data\" | toJson) \"false\" (index $user.user \"client-key-data\" | toJson) }}` }}"
+        {{- else if eq $authMethod "clientCertificate" }}
         config: "{{ `{{ $k8sconfig := .config | fromYaml }}{{- $cluster := (index $k8sconfig.clusters 0) -}}{{- $user := (index $k8sconfig.users 0) -}}{{ printf \"{\\\"bearerToken\\\":\\\"\\\",\\\"tlsClientConfig\\\":{\\\"caData\\\":%s,\\\"certData\\\":%s,\\\"insecure\\\":%s,\\\"keyData\\\":%s}}\" (index $cluster.cluster \"certificate-authority-data\" | toJson) (index $user.user \"client-certificate-data\" | toJson) \"false\" (index $user.user \"client-key-data\" | toJson) }}` }}"
+        {{- else }}
+        {{- fail (printf "Unknown authMethod %q, must be either 'token' or 'clientCertificate'" $authMethod) }}
+        {{- end }}
   data:
     - secretKey: config
       remoteRef:

--- a/src/internal/catalog/built-in/platform-components/helm/traefik/CHANGELOG.md
+++ b/src/internal/catalog/built-in/platform-components/helm/traefik/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.0] - 2026-07-10
+### Changed
+- Bump template-library dependency to 0.2.0
+
 ## [2.0.1] - 2026-07-10
 ### Changed
 - Updated chart dependency version: traefik 41.0.0 → 41.0.2

--- a/src/internal/catalog/built-in/platform-components/helm/traefik/Chart.yaml
+++ b/src/internal/catalog/built-in/platform-components/helm/traefik/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 name: traefik
-version: 2.0.1
+version: 2.1.0
 description: This Chart deploys traefik.
 dependencies:
   - name: traefik

--- a/src/internal/catalog/built-in/platform-components/helm/traefik/Chart.yaml
+++ b/src/internal/catalog/built-in/platform-components/helm/traefik/Chart.yaml
@@ -9,4 +9,4 @@ dependencies:
     repository: oci://ghcr.io/traefik/helm
   - name: template-library
     repository: file://../template-library
-    version: 0.1.0
+    version: 0.2.0

--- a/src/internal/catalog/built-in/platform-components/helm/velero/CHANGELOG.md
+++ b/src/internal/catalog/built-in/platform-components/helm/velero/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2026-07-10
+### Changed
+- Bump template-library dependency to 0.2.0
+
 ## [0.2.0] - 2026-06-29
 ### Changed
 - Updated chart dependency version: velero 12.0.3 → 12.1.0

--- a/src/internal/catalog/built-in/platform-components/helm/velero/Chart.yaml
+++ b/src/internal/catalog/built-in/platform-components/helm/velero/Chart.yaml
@@ -10,4 +10,4 @@ dependencies:
     repository: https://vmware-tanzu.github.io/helm-charts
   - name: template-library
     repository: file://../template-library
-    version: 0.1.0
+    version: 0.2.0

--- a/src/internal/catalog/built-in/platform-components/helm/velero/Chart.yaml
+++ b/src/internal/catalog/built-in/platform-components/helm/velero/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: velero
 description: Umbrella Chart for Velero Config
 type: application
-version: 0.2.0
+version: 0.3.0
 dependencies:
   - name: velero
     version: "12.1.0"


### PR DESCRIPTION
## 📝 Summary
Adds a small improvement to the Helm template for our cluster external secrets. 

* Adding a conditional block that includes the `namespaces` field in the generated cluster secret manifest when `.bootstrapValues.cluster[].namespaces` is set.
* Adding a conditional block to allow for using the user token in addition to the certificate based authentication


## 🧩 Type of change
- [ ] 🔧 CLI / Go code
- [X] 📦 Helm chart
- [ ] 🧱 Terraform module
- [X] 📝 Documentation
- [ ] 🧪 Test or CI change
- [ ] ♻️ Refactor / cleanup

## ⚠️ Is this a breaking change?
- [ ] Yes, this change breaks existing functionality (explain in summary)

## 🧪 Testing
- [X] CI passed
- [X] Manually tested (local/dev cluster)
- [ ] Unit tested
- [ ] Not tested (explain why below)
  
## 🔗 Related Issues / Tickets
<!-- e.g. Closes #42, Related to #99 -->

## ✅ Checklist
- [X] Code compiles and passes all tests
- [X] Linting and style checks pass
- [ ] Comments added for complex logic
- [X] Documentation updated (if applicable)
  
## 📎 Additional Context (optional)
<!-- Add logs, screenshots, diagrams, or design notes. -->
