### PR TITLE
fix: create reloader namespace

### DIFF
--- a/src/internal/catalog/built-in/platform-components/helm/reloader/templates/namespace.yaml
+++ b/src/internal/catalog/built-in/platform-components/helm/reloader/templates/namespace.yaml
@@ -1,0 +1,1 @@
+{{- include "templateLibrary.k8s.namespace" . }}


### PR DESCRIPTION
## 📝 Summary
Add the missing Namespace manifest to the Reloader umbrella chart. Argo CD disables automatic namespace creation, so Reloader otherwise remains OutOfSync on a fresh cluster.

## 🧩 Type of change
- [ ] 🔧 CLI / Go code
- [x] 📦 Helm chart
- [ ] 🧱 Terraform module
- [ ] 📝 Documentation
- [ ] 🧪 Test or CI change
- [ ] ♻️ Refactor / cleanup

## ⚠️ Is this a breaking change?
- [ ] Yes, this change breaks existing functionality (explain in summary)

## 🧪 Testing
- [ ] CI passed
- [x] Manually tested (local/dev cluster)
- [x] Unit tested
- [ ] Not tested (explain why below)

## 🔗 Related Issues / Tickets
None.

## ✅ Checklist
- [x] Code compiles and passes all tests
- [ ] Linting and style checks pass
- [ ] Comments added for complex logic
- [ ] Documentation updated (if applicable)

## 📎 Additional Context (optional)
Validated on a fresh live cluster: the Reloader Application reaches Synced and Healthy, with one controller replica running.