### PR TITLE
fix(docs): fix stale documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ These instructions apply to the entire repository unless a deeper `AGENTS.md` ov
 If docs and code diverge, treat code/tests as current behavior and update the nearest relevant docs in the same change.
 
 ## Reference Map
-- Product setup and bootstrap flow: `docs/content/1_getting_started/bootstrap_process.md`
+- Product setup and bootstrap flow: `docs/content/1_getting_started/bootstrapping.md`
 - Runtime prerequisites: `docs/content/1_getting_started/prerequisites.md`
 - Architecture context: `docs/content/7_architecture/architecture_overview.md`
 - Contributor and PR workflow: `CONTRIBUTING.md`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,7 @@ If docs and code diverge, treat code/tests as current behavior and update the ne
 - Config schema and template keys: `src/internal/config/types.go` (use `kubara schema` when needed)
 
 ## Project Layout
-- `src/`: Go CLI implementation, tests, embedded templates, release Makefile
+- `src/`: Go CLI implementation, tests, catalog engine, release Makefile
 - `docs/`: MkDocs site managed with `uv`
 - Root `Makefile`: monorepo entry point delegating to `src/` and `docs/`
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ See [INSTALLATION.md](docs/content/1_getting_started/installation.md) for Linux,
 
 ```text
 init       Initialize a new kubara directory
-generate   generates files from embedded templates and config (default: both Helm and Terraform).
+generate   Generate Helm and Terraform artifacts from configured catalog templates.
 bootstrap  Bootstrap ArgoCD onto the specified cluster with optional external-secrets and prometheus CRD
 schema     Generate JSON schema file for config structure
 help, h    Shows a list of commands or help for one command

--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ init       Initialize a new kubara directory
 generate   Generate Helm and Terraform artifacts from configured catalog templates.
 bootstrap  Bootstrap ArgoCD onto the specified cluster with optional external-secrets and prometheus CRD
 schema     Generate JSON schema file for config structure
+agents     Scaffold an onboarding file for AI coding assistants (AGENTS.md)
+catalog    Manage platform catalogs
+cluster    Manage your kubara cluster configurations
 help, h    Shows a list of commands or help for one command
 ```
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ See [INSTALLATION.md](docs/content/1_getting_started/installation.md) for Linux,
 ```text
 init       Initialize a new kubara directory
 generate   Generate Helm and Terraform artifacts from configured catalog templates.
-bootstrap  Bootstrap ArgoCD onto the specified cluster with optional external-secrets and prometheus CRD
+bootstrap  Bootstrap prerequisite CRDs and Argo CD onto the specified cluster
 schema     Generate JSON schema file for config structure
 agents     Scaffold an onboarding file for AI coding assistants (AGENTS.md)
 catalog    Manage platform catalogs

--- a/docs/content/1_getting_started/bootstrapping.md
+++ b/docs/content/1_getting_started/bootstrapping.md
@@ -159,7 +159,7 @@ clusters:
 `bootstrapCatalog` is optional and defaults to kubara's versioned bootstrap catalog. It provides the fixed `argo-cd` and `bootstrap-crds` services, which do not appear under the configurable `services` map. Each cluster's ordered `catalogs` list provides its configurable platform services and templates.
 
 `ingressClassName` defaults to `traefik`. Set it explicitly when using a different ingress controller.
-Each service also accepts an optional `ingress.annotations` map under `services.<service>.ingress.annotations` that is merged with kubara's defaults, allowing you to add controller-specific annotations without overwriting the full set.
+Each service also accepts an optional `networking.annotations` map under `services.<service>.networking.annotations` that is merged with kubara's defaults, allowing you to add controller-specific annotations without overwriting the full set.
 User-provided annotations are merged on top using `mergeOverwrite`: equal keys are overwritten, while kubara default keys that are not present in the override remain.
 
 kubara generates resources in two stages:

--- a/docs/content/1_getting_started/installation.md
+++ b/docs/content/1_getting_started/installation.md
@@ -143,7 +143,7 @@ $ source <(kubara completion zsh)
 # after loading your rc file or opening a new terminal you will have tab completion for kubara
 $ kubara <tab>
 bootstrap  -- Bootstrap ArgoCD onto the specified cluster with optional external-secrets and prometheus CRD
-generate   -- generates files from embedded templates and the config file; by default for both Helm and Terraform
+generate   -- Generate Helm and Terraform artifacts from configured catalog templates
 help       -- Shows a list of commands or help for one command
 init       -- Initialize a new kubara directory
 schema     -- Generate JSON schema file for config structure

--- a/docs/content/1_getting_started/installation.md
+++ b/docs/content/1_getting_started/installation.md
@@ -142,7 +142,10 @@ $ source <(kubara completion bash)
 $ source <(kubara completion zsh)
 # after loading your rc file or opening a new terminal you will have tab completion for kubara
 $ kubara <tab>
+agents     -- Scaffold an onboarding file for AI coding assistants (AGENTS.md)
 bootstrap  -- Bootstrap ArgoCD onto the specified cluster with optional external-secrets and prometheus CRD
+catalog    -- Manage platform catalogs
+cluster    -- Manage your kubara cluster configurations
 generate   -- Generate Helm and Terraform artifacts from configured catalog templates
 help       -- Shows a list of commands or help for one command
 init       -- Initialize a new kubara directory

--- a/docs/content/1_getting_started/installation.md
+++ b/docs/content/1_getting_started/installation.md
@@ -143,7 +143,7 @@ $ source <(kubara completion zsh)
 # after loading your rc file or opening a new terminal you will have tab completion for kubara
 $ kubara <tab>
 agents     -- Scaffold an onboarding file for AI coding assistants (AGENTS.md)
-bootstrap  -- Bootstrap ArgoCD onto the specified cluster with optional external-secrets and prometheus CRD
+bootstrap  -- Bootstrap prerequisite CRDs and Argo CD onto the specified cluster
 catalog    -- Manage platform catalogs
 cluster    -- Manage your kubara cluster configurations
 generate   -- Generate Helm and Terraform artifacts from configured catalog templates

--- a/docs/content/3_infrastructure/google-cloud.md
+++ b/docs/content/3_infrastructure/google-cloud.md
@@ -398,8 +398,7 @@ The `Secretstore` can be passed directly into the bootstrap process instead of a
 
 ```bash title="kubara bootstrap"
 kubara bootstrap gcp \
-  --with-es-css-file secretstore.yaml \
-  --with-es-crds --with-prometheus-crds
+  --with-es-css-file secretstore.yaml
 ```
 
 Now you should have a successfully deployed kubara installation.

--- a/docs/content/3_infrastructure/kind.md
+++ b/docs/content/3_infrastructure/kind.md
@@ -162,7 +162,7 @@ kubara also writes a local `ClusterSecretStore` manifest that points `external-s
 
 After the local preparation is done, the remaining bootstrap flow continues with the same general kubara bootstrap logic:
 
-- Install required CRDs when requested
+- Install required CRDs from the bootstrap catalog
 - Install Argo CD
 - Hand ongoing reconciliation over to Argo CD
 

--- a/docs/content/4_building_your_platform/add_spoke_cluster.md
+++ b/docs/content/4_building_your_platform/add_spoke_cluster.md
@@ -22,14 +22,14 @@ Later `schema`, `generate`, and `bootstrap` runs automatically resolve the catal
 
 ### Optional: Ingress annotation overrides
 
-Each service supports an optional `ingress.annotations` map that is merged with kubara's default annotations when rendering the service values files.
+Each service supports an optional `networking.annotations` map that is merged with kubara's default annotations when rendering the service values files.
 This is useful when you use an ingress controller other than Traefik that requires controller-specific annotations.
 
 ```yaml
 services:
-  kubePrometheusStack:
+  kube-prometheus-stack:
     status: enabled
-    ingress:
+    networking:
       annotations:
         nginx.ingress.kubernetes.io/auth-url: "https://$host/oauth2/auth"
         nginx.ingress.kubernetes.io/auth-signin: "https://$host/oauth2/start?rd=$escaped_request_uri"

--- a/src/cmd/generate.go
+++ b/src/cmd/generate.go
@@ -35,7 +35,7 @@ func NewGenerateCmd() *cli.Command {
 		Name:        "generate",
 		Usage:       "Generate files from catalog templates",
 		UsageText:   "kubara generate [--terraform|--helm] [--catalog PATH_OR_OCI [--catalog-overwrite]] [--dry-run]",
-		Description: "Renders embedded Helm and Terraform templates using values from the config file. By default, it generates both template types.",
+		Description: "Renders Helm and Terraform templates from configured local or OCI catalogs using values from the config file. By default, it generates both template types.",
 		Action: func(c context.Context, cmd *cli.Command) error {
 			o, err := flags.ToOptions(cmd)
 			if err != nil {

--- a/src/cmd/generate_test.go
+++ b/src/cmd/generate_test.go
@@ -61,7 +61,7 @@ func TestNewGenerateCmd(t *testing.T) {
 	assert.Equal(t, "generate", command.Name)
 	assert.Equal(t, "Generate files from catalog templates", command.Usage)
 	assert.Equal(t, "kubara generate [--terraform|--helm] [--catalog PATH_OR_OCI [--catalog-overwrite]] [--dry-run]", command.UsageText)
-	assert.Equal(t, "Renders embedded Helm and Terraform templates using values from the config file. By default, it generates both template types.", command.Description)
+	assert.Equal(t, "Renders Helm and Terraform templates from configured local or OCI catalogs using values from the config file. By default, it generates both template types.", command.Description)
 
 	// Check that flags are added
 	require.Len(t, command.Flags, 3)
@@ -146,7 +146,7 @@ func TestGenerateCmd(t *testing.T) {
 				require.NoError(t, err)
 				assert.NotEmpty(t, entries)
 
-				// Provider selector folders are internal to embedded templates
+				// Provider selector folders are internal to catalog templates
 				// and must not leak into generated output paths.
 				_, err = os.Stat(filepath.Join(terraformDir, "stackit", "modules", "ske-cluster", "main.tf"))
 				require.NoError(t, err)

--- a/src/internal/config/types.go
+++ b/src/internal/config/types.go
@@ -18,7 +18,7 @@ const (
 	Spoke string = "spoke"
 )
 
-// TerraformProvider identifies an infrastructure provider with embedded Terraform templates.
+// TerraformProvider identifies an infrastructure provider supported by catalog generation.
 type TerraformProvider string
 
 const (
@@ -32,12 +32,12 @@ var supportedTerraformProviders = [...]TerraformProvider{
 	TerraformProviderTCloudPublic,
 }
 
-// IsSupported reports whether kubara ships Terraform templates for the provider.
+// IsSupported reports whether kubara supports Terraform generation for the provider.
 func (p TerraformProvider) IsSupported() bool {
 	return slices.Contains(supportedTerraformProviders[:], p)
 }
 
-// SupportedTerraformProviders returns the providers with embedded Terraform templates.
+// SupportedTerraformProviders returns the providers supported by Terraform generation.
 func SupportedTerraformProviders() []TerraformProvider {
 	return append([]TerraformProvider(nil), supportedTerraformProviders[:]...)
 }


### PR DESCRIPTION
## 📝 Summary
<!-- Please read first: https://github.com/kubara-io/kubara/blob/main/CONTRIBUTING.md -->
  
<!-- What does this PR do? e.g. "Adds Terraform module for SKE setup" -->

- removed stale references to embedded templates
- added missing CLI commands
- fixed optional CRD installation bootstrap wording for ignored / deprecated flags
- fixed legacy annotations and camelCase style 

## 🧩 Type of change
- [ ] 🔧 CLI / Go code
- [ ] 📦 Helm chart
- [ ] 🧱 Terraform module
- [x] 📝 Documentation
- [ ] 🧪 Test or CI change
- [ ] ♻️ Refactor / cleanup

## ⚠️ Is this a breaking change?
- [ ] Yes, this change breaks existing functionality (explain in summary)

## 🧪 Testing
- [x] CI passed
- [ ] Manually tested (local/dev cluster)
- [x] Unit tested
- [ ] Not tested (explain why below)
  
## 🔗 Related Issues / Tickets
<!-- e.g. Closes #42, Related to #99 -->

Fixes #527 

## ✅ Checklist
- [x] Code compiles and passes all tests
- [x] Linting and style checks pass
- [ ] Comments added for complex logic
- [x] Documentation updated (if applicable)
  
## 📎 Additional Context (optional)
<!-- Add logs, screenshots, diagrams, or design notes. -->
