### PR TITLE
feat: add automatic dex restart after creation of required secrets

### DIFF
--- a/src/internal/catalog/built-in/platform-components/helm/argo-cd/script/restart-dex.tmpl
+++ b/src/internal/catalog/built-in/platform-components/helm/argo-cd/script/restart-dex.tmpl
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+CHECK_INTERVAL={{- .Values.dexRestarter.interval }}       # Seconds to wait between checks
+MAX_ATTEMPTS={{- .Values.dexRestarter.max_attempts }}   # Maximum number of checks before giving up
+
+echo "Checking if secret {{ .Values.dexRestarter.secretName }} exists in namespace {{ .Release.Namespace }}"
+
+attempt=1
+while [ $attempt -le $MAX_ATTEMPTS ]; do
+    echo "Attempt $attempt/$MAX_ATTEMPTS..."
+
+    kubectl get secret {{ .Values.dexRestarter.secretName }} -n {{ .Release.Namespace }}
+    READY_STATUS=$?
+    if [ $READY_STATUS -eq 0 ]; then
+        echo "Success: Secret has been created! Restarting dex server..."
+	kubectl rollout restart deployment/argocd-dex-server -n {{ .Release.Namespace }}
+        RESTART_STATUS=$?
+    	if [ $RESTART_STATUS -eq 0 ]; then
+	    echo "Restart successful"
+            exit 0
+        else
+            echo "Error restarting dex"
+            exit 1
+        fi
+    else
+        echo "Waiting for secret..."
+    fi
+
+    attempt=$((attempt + 1))
+    sleep $CHECK_INTERVAL
+done
+
+echo "Error: Timed out waiting for secret {{ .Values.dexRestarter.secretName }}."
+exit 1

--- a/src/internal/catalog/built-in/platform-components/helm/argo-cd/script/restart-dex.tmpl
+++ b/src/internal/catalog/built-in/platform-components/helm/argo-cd/script/restart-dex.tmpl
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 CHECK_INTERVAL={{- .Values.dexRestarter.interval }}     # Wait time between checks in seconds
-MAX_ATTEMPTS={{- .Values.dexRestarter.max_attempts }}   # Maximum number of checks before giving up
+MAX_ATTEMPTS={{- .Values.dexRestarter.maxAttempts }}    # Maximum number of checks before giving up
 
 echo "Checking if secret {{ .Values.dexRestarter.secretName }} exists in namespace {{ .Release.Namespace }}"
 

--- a/src/internal/catalog/built-in/platform-components/helm/argo-cd/script/restart-dex.tmpl
+++ b/src/internal/catalog/built-in/platform-components/helm/argo-cd/script/restart-dex.tmpl
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-CHECK_INTERVAL={{- .Values.dexRestarter.interval }}       # Seconds to wait between checks
+CHECK_INTERVAL={{- .Values.dexRestarter.interval }}     # Wait time between checks in seconds
 MAX_ATTEMPTS={{- .Values.dexRestarter.max_attempts }}   # Maximum number of checks before giving up
 
 echo "Checking if secret {{ .Values.dexRestarter.secretName }} exists in namespace {{ .Release.Namespace }}"

--- a/src/internal/catalog/built-in/platform-components/helm/argo-cd/templates/post-deploy-restart-job.yaml
+++ b/src/internal/catalog/built-in/platform-components/helm/argo-cd/templates/post-deploy-restart-job.yaml
@@ -1,0 +1,72 @@
+{{ if .Values.externalSecrets }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: dex-restarter
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: dex-restarter
+  namespace: {{ .Release.Namespace }}
+subjects:
+# You can specify more than one "subject"
+- kind: ServiceAccount
+  name: dex-restarter
+  namespace: {{ .Release.Namespace }}
+  apiGroup: ""
+roleRef:
+  kind: Role
+  name: dex-restarter
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: dex-restarter
+rules:
+- apiGroups: ["apps"]
+  resources: ["deployments"]
+  verbs: ["get", "patch", "update"]
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get"]
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: restart-script
+  namespace: {{ .Release.Namespace }}
+data:
+  restart-dex.sh: |-
+    {{- tpl ($.Files.Get "script/restart-dex.tmpl") . | nindent 4 }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: dex-restarter
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": post-install
+spec:
+  template:
+    spec:
+      containers:
+      - name: restart
+        image: "{{ .Values.dexRestarter.image }}"
+        command: ["sh", "-c", "/script/restart-dex.sh"]
+        volumeMounts:
+        - name: config-volume
+          mountPath: "/script"
+      restartPolicy: Never
+      serviceAccountName: dex-restarter
+      volumes:
+        - name: config-volume
+          configMap:
+            name: restart-script
+            defaultMode: 0777
+  backoffLimit: 3
+{{ end }}

--- a/src/internal/catalog/built-in/platform-components/helm/argo-cd/templates/post-deploy-restart-job.yaml
+++ b/src/internal/catalog/built-in/platform-components/helm/argo-cd/templates/post-deploy-restart-job.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.externalSecrets }}
+{{ if .Values.dexRestarter.enabled }}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -56,7 +56,7 @@ spec:
     spec:
       containers:
       - name: restart
-        image: "{{ .Values.dexRestarter.image }}"
+        image: "{{ .Values.dexRestarter.image.repository }}:{{ .Values.dexRestarter.image.tag}}"
         command: ["sh", "-c", "/script/restart-dex.sh"]
         volumeMounts:
         - name: config-volume

--- a/src/internal/catalog/built-in/platform-components/helm/argo-cd/values.yaml
+++ b/src/internal/catalog/built-in/platform-components/helm/argo-cd/values.yaml
@@ -1,6 +1,11 @@
 ---
 namespace: {}
 externalSecrets: {}
+dexRestarter:
+  image: "alpine/kubectl:1.36.2"
+  max_attempts: "20"
+  interval: "10"
+  secretName: "oauth2-credentials"
 defaultProject:
   name: default
   description: |-

--- a/src/internal/catalog/built-in/platform-components/helm/argo-cd/values.yaml
+++ b/src/internal/catalog/built-in/platform-components/helm/argo-cd/values.yaml
@@ -2,8 +2,11 @@
 namespace: {}
 externalSecrets: {}
 dexRestarter:
-  image: "alpine/kubectl:1.36.2"
-  max_attempts: "20"
+  enabled: true
+  image:
+    repository: "alpine/kubectl"
+    tag: "1.36.2"
+  maxAttempts: "30"
   interval: "10"  # in seconds
   secretName: "oauth2-credentials"
 defaultProject:

--- a/src/internal/catalog/built-in/platform-components/helm/argo-cd/values.yaml
+++ b/src/internal/catalog/built-in/platform-components/helm/argo-cd/values.yaml
@@ -4,7 +4,7 @@ externalSecrets: {}
 dexRestarter:
   image: "alpine/kubectl:1.36.2"
   max_attempts: "20"
-  interval: "10"
+  interval: "10"  # in seconds
   secretName: "oauth2-credentials"
 defaultProject:
   name: default


### PR DESCRIPTION
## 📝 Summary
Add job to restart argocd-dex-server after secrets have been created by external secrets.

## 🧩 Type of change
- [ ] 🔧 CLI / Go code
- [x] 📦 Helm chart
- [ ] 🧱 Terraform module
- [ ] 📝 Documentation
- [ ] 🧪 Test or CI change
- [ ] ♻️ Refactor / cleanup

## ⚠️ Is this a breaking change?
- [ ] Yes, this change breaks existing functionality (explain in summary)

## 🧪 Testing
- [ ] CI passed
- [x] Manually tested (local/dev cluster)
- [ ] Unit tested
- [ ] Not tested (explain why below)
  
## 🔗 Related Issues / Tickets
Closes #100 

## ✅ Checklist
- [x] Code compiles and passes all tests
- [x] Linting and style checks pass
- [ ] Comments added for complex logic
- [ ] Documentation updated (if applicable)
  
## 📎 Additional Context (optional)
