### PR TITLE
fix(renovate): group catalog updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -40,6 +40,16 @@
   ],
   "packageRules": [
     {
+      "description": "Update the compatible bootstrap and general catalogs together",
+      "matchDatasources": ["docker"],
+      "matchPackageNames": [
+        "ghcr.io/kubara-io/catalogs/bootstrap",
+        "ghcr.io/kubara-io/catalogs/general"
+      ],
+      "groupName": "Kubara catalogs",
+      "groupSlug": "kubara-catalogs"
+    },
+    {
       "matchFiles": ["**/Chart.{yaml,yml}"],
       "bumpVersions": [
         {


### PR DESCRIPTION
## What changed

- group the built-in bootstrap and general catalog dependencies in Renovate
- use a stable `kubara-catalogs` branch slug for future grouped updates

## Why

The bootstrap catalog provides the shared `template-library`, while charts from both catalogs depend on a compatible version. Updating only one catalog can therefore produce an incompatible bootstrap/general combination. Grouping both dependencies keeps their default versions aligned.

This does not change the currently pinned catalog versions.

Related: https://github.com/kubara-io/catalogs/issues/62

## Validation

- `jq empty renovate.json`
- `git diff --check`
- `renovate-config-validator renovate.json` using Renovate 44.26.0 (successful; existing migration warnings remain)