### PR TITLE
fix(stackit): destroy the cluster before the IAM service account

### DIFF
--- a/src/internal/catalog/built-in/platform-configs/terraform/stackit/infrastructure/main.tf.tplt
+++ b/src/internal/catalog/built-in/platform-configs/terraform/stackit/infrastructure/main.tf.tplt
@@ -56,6 +56,11 @@ module "ske_cluster" {
 
   ### kubeconfig
   expiration = var.expiration
+
+  # Destroy the cluster before the IAM service account. In-cluster workloads
+  # (external-dns, cert-manager, ...) keep requesting tokens with the SA key,
+  # so the service account must outlive the cluster on teardown.
+  depends_on = [module.iam]
 }
 
 locals {
@@ -126,5 +131,8 @@ module "edge_hosts" {
 
   nodes = var.edge_hosts.nodes
 
+  # Destroy the hosts (and the workloads they run) before the IAM service
+  # account, so the SA key is not removed while workloads still request tokens.
+  depends_on = [module.iam]
 }
 {{ end }}


### PR DESCRIPTION
## 📝 Summary

On teardown, `terraform destroy` removed the STACKIT service account and its key within seconds, while the cluster deletion itself ran much longer. During that window the in-cluster workloads (external-dns, cert-manager, ...) kept requesting tokens with the now-deleted service account key, producing a burst of failed (4xx) token requests against the STACKIT IAM endpoint.

Root cause: there was no dependency edge between `module.iam` (service account + key) and the cluster modules, so terraform tore them down concurrently. The service account must outlive the workloads that use its key.

Fix: add `depends_on = [module.iam]` to `module.ske_cluster` and `module.edge_hosts`. Terraform then creates the service account before the cluster and, on destroy, removes the cluster/hosts first and the service account last.

## 🧩 Type of change
- [ ] 🔧 CLI / Go code
- [ ] 📦 Helm chart
- [x] 🧱 Terraform module
- [ ] 📝 Documentation
- [ ] 🧪 Test or CI change
- [ ] ♻️ Refactor / cleanup

## ⚠️ Is this a breaking change?
- [ ] Yes, this change breaks existing functionality (explain in summary)

## 🧪 Testing
- [ ] CI passed
- [x] Manually tested (local/dev cluster)
- [x] Unit tested

Rendered `kubara generate --terraform` for the SKE path: the generated `infrastructure/main.tf` carries `depends_on = [module.iam]` on `module.ske_cluster`; `terraform fmt` is clean. `go test ./internal/render/... ./internal/cmd/generate/...` passes.

## 🔗 Related Issues / Tickets

## ✅ Checklist
- [x] Code compiles and passes all tests
- [x] Linting and style checks pass
- [x] Comments added for complex logic
- [ ] Documentation updated (if applicable)

## 📎 Additional Context (optional)

Observed on a teardown where the SKE cluster deletion took ~1h: the service account was destroyed ~11s in, and token requests for the deleted account continued for the remainder of the cluster deletion.
