### PR TITLE
docs(contributing): fix broken documentation links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Whether you're fixing bugs, improving documentation, or adding features - all co
 
 * **Contributors**: Anyone submitting code, docs or ideas via Issues or Pull Requests.
 * **Maintainers**: Core team members with permission to review, approve, and merge contributions. Maintainers help enforce standards and ensure quality.
-[Current Maintainers](https://docs.kubara.io/latest-stable/5_community/maintainers/)
+[Current Maintainers](https://docs.kubara.io/latest-stable/8_community/maintainers/)
 
 ## 🐛 Reporting Issues
 
@@ -28,8 +28,8 @@ Before you begin working on a bug fix or implementing a new feature, please crea
 This allows us to briefly discuss the best approach to solving the problem and avoid duplicated efforts.
 
 For larger topics, such as fundamental or strategic decisions, we recommend discussing them in a contributor meeting or during the kubara Office Hours.
-For significant technical decisions, please document the outcome using an Architecture Decision Record (ADR), see [ADR](https://docs.kubara.io/latest-stable/7_decisions/ADR/).
-For more information, please refer to our support documentation: [Support](https://docs.kubara.io/latest-stable/5_community/support/)
+For significant technical decisions, please document the outcome using an Architecture Decision Record (ADR), see [ADR](https://docs.kubara.io/latest-stable/10_decisions/ADR/).
+For more information, please refer to our support documentation: [Support](https://docs.kubara.io/latest-stable/8_community/community-n-support/)
 
 ### AI-Assisted Contributions
 
@@ -73,7 +73,7 @@ Temporarily skipping a hook (use only if necessary):
 
 Once you have set up the pre-commit hooks, you can follow the steps below to start contributing:
 
-1. **Check if an ADR is required**: If your change involves a significant technical or architectural decision, create an Architecture Decision Record (ADR) first, see [ADR](https://docs.kubara.io/latest-stable/7_decisions/ADR/)
+1. **Check if an ADR is required**: If your change involves a significant technical or architectural decision, create an Architecture Decision Record (ADR) first, see [ADR](https://docs.kubara.io/latest-stable/10_decisions/ADR/)
 2. **Fork** the repository and clone it locally, see also here: https://docs.github.com/en/get-started/exploring-projects-on-github/contributing-to-a-project
 3. **Create a new branch** for your work
 4. **Implement your changes**
@@ -248,4 +248,4 @@ The following is a list on critera which leads to the automatic rejection of the
 - **Suggestions for alternative approaches**
 - **Path for resubmission**: Clear requirements for reconsideration
 
-Support: [Support](https://docs.kubara.io/latest-stable/5_community/support/)
+Support: [Support](https://docs.kubara.io/latest-stable/8_community/community-n-support/)


### PR DESCRIPTION
## 📝 Summary

A few links in CONTRIBUTING.md are dead. The docs folders got renumbered at some point and the support page was renamed, but these links were left behind.

Fixed:

- Current Maintainers: `5_community/maintainers/` -> `8_community/maintainers/`
- ADR: `7_decisions/ADR/` -> `10_decisions/ADR/`
- Support: `5_community/support/` -> `8_community/community-n-support/`

Three links, five spots in the file (ADR and Support are each linked twice). I checked the new paths against mkdocs.yml and the files in docs/content.

## 🧩 Type of change
- [ ] 🔧 CLI / Go code
- [x] 📝 Documentation
- [ ] 🧪 Test or CI change
- [ ] ♻️ Refactor / cleanup

## ⚠️ Is this a breaking change?
- [ ] Yes, this change breaks existing functionality (explain in summary)

## 🧪 Testing
- [ ] CI passed
- [ ] Manually tested (local/dev cluster)
- [ ] Unit tested
- [x] Not tested (explain why below)

Only link URLs changed, nothing to run. I just opened each new path in the docs to make sure it exists.

## 🔗 Additional Context / Related Issues / Tickets

No issue for this one, it's just a small docs fix.

While looking around I noticed the same old paths in a couple of other places. Left them out to keep this PR to one thing, happy to do a follow-up if you want:

- CODE_OF_CONDUCT.md still points to `5_community/maintainers/` in 3 spots
- `src/internal/envconfig/env.go:54` points to `6_reference/faq/`, but the folder is `9_reference/`

## ✅ Checklist
- [x] Code compiles and passes all tests
- [x] Linting and style checks pass
- [ ] Comments added for complex logic
- [x] Documentation updated (if applicable)
