### PR TITLE
feat(init): support bootstrap catalog override

### DIFF
--- a/docs/content/1_getting_started/bootstrapping.md
+++ b/docs/content/1_getting_started/bootstrapping.md
@@ -92,6 +92,17 @@ kubara init \
   --catalog oci://ghcr.io/acme/platform-catalogs/security:1.4.0
 ```
 
+Use `--bootstrap-catalog` when the new configuration should also reference a custom bootstrap catalog:
+
+```bash
+kubara init \
+  --bootstrap-catalog ./bootstrap \
+  --catalog ./company-platform \
+  --catalog-overwrite
+```
+
+The bootstrap reference is stored in the root `bootstrapCatalog` field, while repeated `--catalog` values are stored on the generated cluster. Local paths are resolved relative to `--work-dir` when kubara loads them.
+
 When using `--overwrite`, only values from `.env` are replaced.
 Additional settings in your existing `config.yaml` are preserved and merged.
 This currently applies **only to the first cluster entry**.

--- a/docs/content/1_getting_started/commands.md
+++ b/docs/content/1_getting_started/commands.md
@@ -75,7 +75,9 @@ kubara [command]
 
 Initialize kubara config for your GitOps repository
 
->kubara init [--prep] [--local] [--renovate=false]
+>kubara init [--prep] [--local] [--renovate=false] [--bootstrap-catalog PATH_OR_OCI]
+
+**--bootstrap-catalog**="": Path to the bootstrap catalog directory or an OCI reference in the form oci://registry/repository:x.y.z
 
 **--envVarPrefix**="": Prefix for envs read from envVars (default: "KUBARA_")
 

--- a/src/cmd/bootstrap.go
+++ b/src/cmd/bootstrap.go
@@ -112,7 +112,7 @@ func (flags *BootstrapFlags) ToOptions(cmd *cli.Command) (*bootstrap.Options, er
 		}
 	}
 
-	catalogOptions, err := catalogLoadOptionsFromCommand(cmd)
+	catalogOptions, err := catalogLoadOptionsFromCommand(cmd, "")
 	if err != nil {
 		return nil, fmt.Errorf("get catalog options: %w", err)
 	}

--- a/src/cmd/cluster/add.go
+++ b/src/cmd/cluster/add.go
@@ -38,7 +38,7 @@ func CreateAddClusterCommand() *cli.Command {
 				return fmt.Errorf("get working directory: %w", err)
 			}
 
-			catalogOptions, err := catalog.ResolveLoadOptions(cwd, cmd.StringSlice("catalog"), cmd.Bool("catalog-overwrite"))
+			catalogOptions, err := catalog.ResolveLoadOptions(cwd, "", cmd.StringSlice("catalog"), cmd.Bool("catalog-overwrite"))
 			if err != nil {
 				return fmt.Errorf("could not resolve catalog options: %w", err)
 			}

--- a/src/cmd/cluster/list.go
+++ b/src/cmd/cluster/list.go
@@ -31,7 +31,7 @@ func CreateClusterList() *cli.Command {
 				return fmt.Errorf("get config file path: %w", err)
 			}
 
-			catalogOptions, err := catalog.ResolveLoadOptions(cwd, cmd.StringSlice("catalog"), cmd.Bool("catalog-overwrite"))
+			catalogOptions, err := catalog.ResolveLoadOptions(cwd, "", cmd.StringSlice("catalog"), cmd.Bool("catalog-overwrite"))
 			if err != nil {
 				return fmt.Errorf("could not resolve catalog options: %w", err)
 			}

--- a/src/cmd/flags.go
+++ b/src/cmd/flags.go
@@ -195,10 +195,14 @@ func (flags *GlobalFlags) CLIFlags() []cli.Flag {
 }
 
 func catalogLoadOptionsFromCommand(cmd *cli.Command) (catalog.LoadOptions, error) {
+	return catalogLoadOptionsFromCommandWithBootstrap(cmd, "")
+}
+
+func catalogLoadOptionsFromCommandWithBootstrap(cmd *cli.Command, bootstrapCatalog string) (catalog.LoadOptions, error) {
 	cwd, err := filepath.Abs(cmd.String("work-dir"))
 	if err != nil {
 		return catalog.LoadOptions{}, fmt.Errorf("get working directory: %w", err)
 	}
 
-	return catalog.ResolveLoadOptions(cwd, cmd.StringSlice("catalog"), cmd.Bool("catalog-overwrite"))
+	return catalog.ResolveLoadOptionsWithBootstrap(cwd, bootstrapCatalog, cmd.StringSlice("catalog"), cmd.Bool("catalog-overwrite"))
 }

--- a/src/cmd/flags.go
+++ b/src/cmd/flags.go
@@ -194,15 +194,11 @@ func (flags *GlobalFlags) CLIFlags() []cli.Flag {
 	}
 }
 
-func catalogLoadOptionsFromCommand(cmd *cli.Command) (catalog.LoadOptions, error) {
-	return catalogLoadOptionsFromCommandWithBootstrap(cmd, "")
-}
-
-func catalogLoadOptionsFromCommandWithBootstrap(cmd *cli.Command, bootstrapCatalog string) (catalog.LoadOptions, error) {
+func catalogLoadOptionsFromCommand(cmd *cli.Command, bootstrapCatalog string) (catalog.LoadOptions, error) {
 	cwd, err := filepath.Abs(cmd.String("work-dir"))
 	if err != nil {
 		return catalog.LoadOptions{}, fmt.Errorf("get working directory: %w", err)
 	}
 
-	return catalog.ResolveLoadOptionsWithBootstrap(cwd, bootstrapCatalog, cmd.StringSlice("catalog"), cmd.Bool("catalog-overwrite"))
+	return catalog.ResolveLoadOptions(cwd, bootstrapCatalog, cmd.StringSlice("catalog"), cmd.Bool("catalog-overwrite"))
 }

--- a/src/cmd/generate.go
+++ b/src/cmd/generate.go
@@ -67,7 +67,7 @@ func (flags *GenerateFlags) ToOptions(cmd *cli.Command) (*generate.Options, erro
 	if err != nil {
 		return nil, fmt.Errorf("get platform-configs path: %w", err)
 	}
-	catalogOptions, err := catalogLoadOptionsFromCommand(cmd)
+	catalogOptions, err := catalogLoadOptionsFromCommand(cmd, "")
 	if err != nil {
 		return nil, fmt.Errorf("get catalog options: %w", err)
 	}

--- a/src/cmd/init.go
+++ b/src/cmd/init.go
@@ -34,12 +34,13 @@ type InitOptions struct {
 }
 
 type InitFlags struct {
-	PrepFlag      bool
-	ForceFlag     bool
-	LocalFlag     bool
-	RenovateFlag  bool
-	EnvFileFlag   string
-	EnvPrefixFlag string
+	PrepFlag             bool
+	ForceFlag            bool
+	LocalFlag            bool
+	RenovateFlag         bool
+	EnvFileFlag          string
+	EnvPrefixFlag        string
+	BootstrapCatalogFlag string
 }
 
 func NewInitFlags() *InitFlags {
@@ -59,7 +60,7 @@ func NewInitCmd() *cli.Command {
 	cmd := &cli.Command{
 		Name:        "init",
 		Usage:       "Initialize kubara config for your GitOps repository",
-		UsageText:   "kubara init [--prep] [--local] [--renovate=false]",
+		UsageText:   "kubara init [--prep] [--local] [--renovate=false] [--bootstrap-catalog PATH_OR_OCI]",
 		Description: "Initializes the kubara configuration for your GitOps repository, including environment variables, catalog options, and Renovate support for catalog updates. By default, it creates a config file and, if none exists, a renovate.json file. With --prep, it only generates the .env template for manual configuration. Combined with --local, --prep pre-fills local-evaluation defaults in .env and init writes a local-only cluster profile in config.yaml.",
 		Action: func(c context.Context, cmd *cli.Command) error {
 			o, _ := flags.ToOptions(cmd)
@@ -85,7 +86,7 @@ func (flags *InitFlags) ToOptions(cmd *cli.Command) (*InitOptions, error) {
 	if err != nil {
 		return nil, fmt.Errorf("get env file path: %w", err)
 	}
-	catalogOptions, err := catalogLoadOptionsFromCommand(cmd)
+	catalogOptions, err := catalogLoadOptionsFromCommandWithBootstrap(cmd, flags.BootstrapCatalogFlag)
 	if err != nil {
 		return nil, fmt.Errorf("get catalog options: %w", err)
 	}
@@ -129,6 +130,14 @@ func (flags *InitFlags) AddFlags(cmd *cli.Command) {
 			Value:       flags.RenovateFlag,
 			Usage:       "Generate a Renovate configuration for kubara catalog updates if none exists",
 			Destination: &flags.RenovateFlag,
+		},
+		&cli.StringFlag{
+			Name:        "bootstrap-catalog",
+			Usage:       "Path to the bootstrap catalog directory or an OCI reference in the form oci://registry/repository:x.y.z",
+			Destination: &flags.BootstrapCatalogFlag,
+			Config: cli.StringConfig{
+				TrimSpace: true,
+			},
 		},
 		&cli.StringFlag{
 			Name:        "envVarPrefix",
@@ -176,6 +185,13 @@ func (o *InitOptions) Run() error {
 
 func (o *InitOptions) catalogLoadOptions() catalog.LoadOptions {
 	return o.catalogOptions
+}
+
+func (o *InitOptions) applyBootstrapCatalogOverride(cfg *config.Config) {
+	bootstrapCatalog := strings.TrimSpace(o.catalogOptions.BootstrapCatalog)
+	if bootstrapCatalog != "" {
+		cfg.BootstrapCatalog = &bootstrapCatalog
+	}
 }
 
 func (o *InitOptions) ensureLocalDotEnv(es *envconfig.EnvStore) error {
@@ -304,6 +320,7 @@ func (o *InitOptions) runNormalMode(es *envconfig.EnvStore, cs *config.ConfigSto
 	}
 
 	cs.GetConfig().Clusters = []config.Cluster{newCluster}
+	o.applyBootstrapCatalogOverride(cs.GetConfig())
 	if err := cs.SaveToFile(); err != nil {
 		return fmt.Errorf("write config file: %w", err)
 	}

--- a/src/cmd/init.go
+++ b/src/cmd/init.go
@@ -86,7 +86,7 @@ func (flags *InitFlags) ToOptions(cmd *cli.Command) (*InitOptions, error) {
 	if err != nil {
 		return nil, fmt.Errorf("get env file path: %w", err)
 	}
-	catalogOptions, err := catalogLoadOptionsFromCommandWithBootstrap(cmd, flags.BootstrapCatalogFlag)
+	catalogOptions, err := catalogLoadOptionsFromCommand(cmd, flags.BootstrapCatalogFlag)
 	if err != nil {
 		return nil, fmt.Errorf("get catalog options: %w", err)
 	}

--- a/src/cmd/init_test.go
+++ b/src/cmd/init_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"os"
@@ -9,11 +10,14 @@ import (
 	"strings"
 	"testing"
 
+	cmdtestutil "github.com/kubara-io/kubara/cmd/testutil"
 	"github.com/kubara-io/kubara/internal/catalog"
 	"github.com/kubara-io/kubara/internal/config"
+	internaltestutil "github.com/kubara-io/kubara/internal/testutil"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
 )
 
 func TestNewInitFlags(t *testing.T) {
@@ -27,6 +31,7 @@ func TestNewInitFlags(t *testing.T) {
 	assert.True(t, flags.RenovateFlag)
 	assert.Equal(t, ".env", flags.EnvFileFlag)
 	assert.Equal(t, "KUBARA_", flags.EnvPrefixFlag)
+	assert.Empty(t, flags.BootstrapCatalogFlag)
 }
 
 func TestNewInitCmd(t *testing.T) {
@@ -44,6 +49,40 @@ func TestNewInitCmd(t *testing.T) {
 	assert.True(t, flagNames["local"])
 	assert.True(t, flagNames["renovate"])
 	assert.True(t, flagNames["envVarPrefix"])
+	assert.True(t, flagNames["bootstrap-catalog"])
+}
+
+func TestInitPersistsBootstrapCatalogOverride(t *testing.T) {
+	t.Parallel()
+
+	workDir := t.TempDir()
+	bootstrapPath, generalPath, err := internaltestutil.CreateCatalogFixtures(filepath.Join(workDir, "catalogs"))
+	require.NoError(t, err)
+	envPath := cmdtestutil.CreateDefaultGenerateTestEnv(t, workDir)
+	configPath := filepath.Join(workDir, "config.yaml")
+	app := cmdtestutil.CreateTestAppWithFlags(NewGlobalFlags().CLIFlags(), NewInitCmd())
+
+	err = app.Run(context.Background(), []string{
+		"kubara",
+		"--work-dir", workDir,
+		"--config-file", configPath,
+		"--env-file", envPath,
+		"init",
+		"--bootstrap-catalog", bootstrapPath,
+		"--catalog", generalPath,
+		"--catalog-overwrite",
+		"--renovate=false",
+	})
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+	var generated config.Config
+	require.NoError(t, yaml.Unmarshal(data, &generated))
+	require.NotNil(t, generated.BootstrapCatalog)
+	assert.Equal(t, bootstrapPath, *generated.BootstrapCatalog)
+	require.Len(t, generated.Clusters, 1)
+	assert.Equal(t, []string{generalPath}, generated.Clusters[0].Catalogs)
 }
 
 func TestEnsureRenovateConfig(t *testing.T) {

--- a/src/cmd/schema.go
+++ b/src/cmd/schema.go
@@ -68,7 +68,7 @@ func (flags *SchemaFlags) ToOptions(cmd *cli.Command) (*SchemaOptions, error) {
 		return nil, fmt.Errorf("get config file path: %w", err)
 	}
 
-	catalogOptions, err := catalogLoadOptionsFromCommand(cmd)
+	catalogOptions, err := catalogLoadOptionsFromCommand(cmd, "")
 	if err != nil {
 		return nil, fmt.Errorf("get catalog options: %w", err)
 	}

--- a/src/internal/catalog/load_options.go
+++ b/src/internal/catalog/load_options.go
@@ -7,11 +7,7 @@ import (
 	"github.com/kubara-io/kubara/internal/utils"
 )
 
-func ResolveLoadOptions(cwd string, catalogs []string, overwrite bool) (LoadOptions, error) {
-	return ResolveLoadOptionsWithBootstrap(cwd, "", catalogs, overwrite)
-}
-
-func ResolveLoadOptionsWithBootstrap(cwd, bootstrapCatalog string, catalogs []string, overwrite bool) (LoadOptions, error) {
+func ResolveLoadOptions(cwd, bootstrapCatalog string, catalogs []string, overwrite bool) (LoadOptions, error) {
 	options := LoadOptions{
 		CWD:              cwd,
 		BootstrapCatalog: bootstrapCatalog,

--- a/src/internal/catalog/load_options.go
+++ b/src/internal/catalog/load_options.go
@@ -8,10 +8,15 @@ import (
 )
 
 func ResolveLoadOptions(cwd string, catalogs []string, overwrite bool) (LoadOptions, error) {
+	return ResolveLoadOptionsWithBootstrap(cwd, "", catalogs, overwrite)
+}
+
+func ResolveLoadOptionsWithBootstrap(cwd, bootstrapCatalog string, catalogs []string, overwrite bool) (LoadOptions, error) {
 	options := LoadOptions{
-		CWD:       cwd,
-		Catalogs:  append([]string(nil), catalogs...),
-		Overwrite: overwrite,
+		CWD:              cwd,
+		BootstrapCatalog: bootstrapCatalog,
+		Catalogs:         append([]string(nil), catalogs...),
+		Overwrite:        overwrite,
 	}
 	if _, err := ResolveSources(options); err != nil {
 		return LoadOptions{}, err

--- a/src/internal/catalog/loader_test.go
+++ b/src/internal/catalog/loader_test.go
@@ -43,7 +43,7 @@ func TestLoad_MergesGeneralCatalogAfterBootstrap(t *testing.T) {
 }
 
 func TestResolveLoadOptions_PreservesPortableReferences(t *testing.T) {
-	options, err := ResolveLoadOptions("/workspace", []string{"./catalog", DefaultGeneralCatalog}, true)
+	options, err := ResolveLoadOptions("/workspace", "", []string{"./catalog", DefaultGeneralCatalog}, true)
 	require.NoError(t, err)
 
 	assert.Equal(t, "/workspace", options.CWD)
@@ -52,7 +52,7 @@ func TestResolveLoadOptions_PreservesPortableReferences(t *testing.T) {
 }
 
 func TestResolveLoadOptionsWithBootstrap_PreservesPortableReferences(t *testing.T) {
-	options, err := ResolveLoadOptionsWithBootstrap(
+	options, err := ResolveLoadOptions(
 		"/workspace",
 		"./bootstrap",
 		[]string{"./catalog", DefaultGeneralCatalog},

--- a/src/internal/catalog/loader_test.go
+++ b/src/internal/catalog/loader_test.go
@@ -50,3 +50,18 @@ func TestResolveLoadOptions_PreservesPortableReferences(t *testing.T) {
 	assert.Equal(t, []string{"./catalog", DefaultGeneralCatalog}, options.Catalogs)
 	assert.True(t, options.Overwrite)
 }
+
+func TestResolveLoadOptionsWithBootstrap_PreservesPortableReferences(t *testing.T) {
+	options, err := ResolveLoadOptionsWithBootstrap(
+		"/workspace",
+		"./bootstrap",
+		[]string{"./catalog", DefaultGeneralCatalog},
+		true,
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, "/workspace", options.CWD)
+	assert.Equal(t, "./bootstrap", options.BootstrapCatalog)
+	assert.Equal(t, []string{"./catalog", DefaultGeneralCatalog}, options.Catalogs)
+	assert.True(t, options.Overwrite)
+}


### PR DESCRIPTION
## 📝 Summary

Add an init-only `--bootstrap-catalog` option so a new configuration can select both its bootstrap catalog and ordered general catalogs in one command.

The selected bootstrap reference is validated with the existing catalog resolver and persisted in the root `bootstrapCatalog` field. Existing `init --overwrite` behavior is unchanged. The generated command reference and bootstrapping guide now document the option.

## 🧩 Type of change
- [x] 🔧 CLI / Go code
- [x] 📝 Documentation
- [x] 🧪 Test or CI change
- [ ] ♻️ Refactor / cleanup

## ⚠️ Is this a breaking change?
- [ ] Yes, this change breaks existing functionality (explain in summary)

## 🧪 Testing
- [ ] CI passed
- [x] Manually tested (local CLI help and generated config)
- [x] Unit tested
- [ ] Not tested (explain why below)

Commands run locally with Go 1.26.5:

- `go test ./...`
- `go test -race -timeout=10m -coverprofile=... -covermode=atomic ./...` (37.5% total coverage)
- `go vet ./...`
- `go mod verify`
- `go mod tidy -diff`
- `gofmt -l .`
- `make -C src docs`
- `go run main.go init --help`

`make docs-validate` could not start locally because the pinned Python 3.14.7 interpreter is not available in the local `uv` managed/search path; no documentation files were modified by that failed setup step.

## 🔗 Additional Context / Related Issues / Tickets

Closes #560.

## ✅ Checklist
- [x] Code compiles and passes all tests
- [ ] Linting and style checks pass
- [x] Comments added for complex logic (not applicable; no complex branching added)
- [x] Documentation updated (if applicable)
