### PR TITLE
docs: fix remaining stale documentation links

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -38,7 +38,7 @@ Examples of unacceptable behavior include:
 
 ## Enforcement Responsibilities
 
-Project maintainers (see [Maintainers](https://docs.kubara.io/latest-stable/5_community/maintainers/))
+Project maintainers (see [Maintainers](https://docs.kubara.io/latest-stable/8_community/maintainers/))
 are responsible for clarifying and enforcing our standards of
 acceptable behavior and will take appropriate and fair corrective action in
 response to any behavior that they deem inappropriate, threatening, offensive,
@@ -64,10 +64,10 @@ representative at an online or offline event.
 If you observe any instance of abusive, harassing, or otherwise unacceptable behavior,
 report it by email to the project maintainers at **kubara@digits.schwarz**.
 As a second channel, you can contact one or more maintainers directly by email
-(see [Maintainers](https://docs.kubara.io/latest-stable/5_community/maintainers/)).
+(see [Maintainers](https://docs.kubara.io/latest-stable/8_community/maintainers/)).
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the [project maintainers](https://docs.kubara.io/latest-stable/5_community/maintainers/)
+reported to the [project maintainers](https://docs.kubara.io/latest-stable/8_community/maintainers/)
 responsible for enforcement at **kubara@digits.schwarz**.
 
 Please do **not** report Code of Conduct violations in public GitHub issues.

--- a/src/internal/envconfig/env.go
+++ b/src/internal/envconfig/env.go
@@ -51,7 +51,7 @@ type EnvMap struct {
 	ArgocdHelmRepoPassword      string   `default:"" koanf:"ARGOCD_HELM_REPO_PASSWORD" optional:"true"`
 	ArgocdHelmRepoUrl           string   `default:"" koanf:"ARGOCD_HELM_REPO_URL" optional:"true"`
 	_                           struct{} `doc:"\n# Optional: Container Registry Config"`
-	_                           struct{} `doc:"# the variable must be base64 encoded - how to: https://docs.kubara.io/latest-stable/6_reference/faq/#how-do-i-create-a-dockerconfigjson-for-env-file"`
+	_                           struct{} `doc:"# the variable must be base64 encoded - how to: https://docs.kubara.io/latest-stable/9_reference/faq/#how-do-i-create-a-dockerconfigjson-for-env-file"`
 	DockerconfigBase64          string   `default:"" koanf:"DOCKERCONFIG_BASE64" optional:"true"`
 }
 


### PR DESCRIPTION
## 📝 Summary

Follow-up to #550, fixes the last two spots with the old docs paths:

- CODE_OF_CONDUCT.md, 3 links to Maintainers: `5_community/maintainers/` -> `8_community/maintainers/`
- `src/internal/envconfig/env.go`, the dockerconfig hint: `6_reference/faq/` -> `9_reference/faq/`

Only the folder numbers changed, the FAQ anchor still works.

## 🧩 Type of change
- [x] 🔧 CLI / Go code
- [x] 📝 Documentation
- [ ] 🧪 Test or CI change
- [ ] ♻️ Refactor / cleanup

## ⚠️ Is this a breaking change?
- [ ] Yes, this change breaks existing functionality (explain in summary)

## 🧪 Testing
- [ ] CI passed
- [ ] Manually tested (local/dev cluster)
- [x] Unit tested
- [ ] Not tested (explain why below)

The env.go string shows up in the generated .env file. `go test ./internal/envconfig/...` and `go build ./...` pass.

## 🔗 Additional Context / Related Issues / Tickets

Follow-up to #550.

## ✅ Checklist
- [x] Code compiles and passes all tests
- [x] Linting and style checks pass
- [ ] Comments added for complex logic
- [x] Documentation updated (if applicable)
