### PR TITLE
fix(external-dns): publish the public IP via default-targets

### DIFF
--- a/src/internal/catalog/built-in/platform-configs/helm/argo-cd/values.generated.yaml.tplt
+++ b/src/internal/catalog/built-in/platform-configs/helm/argo-cd/values.generated.yaml.tplt
@@ -129,21 +129,14 @@ externalSecrets:
 
 {{- $oauth2ProxyStatus := dig "cluster" "services" "oauth2-proxy" "status" "disabled" . -}}
 {{- $traefikStatus := dig "cluster" "services" "traefik" "status" "disabled" . -}}
-{{- $metallbStatus := dig "cluster" "services" "metallb" "status" "disabled" . -}}
 {{- $certManagerIssuer := dig "cluster" "services" "cert-manager" "config" "clusterIssuer" "name" "letsencrypt-staging" . -}}
 {{- $argocdUserIngressAnnotations := dig "cluster" "services" "argocd" "networking" "annotations" (dict) . -}}
 {{- $argocdIngressGrpcAnnotations := dict "cert-manager.io/cluster-issuer" $certManagerIssuer -}}
-{{- if (eq $metallbStatus "enabled") -}}
-{{- $_ := set $argocdIngressGrpcAnnotations "external-dns.alpha.kubernetes.io/target" (dig "cluster" "services" "metallb" "config" "publicLoadBalancerIPs" "" .) -}}
-{{- end -}}
 {{- $argocdIngressGrpcAnnotations = mergeOverwrite $argocdIngressGrpcAnnotations $argocdUserIngressAnnotations -}}
 
 {{- $argocdIngressAnnotations := dict "cert-manager.io/cluster-issuer" $certManagerIssuer -}}
 {{- if (and (eq $oauth2ProxyStatus "enabled") (eq $traefikStatus "enabled")) -}}
 {{- $_ := set $argocdIngressAnnotations "traefik.ingress.kubernetes.io/router.middlewares" "oauth2-proxy-oauth-auth@kubernetescrd" -}}
-{{- end -}}
-{{- if (eq $metallbStatus "enabled") -}}
-{{- $_ := set $argocdIngressAnnotations "external-dns.alpha.kubernetes.io/target" (dig "cluster" "services" "metallb" "config" "publicLoadBalancerIPs" "" .) -}}
 {{- end -}}
 {{- $argocdIngressAnnotations = mergeOverwrite $argocdIngressAnnotations $argocdUserIngressAnnotations -}}
 

--- a/src/internal/catalog/built-in/platform-configs/helm/external-dns/values.generated.yaml.tplt
+++ b/src/internal/catalog/built-in/platform-configs/helm/external-dns/values.generated.yaml.tplt
@@ -66,6 +66,16 @@ external-dns:
   extraArgs:
     source:
       - traefik-proxy
+    {{- $publicLoadBalancerIP := dig "cluster" "services" "metallb" "config" "publicLoadBalancerIPs" "" . }}
+    {{- if $publicLoadBalancerIP }}
+    # The load balancer service holds a private address (e.g. a MetalLB pool
+    # IP) while the cluster is reached through a routed public IP. Publish that
+    # public IP for every record, overriding the private target the sources
+    # (ingress and traefik-proxy) would otherwise derive from the service.
+    default-targets:
+      - {{ $publicLoadBalancerIP }}
+    force-default-targets: true
+    {{- end }}
     webhook-provider-url: http://localhost:8080
   rbac:
     create: true

--- a/src/internal/catalog/built-in/platform-configs/helm/external-dns/values.generated.yaml.tplt
+++ b/src/internal/catalog/built-in/platform-configs/helm/external-dns/values.generated.yaml.tplt
@@ -66,14 +66,19 @@ external-dns:
   extraArgs:
     source:
       - traefik-proxy
-    {{- $publicLoadBalancerIP := dig "cluster" "services" "metallb" "config" "publicLoadBalancerIPs" "" . }}
-    {{- if $publicLoadBalancerIP }}
+    {{- $publicLoadBalancerIPs := dig "cluster" "services" "metallb" "config" "publicLoadBalancerIPs" "" . }}
+    {{- if $publicLoadBalancerIPs }}
     # The load balancer service holds a private address (e.g. a MetalLB pool
     # IP) while the cluster is reached through a routed public IP. Publish that
     # public IP for every record, overriding the private target the sources
     # (ingress and traefik-proxy) would otherwise derive from the service.
+    # publicLoadBalancerIPs is a comma-separated string; emit one target each.
     default-targets:
-      - {{ $publicLoadBalancerIP }}
+    {{- range (splitList "," $publicLoadBalancerIPs) }}
+    {{- with (. | trim) }}
+      - {{ . }}
+    {{- end }}
+    {{- end }}
     force-default-targets: true
     {{- end }}
     webhook-provider-url: http://localhost:8080

--- a/src/internal/catalog/built-in/platform-configs/helm/homer-dashboard/values.generated.yaml.tplt
+++ b/src/internal/catalog/built-in/platform-configs/helm/homer-dashboard/values.generated.yaml.tplt
@@ -5,7 +5,6 @@
 {{- $certManagerIssuer := dig "cluster" "services" "cert-manager" "config" "clusterIssuer" "name" "letsencrypt-staging" . }}
 {{- $oauth2ProxyStatus := dig "cluster" "services" "oauth2-proxy" "status" "disabled" . }}
 {{- $traefikStatus := dig "cluster" "services" "traefik" "status" "disabled" . }}
-{{- $metallbStatus := dig "cluster" "services" "metallb" "status" "disabled" . }}
 {{- $kubePrometheusStatus := dig "cluster" "services" "kube-prometheus-stack" "status" "disabled" . }}
 {{- $longhornStatus := dig "cluster" "services" "longhorn" "status" "disabled" . }}
 {{- $kyvernoStatus := dig "cluster" "services" "kyverno" "status" "disabled" . }}
@@ -16,9 +15,6 @@
 {{- $homerIngressAnnotations := dict "cert-manager.io/cluster-issuer" $certManagerIssuer }}
 {{- if (and (eq $oauth2ProxyStatus "enabled") (eq $traefikStatus "enabled")) }}
 {{- $_ := set $homerIngressAnnotations "traefik.ingress.kubernetes.io/router.middlewares" "oauth2-proxy-oauth-auth@kubernetescrd" }}
-{{- end }}
-{{- if (eq $metallbStatus "enabled") }}
-{{- $_ := set $homerIngressAnnotations "external-dns.alpha.kubernetes.io/target" (dig "cluster" "services" "metallb" "config" "publicLoadBalancerIPs" "" .) }}
 {{- end }}
 {{- $homerIngressAnnotations = mergeOverwrite $homerIngressAnnotations (dig "cluster" "services" "homer-dashboard" "networking" "annotations" (dict) .) }}
 

--- a/src/internal/catalog/built-in/platform-configs/helm/kube-prometheus-stack/values.generated.yaml.tplt
+++ b/src/internal/catalog/built-in/platform-configs/helm/kube-prometheus-stack/values.generated.yaml.tplt
@@ -5,11 +5,7 @@
 {{- $certManagerIssuer := dig "cluster" "services" "cert-manager" "config" "clusterIssuer" "name" "letsencrypt-staging" . }}
 {{- $oauth2ProxyStatus := dig "cluster" "services" "oauth2-proxy" "status" "disabled" . }}
 {{- $traefikStatus := dig "cluster" "services" "traefik" "status" "disabled" . }}
-{{- $metallbStatus := dig "cluster" "services" "metallb" "status" "disabled" . }}
 {{- $kubePromIngressAnnotations := dict "cert-manager.io/cluster-issuer" $certManagerIssuer }}
-{{- if (eq $metallbStatus "enabled") }}
-{{- $_ := set $kubePromIngressAnnotations "external-dns.alpha.kubernetes.io/target" (dig "cluster" "services" "metallb" "config" "publicLoadBalancerIPs" "" .) }}
-{{- end }}
 {{- if (and (eq $oauth2ProxyStatus "enabled") (eq $traefikStatus "enabled")) }}
 {{- $_ := set $kubePromIngressAnnotations "traefik.ingress.kubernetes.io/router.middlewares" "oauth2-proxy-oauth-auth@kubernetescrd" }}
 {{- end }}

--- a/src/internal/catalog/built-in/platform-configs/helm/kyverno-policy-reporter/values.generated.yaml.tplt
+++ b/src/internal/catalog/built-in/platform-configs/helm/kyverno-policy-reporter/values.generated.yaml.tplt
@@ -4,11 +4,7 @@
 
 {{- $oauth2ProxyStatus := dig "cluster" "services" "oauth2-proxy" "status" "disabled" . }}
 {{- $traefikStatus := dig "cluster" "services" "traefik" "status" "disabled" . }}
-{{- $metallbStatus := dig "cluster" "services" "metallb" "status" "disabled" . }}
 {{- $kyvernoPolicyReporterIngressAnnotations := dict "cert-manager.io/cluster-issuer" (dig "cluster" "services" "cert-manager" "config" "clusterIssuer" "name" "letsencrypt-staging" .) }}
-{{- if (eq $metallbStatus "enabled") }}
-{{- $_ := set $kyvernoPolicyReporterIngressAnnotations "external-dns.alpha.kubernetes.io/target" (dig "cluster" "services" "metallb" "config" "publicLoadBalancerIPs" "" .) }}
-{{- end }}
 {{- if (and (eq $oauth2ProxyStatus "enabled") (eq $traefikStatus "enabled")) }}
 {{- $_ := set $kyvernoPolicyReporterIngressAnnotations "traefik.ingress.kubernetes.io/router.middlewares" "oauth2-proxy-oauth-auth@kubernetescrd,\nkyverno-policy-reporter-strip-kyverno-prefix@kubernetescrd" }}
 {{- $_ := set $kyvernoPolicyReporterIngressAnnotations "traefik.ingress.kubernetes.io/app-root" "/kyverno/#/" }}

--- a/src/internal/catalog/built-in/platform-configs/helm/longhorn/values.generated.yaml.tplt
+++ b/src/internal/catalog/built-in/platform-configs/helm/longhorn/values.generated.yaml.tplt
@@ -8,9 +8,6 @@
 {{- else if (eq (index .cluster.services "traefik" "status") "enabled") }}
 {{- $_ := set $longhornIngressAnnotations "traefik.ingress.kubernetes.io/router.middlewares" "longhorn-redirect-noslash@kubernetescrd,longhorn-strip-prefix@kubernetescrd" }}
 {{- end }}
-{{- if (eq (index .cluster.services "metallb" "status") "enabled") }}
-{{- $_ := set $longhornIngressAnnotations "external-dns.alpha.kubernetes.io/target" (dig "cluster" "services" "metallb" "config" "publicLoadBalancerIPs" "" .) }}
-{{- end }}
 {{- $longhornIngressAnnotations = mergeOverwrite $longhornIngressAnnotations (dig "cluster" "services" "longhorn" "networking" "annotations" (dict) .) }}
 
 longhorn:

--- a/src/internal/catalog/built-in/platform-configs/helm/oauth2-proxy/values.generated.yaml.tplt
+++ b/src/internal/catalog/built-in/platform-configs/helm/oauth2-proxy/values.generated.yaml.tplt
@@ -3,9 +3,6 @@
 # To customize values, you can add additional files named values-*.yaml to this directory.
 
 {{- $oauth2ProxyIngressAnnotations := dict "cert-manager.io/cluster-issuer" (dig "cluster" "services" "cert-manager" "config" "clusterIssuer" "name" "letsencrypt-staging" .) }}
-{{- if (eq (index .cluster.services "metallb" "status") "enabled") }}
-{{- $_ := set $oauth2ProxyIngressAnnotations "external-dns.alpha.kubernetes.io/target" (dig "cluster" "services" "metallb" "config" "publicLoadBalancerIPs" "" .) }}
-{{- end }}
 {{- $oauth2ProxyIngressAnnotations = mergeOverwrite $oauth2ProxyIngressAnnotations (dig "cluster" "services" "oauth2-proxy" "networking" "annotations" (dict) .) }}
 
 namespace:


### PR DESCRIPTION
## 📝 Summary

When a cluster's load balancer service holds a private address (e.g. a MetalLB pool IP) while the cluster is reached through a routed public IP, external-dns published the **private** address as the DNS target. The Traefik dashboard `IngressRoute` had no per-resource target override, so the cluster hostname ended up with an unreachable private A record next to the public one — the record set round-robins and the dashboard becomes intermittently unreachable.

This sets external-dns `default-targets` to the configured `publicLoadBalancerIPs` together with `force-default-targets`, so every published record points at the public IP regardless of source (`ingress` and `traefik-proxy`). It replaces the per-ingress `external-dns.alpha.kubernetes.io/target` annotations — and the `metallb` status branching they required — which are removed from the service value templates (argo-cd, homer-dashboard, kube-prometheus-stack, kyverno-policy-reporter, longhorn, oauth2-proxy).

The block is guarded by `publicLoadBalancerIPs`: clusters without it (e.g. SKE, where the LB IP is already public) render unchanged.

## 🧩 Type of change
- [ ] 🔧 CLI / Go code
- [x] 📦 Helm chart
- [ ] 🧱 Terraform module
- [ ] 📝 Documentation
- [ ] 🧪 Test or CI change
- [x] ♻️ Refactor / cleanup

## ⚠️ Is this a breaking change?
- [ ] Yes, this change breaks existing functionality (explain in summary)

## 🧪 Testing
- [ ] CI passed
- [x] Manually tested (local/dev cluster)
- [x] Unit tested

Rendered `kubara generate` for both paths: with `metallb` enabled + `publicLoadBalancerIPs` set, external-dns gets `default-targets` + `force-default-targets` and the ingress values carry no target annotation; without it, the block is omitted and output is unchanged. `go test ./internal/render/... ./internal/cmd/generate/...` passes.

## 🔗 Related Issues / Tickets

## ✅ Checklist
- [x] Code compiles and passes all tests
- [x] Linting and style checks pass
- [ ] Comments added for complex logic
- [ ] Documentation updated (if applicable)

## 📎 Additional Context (optional)

Observed on an Edge Cloud cluster: `dig` returned both the public IP and the private MetalLB pool IP for the ingress host; the private record came from the `traefik-proxy` source publishing the Traefik service's (private) load balancer IP for the dashboard `IngressRoute`.
