### PR TITLE
feat(bootstrap): provision STACKIT secret store

### DIFF
--- a/docs/content/1_getting_started/bootstrapping.md
+++ b/docs/content/1_getting_started/bootstrapping.md
@@ -273,9 +273,15 @@ CI-specific values can be stored in chart-local CI files (for example `ci/ci-val
 
 External Secrets needs a `ClusterSecretStore`.
 
+If the `external-secrets` service is disabled, kubara skips all store discovery and automatic setup.
+
 For T Cloud Public CCE, kubara already renders the OpenBao-backed `ClusterSecretStore` into `external-secrets/values.yaml`. Do not pass `--with-es-css-file` and do not create a separate provider credential secret.
 
-For other providers, create the provider credential secret first and either pass a `ClusterSecretStore` manifest during bootstrap with `--with-es-css-file`, or apply the `ClusterSecretStore` manually after bootstrap.
+For STACKIT, kubara first looks for an existing store named `<cluster-name>-<stage>`. If none exists, it reads the read-only Secrets Manager credentials, API URL, and mount path from the generated Terraform or OpenTofu outputs. It then creates the `stackit-secrets-manager-cred` Secret and the `ClusterSecretStore` automatically. Run the infrastructure apply before bootstrap so those outputs are available.
+
+Kubara automatically selects Terraform or OpenTofu when only one is installed. If both are installed, select the state tool explicitly with `--iac-command terraform` or `--iac-command tofu`.
+
+To use another secret backend on STACKIT or any provider without automatic setup, either create the expected store before bootstrap or pass its manifest with `--with-es-css-file`. A supplied manifest takes precedence over automatic STACKIT setup. Create any credential Secret referenced by that custom manifest separately.
 
 Bootstrap always installs the required CRDs from the bootstrap catalog's `bootstrap-crds` service. Separate External Secrets and Prometheus CRD flags are no longer required.
 
@@ -292,13 +298,9 @@ Example provider credential secret(s) for the `ClusterSecretStore`:
 kubectl -n external-secrets create secret generic bitwarden-access-token \
   --from-literal=token="<BITWARDEN_MACHINE_ACCOUNT_TOKEN>"
 
-## STACKIT Secrets Manager
-kubectl -n external-secrets create secret generic stackit-secrets-manager-cred \
-  --from-literal=username="<USERNAME>" \
-  --from-literal=password="<PASSWORD>"
 ```
 
-Example `clustersecretstore.yaml` for `--with-es-css-file` (templating with `{{ .cluster.name }}` / `{{ .cluster.stage }}` is supported):
+Example custom `clustersecretstore.yaml` for `--with-es-css-file` (templating with `{{ .cluster.name }}` / `{{ .cluster.stage }}` is supported):
 
 ```yaml
 apiVersion: external-secrets.io/v1
@@ -334,7 +336,7 @@ This path layout is the same for every provider and secret backend, including th
 kubara bootstrap <cluster-name-from-config-yaml>
 ```
 
-For providers that need an external `ClusterSecretStore` manifest, pass it during bootstrap:
+To override automatic setup or use another backend, pass its `ClusterSecretStore` manifest during bootstrap:
 
 ```bash
 kubara bootstrap <cluster-name-from-config-yaml> \

--- a/docs/content/1_getting_started/commands.md
+++ b/docs/content/1_getting_started/commands.md
@@ -123,6 +123,8 @@ Bootstrap Argo CD onto a cluster
 
 **--help, -h**: show help
 
+**--iac-command**="": Infrastructure command used to read bootstrap outputs: auto, terraform, or tofu (default: "auto")
+
 **--local**: Provision an isolated local evaluation environment. Local testing only; not for production use.
 
 **--platform-components**="": Path to the platform-components directory (default: "platform-components")

--- a/docs/content/2_concepts/overview_core_concept.md
+++ b/docs/content/2_concepts/overview_core_concept.md
@@ -89,8 +89,8 @@ graph TD
 2. Run `kubara generate` to render Terraform and Helm output.
 3. Commit and push the generated result to Git.
 4. Apply infrastructure where needed 
-5. Create your ClusterSecretStore yaml for External Secrets based on your used Secret Manager solution
-6. Bootstrap Argo CD using `kubara bootstrap <cluster-name> --with-es-css-file=<your-css.yaml>`
+5. Prepare a custom ClusterSecretStore only when your provider does not support automatic setup or you want to override it
+6. Bootstrap Argo CD using `kubara bootstrap <cluster-name>` and optionally `--with-es-css-file=<your-css.yaml>`
 7. Let Argo CD continuously reconcile the generated platform state.
 
 Secrets are typically synced via External Secrets based on your configured SecretStore or ClusterSecretStore.

--- a/docs/content/3_infrastructure/stackit_ske.md
+++ b/docs/content/3_infrastructure/stackit_ske.md
@@ -201,6 +201,8 @@ Sensitive output example:
     tofu output vault_user_ro_password_b64
     ```
 
+When `external-secrets` is enabled, `kubara bootstrap` reads the read-only Secrets Manager outputs directly and creates the Kubernetes credential Secret and `ClusterSecretStore`. You do not need to copy these values into `.env` or create the resources manually. If both Terraform and OpenTofu are installed, pass the tool used for the state explicitly, for example `--iac-command tofu`.
+
 ## 7. Optional: OAuth2-related Vault entries via Terraform
 
 If you use OAuth2, create a GitHub application as shown [here](../4_building_your_platform/sso/add_sso.md).

--- a/src/cmd/bootstrap.go
+++ b/src/cmd/bootstrap.go
@@ -23,6 +23,7 @@ import (
 type BootstrapFlags struct {
 	Local                  bool
 	ClusterSecretStorePath string
+	IaCCommand             string
 	PlatformComponentsPath string
 	PlatformConfigsPath    string
 	EnvFile                string
@@ -40,6 +41,7 @@ func NewBootstrapFlags() *BootstrapFlags {
 	return &BootstrapFlags{
 		EnvFile:       ".env",
 		EnvPrefixFlag: "KUBARA_",
+		IaCCommand:    "auto",
 		Timeout:       2 * time.Minute,
 	}
 }
@@ -191,6 +193,7 @@ func (flags *BootstrapFlags) ToOptions(cmd *cli.Command) (*bootstrap.Options, er
 		PlatformConfigs:    configsAbsPath,
 		Local:              flags.Local,
 		WithESCSSPath:      cssAbsPath,
+		IaCCommand:         flags.IaCCommand,
 		EnvMap:             envMap,
 		Catalog:            loadedCatalog,
 		ClusterConfig:      clusterConfig,
@@ -223,6 +226,12 @@ func (flags *BootstrapFlags) AddFlags(cmd *cli.Command) {
 			Name:        "with-es-css-file",
 			Usage:       "Path to the ClusterSecretStore manifest file (supports go-template + sprig)",
 			Destination: &flags.ClusterSecretStorePath,
+		},
+		&cli.StringFlag{
+			Name:        "iac-command",
+			Value:       flags.IaCCommand,
+			Usage:       "Infrastructure command used to read bootstrap outputs: auto, terraform, or tofu",
+			Destination: &flags.IaCCommand,
 		},
 		&cli.BoolFlag{
 			Name:  "with-es-crds",

--- a/src/internal/cmd/bootstrap/bootstrap.go
+++ b/src/internal/cmd/bootstrap/bootstrap.go
@@ -31,6 +31,7 @@ type Options struct {
 	PlatformConfigs    string
 	Local              bool
 	WithESCSSPath      string
+	IaCCommand         string
 	EnvMap             *envconfig.EnvMap
 	Catalog            catalog.Catalog
 	ClusterConfig      *config.Cluster

--- a/src/internal/cmd/bootstrap/cluster_secret_store.go
+++ b/src/internal/cmd/bootstrap/cluster_secret_store.go
@@ -1,0 +1,199 @@
+package bootstrap
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"path/filepath"
+
+	"github.com/kubara-io/kubara/internal/config"
+	"github.com/kubara-io/kubara/internal/service"
+
+	externalsecretsv1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1"
+	externalsecretsmeta "github.com/external-secrets/external-secrets/apis/meta/v1"
+	"github.com/rs/zerolog/log"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+const (
+	externalSecretsNamespace    = "external-secrets"
+	stackitCredentialSecretName = "stackit-secrets-manager-cred"
+	stackitVaultUsernameOutput  = "vault_user_ro_name"
+	stackitVaultPasswordOutput  = "vault_user_ro_password_b64"
+	stackitVaultAPIURLOutput    = "vault_api_url"
+	stackitVaultPathOutput      = "vault_path"
+)
+
+var clusterSecretStoreGVR = schema.GroupVersionResource{
+	Group:    "external-secrets.io",
+	Version:  "v1",
+	Resource: "clustersecretstores",
+}
+
+func (sm *SecretManager) resolveClusterSecretStore(ctx context.Context, o *Options) (*externalsecretsv1.ClusterSecretStore, *corev1.Secret, bool, error) {
+	if o.ClusterConfig == nil {
+		return nil, nil, false, fmt.Errorf("cluster config is required")
+	}
+
+	externalSecrets, exists := o.ClusterConfig.Services["external-secrets"]
+	if !exists || externalSecrets.Status != service.StatusEnabled {
+		return nil, nil, false, nil
+	}
+
+	if o.ClusterConfig.Terraform != nil && o.ClusterConfig.Terraform.Provider == config.TerraformProviderTCloudPublic {
+		log.Info().Msg("ClusterSecretStore is managed by the generated T Cloud Public configuration")
+		return nil, nil, false, nil
+	}
+
+	if o.DryRun {
+		log.Warn().
+			Str("name", clusterSecretStoreName(o.ClusterConfig)).
+			Msg("Skipping ClusterSecretStore discovery and automatic creation during dry-run")
+		return nil, nil, false, nil
+	}
+
+	exists, err := sm.clusterSecretStoreExists(ctx, clusterSecretStoreName(o.ClusterConfig))
+	if err != nil {
+		return nil, nil, false, err
+	}
+	if exists {
+		log.Info().Str("name", clusterSecretStoreName(o.ClusterConfig)).Msg("Using existing ClusterSecretStore")
+		return nil, nil, false, nil
+	}
+
+	if o.ClusterConfig.Terraform != nil && o.ClusterConfig.Terraform.Provider == config.TerraformProviderStackit {
+		css, credentialSecret, err := sm.createStackitClusterSecretStore(ctx, o)
+		return css, credentialSecret, err == nil, err
+	}
+
+	return nil, nil, false, fmt.Errorf("ClusterSecretStore %q was not found; provide it with --with-es-css-file or create it in the cluster and rerun bootstrap", clusterSecretStoreName(o.ClusterConfig))
+}
+
+func (sm *SecretManager) createStackitClusterSecretStore(ctx context.Context, o *Options) (*externalsecretsv1.ClusterSecretStore, *corev1.Secret, error) {
+	if sm.iacCommandResolver == nil {
+		return nil, nil, fmt.Errorf("infrastructure command resolver is required")
+	}
+	command, err := sm.iacCommandResolver(o.IaCCommand)
+	if err != nil {
+		return nil, nil, err
+	}
+	if sm.outputReader == nil {
+		return nil, nil, fmt.Errorf("infrastructure output reader is required")
+	}
+	if sm.client == nil || sm.client.Clientset == nil {
+		return nil, nil, fmt.Errorf("Kubernetes clientset is required")
+	}
+
+	infrastructureDir := filepath.Join(o.PlatformConfigs, o.ClusterConfig.Name, "terraform", "infrastructure")
+	username, err := sm.outputReader.Read(ctx, infrastructureDir, command, stackitVaultUsernameOutput)
+	if err != nil {
+		return nil, nil, err
+	}
+	passwordBase64, err := sm.outputReader.Read(ctx, infrastructureDir, command, stackitVaultPasswordOutput)
+	if err != nil {
+		return nil, nil, err
+	}
+	passwordBytes, err := base64.StdEncoding.DecodeString(passwordBase64)
+	if err != nil {
+		return nil, nil, fmt.Errorf("decode %s: %w", stackitVaultPasswordOutput, err)
+	}
+	password := string(passwordBytes)
+	server, err := sm.outputReader.Read(ctx, infrastructureDir, command, stackitVaultAPIURLOutput)
+	if err != nil {
+		return nil, nil, err
+	}
+	vaultPath, err := sm.outputReader.Read(ctx, infrastructureDir, command, stackitVaultPathOutput)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if err := sm.client.EnsureNamespace(ctx, externalSecretsNamespace, false); err != nil {
+		return nil, nil, fmt.Errorf("ensure external-secrets namespace: %w", err)
+	}
+
+	credentialSecret := &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Secret"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      stackitCredentialSecretName,
+			Namespace: externalSecretsNamespace,
+		},
+		Type: corev1.SecretTypeOpaque,
+		StringData: map[string]string{
+			"username": username,
+			"password": password,
+		},
+	}
+
+	secretNamespace := externalSecretsNamespace
+	css := &externalsecretsv1.ClusterSecretStore{
+		TypeMeta: metav1.TypeMeta{APIVersion: "external-secrets.io/v1", Kind: "ClusterSecretStore"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: clusterSecretStoreName(o.ClusterConfig),
+			Labels: map[string]string{
+				"argocd.argoproj.io/instance": fmt.Sprintf("%s-external-secrets", o.ClusterConfig.Name),
+			},
+		},
+		Spec: externalsecretsv1.SecretStoreSpec{
+			Provider: &externalsecretsv1.SecretStoreProvider{
+				Vault: &externalsecretsv1.VaultProvider{
+					Server:  server,
+					Path:    &vaultPath,
+					Version: externalsecretsv1.VaultKVStoreV2,
+					Auth: &externalsecretsv1.VaultAuth{
+						UserPass: &externalsecretsv1.VaultUserPassAuth{
+							Path:     "userpass",
+							Username: username,
+							SecretRef: externalsecretsmeta.SecretKeySelector{
+								Name:      stackitCredentialSecretName,
+								Namespace: &secretNamespace,
+								Key:       "password",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	log.Info().Msg("Prepared STACKIT ClusterSecretStore from infrastructure outputs")
+	return css, credentialSecret, nil
+}
+
+func (sm *SecretManager) clusterSecretStoreExists(ctx context.Context, name string) (bool, error) {
+	if sm.client == nil || sm.client.DynamicClient == nil {
+		return false, fmt.Errorf("Kubernetes dynamic client is required")
+	}
+	_, err := sm.client.DynamicClient.Resource(clusterSecretStoreGVR).Get(ctx, name, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("get ClusterSecretStore %q: %w", name, err)
+	}
+	return true, nil
+}
+
+func (sm *SecretManager) validateCredentialSecret(ctx context.Context, name string) error {
+	if _, err := sm.client.Clientset.CoreV1().Secrets(externalSecretsNamespace).Get(ctx, name, metav1.GetOptions{}); err != nil {
+		return fmt.Errorf("validate credential Secret %q: %w", name, err)
+	}
+	return nil
+}
+
+func (sm *SecretManager) validateClusterSecretStore(ctx context.Context, name string) error {
+	exists, err := sm.clusterSecretStoreExists(ctx, name)
+	if err != nil {
+		return fmt.Errorf("validate ClusterSecretStore: %w", err)
+	}
+	if !exists {
+		return fmt.Errorf("validate ClusterSecretStore: %q was not found after apply", name)
+	}
+	return nil
+}
+
+func clusterSecretStoreName(cluster *config.Cluster) string {
+	return fmt.Sprintf("%s-%s", cluster.Name, cluster.Stage)
+}

--- a/src/internal/cmd/bootstrap/cluster_secret_store.go
+++ b/src/internal/cmd/bootstrap/cluster_secret_store.go
@@ -84,7 +84,7 @@ func (sm *SecretManager) createStackitClusterSecretStore(ctx context.Context, o 
 		return nil, nil, fmt.Errorf("infrastructure output reader is required")
 	}
 	if sm.client == nil || sm.client.Clientset == nil {
-		return nil, nil, fmt.Errorf("Kubernetes clientset is required")
+		return nil, nil, fmt.Errorf("kubernetes clientset is required")
 	}
 
 	infrastructureDir := filepath.Join(o.PlatformConfigs, o.ClusterConfig.Name, "terraform", "infrastructure")
@@ -164,7 +164,7 @@ func (sm *SecretManager) createStackitClusterSecretStore(ctx context.Context, o 
 
 func (sm *SecretManager) clusterSecretStoreExists(ctx context.Context, name string) (bool, error) {
 	if sm.client == nil || sm.client.DynamicClient == nil {
-		return false, fmt.Errorf("Kubernetes dynamic client is required")
+		return false, fmt.Errorf("kubernetes dynamic client is required")
 	}
 	_, err := sm.client.DynamicClient.Resource(clusterSecretStoreGVR).Get(ctx, name, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {

--- a/src/internal/cmd/bootstrap/infrastructure_outputs.go
+++ b/src/internal/cmd/bootstrap/infrastructure_outputs.go
@@ -1,0 +1,85 @@
+package bootstrap
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os/exec"
+	"strings"
+)
+
+const maxInfrastructureOutputSize = 1024 * 1024
+
+type infrastructureOutputReader interface {
+	Read(ctx context.Context, dir, command, name string) (string, error)
+}
+
+type commandInfrastructureOutputReader struct{}
+
+type cappedBuffer struct {
+	bytes.Buffer
+	limit    int
+	exceeded bool
+}
+
+func (b *cappedBuffer) Write(p []byte) (int, error) {
+	originalLength := len(p)
+	remaining := b.limit - b.Len()
+	if remaining <= 0 {
+		b.exceeded = true
+		return originalLength, nil
+	}
+	if len(p) > remaining {
+		p = p[:remaining]
+		b.exceeded = true
+	}
+	_, _ = b.Buffer.Write(p)
+	return originalLength, nil
+}
+
+func (commandInfrastructureOutputReader) Read(ctx context.Context, dir, command, name string) (string, error) {
+	cmd := exec.CommandContext(ctx, command, "output", "-raw", name)
+	cmd.Dir = dir
+
+	stdout := cappedBuffer{limit: maxInfrastructureOutputSize}
+	cmd.Stdout = &stdout
+	cmd.Stderr = io.Discard
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("%s output %q failed: %w; ensure the infrastructure has been applied and the output exists", command, name, err)
+	}
+	if stdout.exceeded {
+		return "", fmt.Errorf("%s output %q exceeds %d bytes", command, name, maxInfrastructureOutputSize)
+	}
+
+	value := strings.TrimSpace(stdout.String())
+	if value == "" {
+		return "", fmt.Errorf("%s output %q is empty", command, name)
+	}
+	return value, nil
+}
+
+func resolveIaCCommand(configured string) (string, error) {
+	switch configured {
+	case "terraform", "tofu":
+		if _, err := exec.LookPath(configured); err != nil {
+			return "", fmt.Errorf("%s executable not found: %w", configured, err)
+		}
+		return configured, nil
+	case "", "auto":
+		_, terraformErr := exec.LookPath("terraform")
+		_, tofuErr := exec.LookPath("tofu")
+		switch {
+		case terraformErr == nil && tofuErr != nil:
+			return "terraform", nil
+		case tofuErr == nil && terraformErr != nil:
+			return "tofu", nil
+		case terraformErr == nil && tofuErr == nil:
+			return "", fmt.Errorf("both terraform and tofu are installed; select one with --iac-command")
+		default:
+			return "", fmt.Errorf("neither terraform nor tofu executable was found")
+		}
+	default:
+		return "", fmt.Errorf("unsupported --iac-command %q; expected auto, terraform, or tofu", configured)
+	}
+}

--- a/src/internal/cmd/bootstrap/infrastructure_outputs_test.go
+++ b/src/internal/cmd/bootstrap/infrastructure_outputs_test.go
@@ -1,0 +1,26 @@
+package bootstrap
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveIaCCommandRejectsUnsupportedValue(t *testing.T) {
+	_, err := resolveIaCCommand("pulumi")
+
+	require.EqualError(t, err, `unsupported --iac-command "pulumi"; expected auto, terraform, or tofu`)
+}
+
+func TestCappedBufferLimitsCapturedOutput(t *testing.T) {
+	buffer := cappedBuffer{limit: 4}
+
+	written, err := buffer.Write([]byte("secret"))
+
+	require.NoError(t, err)
+	require.Equal(t, len("secret"), written)
+	require.Equal(t, "secr", buffer.String())
+	require.True(t, buffer.exceeded)
+	require.False(t, strings.Contains(buffer.String(), "et"))
+}

--- a/src/internal/cmd/bootstrap/secrets.go
+++ b/src/internal/cmd/bootstrap/secrets.go
@@ -24,12 +24,18 @@ import (
 
 // SecretManager handles Kubernetes secret creation programmatically
 type SecretManager struct {
-	client *k8s.Client
+	client             *k8s.Client
+	outputReader       infrastructureOutputReader
+	iacCommandResolver func(string) (string, error)
 }
 
 // NewSecretManager creates a new secret manager
 func NewSecretManager(client *k8s.Client) *SecretManager {
-	return &SecretManager{client: client}
+	return &SecretManager{
+		client:             client,
+		outputReader:       commandInfrastructureOutputReader{},
+		iacCommandResolver: resolveIaCCommand,
+	}
 }
 
 // CreateHubSecrets creates all hub cluster secrets
@@ -49,6 +55,24 @@ func (sm *SecretManager) CreateHubSecrets(ctx context.Context, o *Options) error
 		sm.createHelmRepositorySecret(o.EnvMap),
 	}
 
+	clusterSecStore, err := sm.createClusterSecretStore(o)
+	if err != nil {
+		return fmt.Errorf("create ClusterSecretStore: %w", err)
+	}
+	verifyClusterSecretStore := clusterSecStore != nil
+	verifyCredentialSecret := false
+	if clusterSecStore == nil {
+		var credentialSecret *corev1.Secret
+		clusterSecStore, credentialSecret, verifyClusterSecretStore, err = sm.resolveClusterSecretStore(ctx, o)
+		if err != nil {
+			return fmt.Errorf("resolve ClusterSecretStore: %w", err)
+		}
+		if credentialSecret != nil {
+			secrets = append(secrets, credentialSecret)
+			verifyCredentialSecret = true
+		}
+	}
+
 	for _, secret := range secrets {
 		if secret == nil {
 			continue
@@ -64,10 +88,6 @@ func (sm *SecretManager) CreateHubSecrets(ctx context.Context, o *Options) error
 	}
 
 	// Handle clusterSecretStore separately since it is its own type
-	clusterSecStore, err := sm.createClusterSecretStore(o)
-	if err != nil {
-		return fmt.Errorf("create ClusterSecretStore: %w", err)
-	}
 	if clusterSecStore != nil {
 		yamlData, err := yaml.Marshal(clusterSecStore)
 		if err != nil {
@@ -84,6 +104,18 @@ func (sm *SecretManager) CreateHubSecrets(ctx context.Context, o *Options) error
 	// Apply all secrets in one API call
 	if err := sm.client.ApplyManifest(ctx, manifest, k8sOpts); err != nil {
 		return fmt.Errorf("applying hub secrets: %w", err)
+	}
+	if !o.DryRun {
+		if verifyCredentialSecret {
+			if err := sm.validateCredentialSecret(ctx, stackitCredentialSecretName); err != nil {
+				return err
+			}
+		}
+		if verifyClusterSecretStore {
+			if err := sm.validateClusterSecretStore(ctx, clusterSecStore.Name); err != nil {
+				return err
+			}
+		}
 	}
 
 	log.Info().Msg("Created hub secrets successfully")
@@ -246,7 +278,6 @@ func loadAndValidateClusterSecretStore(filePath string, cluster *config.Cluster)
 // createClusterSecretStore creates the ClusterSecretStore for external-secrets
 func (sm *SecretManager) createClusterSecretStore(o *Options) (*externalsecretsv1.ClusterSecretStore, error) {
 	if o.WithESCSSPath == "" {
-		log.Warn().Msg("ClusterSecretStore manifest file not provided. You must apply an existing ClusterSecretStore or create one manually")
 		return nil, nil
 	}
 
@@ -265,7 +296,7 @@ func (sm *SecretManager) createClusterSecretStore(o *Options) (*externalsecretsv
 		log.Warn().
 			Str("expected", expectedName).
 			Str("actual", css.Name).
-			Msg("ClusterSecretStore name does not follow the pattern <cluster.name>-<cluster.stage>. Make sure to update any helm values reffering to the ClusterSecretStore accordingly")
+			Msg("ClusterSecretStore name does not follow the pattern <cluster.name>-<cluster.stage>. Make sure to update any Helm values referring to the ClusterSecretStore accordingly")
 	}
 
 	log.Info().

--- a/src/internal/cmd/bootstrap/secrets_test.go
+++ b/src/internal/cmd/bootstrap/secrets_test.go
@@ -1,12 +1,23 @@
 package bootstrap
 
 import (
+	"context"
+	"fmt"
 	"testing"
 
+	"github.com/kubara-io/kubara/internal/config"
 	"github.com/kubara-io/kubara/internal/envconfig"
+	"github.com/kubara-io/kubara/internal/k8s"
+	"github.com/kubara-io/kubara/internal/service"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	kubernetesfake "k8s.io/client-go/kubernetes/fake"
 )
 
 func TestCreateHelmRepositorySecret(t *testing.T) {
@@ -58,4 +69,188 @@ func TestCreateHelmRepositorySecret(t *testing.T) {
 		assert.Equal(t, "registry-1.docker.io/bitnamicharts", secret.StringData["url"])
 		assert.Equal(t, "true", secret.StringData["enableOCI"])
 	})
+}
+
+type fakeInfrastructureOutputReader map[string]string
+
+func (f fakeInfrastructureOutputReader) Read(_ context.Context, _, _, name string) (string, error) {
+	value, exists := f[name]
+	if !exists {
+		return "", fmt.Errorf("missing output %q", name)
+	}
+	return value, nil
+}
+
+func TestResolveClusterSecretStore(t *testing.T) {
+	existingStore := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "external-secrets.io/v1",
+			"kind":       "ClusterSecretStore",
+			"metadata": map[string]interface{}{
+				"name": "test-cluster-local",
+			},
+		},
+	}
+
+	tests := []struct {
+		name         string
+		provider     config.TerraformProvider
+		objects      []runtime.Object
+		dryRun       bool
+		disabled     bool
+		wantCreated  bool
+		wantValidate bool
+		wantError    string
+	}{
+		{
+			name:     "accepts existing store",
+			provider: config.TerraformProviderStackit,
+			objects:  []runtime.Object{existingStore},
+		},
+		{
+			name:         "creates missing STACKIT store",
+			provider:     config.TerraformProviderStackit,
+			wantCreated:  true,
+			wantValidate: true,
+		},
+		{
+			name:     "allows generated T Cloud Public store",
+			provider: config.TerraformProviderTCloudPublic,
+		},
+		{
+			name:     "skips live validation during dry-run",
+			provider: config.TerraformProviderStackit,
+			dryRun:   true,
+		},
+		{
+			name:     "skips validation when external secrets is disabled",
+			provider: config.TerraformProviderStackit,
+			disabled: true,
+		},
+		{
+			name:      "rejects missing store for unsupported provider",
+			provider:  config.TerraformProviderNone,
+			wantError: `ClusterSecretStore "test-cluster-local" was not found`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dynamicClient := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme(), tt.objects...)
+			sm := NewSecretManager(&k8s.Client{
+				Clientset:     kubernetesfake.NewSimpleClientset(),
+				DynamicClient: dynamicClient,
+			})
+			sm.outputReader = fakeInfrastructureOutputReader{
+				stackitVaultUsernameOutput: "readonly-user",
+				stackitVaultPasswordOutput: "cmVhZG9ubHktcGFzc3dvcmQ=",
+				stackitVaultAPIURLOutput:   "https://secrets.example.com",
+				stackitVaultPathOutput:     "instance-id",
+			}
+			sm.iacCommandResolver = func(string) (string, error) { return "tofu", nil }
+			externalSecretsStatus := service.StatusEnabled
+			if tt.disabled {
+				externalSecretsStatus = service.StatusDisabled
+			}
+			opts := &Options{
+				ClusterConfig: &config.Cluster{
+					Name:  "test-cluster",
+					Stage: "local",
+					Terraform: &config.Terraform{
+						Provider: tt.provider,
+					},
+					Services: service.Services{
+						"external-secrets": {Status: externalSecretsStatus},
+					},
+				},
+				DryRun: tt.dryRun,
+			}
+
+			css, credentialSecret, validate, err := sm.resolveClusterSecretStore(context.Background(), opts)
+			if tt.wantError != "" {
+				require.ErrorContains(t, err, tt.wantError)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantValidate, validate)
+			if !tt.wantCreated {
+				assert.Nil(t, css)
+				assert.Nil(t, credentialSecret)
+				return
+			}
+
+			require.NotNil(t, css)
+			require.NotNil(t, credentialSecret)
+			assert.Equal(t, "test-cluster-local", css.Name)
+			assert.Equal(t, "readonly-user", credentialSecret.StringData["username"])
+			assert.Equal(t, "readonly-password", credentialSecret.StringData["password"])
+			require.NotNil(t, css.Spec.Provider)
+			require.NotNil(t, css.Spec.Provider.Vault)
+			assert.Equal(t, "https://secrets.example.com", css.Spec.Provider.Vault.Server)
+			assert.Equal(t, "instance-id", *css.Spec.Provider.Vault.Path)
+			assert.Equal(t, "readonly-user", css.Spec.Provider.Vault.Auth.UserPass.Username)
+		})
+	}
+}
+
+func TestResolveClusterSecretStoreRequiresClusterConfig(t *testing.T) {
+	sm := NewSecretManager(&k8s.Client{
+		Clientset:     kubernetesfake.NewSimpleClientset(),
+		DynamicClient: dynamicfake.NewSimpleDynamicClient(runtime.NewScheme()),
+	})
+
+	_, _, _, err := sm.resolveClusterSecretStore(context.Background(), &Options{})
+
+	require.EqualError(t, err, "cluster config is required")
+}
+
+func TestCreateStackitClusterSecretStoreDoesNotExposeInvalidPasswordOutput(t *testing.T) {
+	sm := NewSecretManager(&k8s.Client{
+		Clientset:     kubernetesfake.NewSimpleClientset(),
+		DynamicClient: dynamicfake.NewSimpleDynamicClient(runtime.NewScheme()),
+	})
+	sm.outputReader = fakeInfrastructureOutputReader{
+		stackitVaultUsernameOutput: "readonly-user",
+		stackitVaultPasswordOutput: "sensitive-invalid-value",
+	}
+	sm.iacCommandResolver = func(string) (string, error) { return "terraform", nil }
+	opts := &Options{
+		PlatformConfigs: t.TempDir(),
+		ClusterConfig: &config.Cluster{
+			Name:  "test-cluster",
+			Stage: "local",
+		},
+	}
+
+	_, _, err := sm.createStackitClusterSecretStore(context.Background(), opts)
+
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "sensitive-invalid-value")
+}
+
+func TestValidateCreatedExternalSecretsResources(t *testing.T) {
+	existingStore := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "external-secrets.io/v1",
+			"kind":       "ClusterSecretStore",
+			"metadata": map[string]interface{}{
+				"name": "test-cluster-local",
+			},
+		},
+	}
+	credentialSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      stackitCredentialSecretName,
+			Namespace: externalSecretsNamespace,
+		},
+	}
+	sm := NewSecretManager(&k8s.Client{
+		Clientset:     kubernetesfake.NewSimpleClientset(credentialSecret),
+		DynamicClient: dynamicfake.NewSimpleDynamicClient(runtime.NewScheme(), existingStore),
+	})
+
+	require.NoError(t, sm.validateCredentialSecret(context.Background(), stackitCredentialSecretName))
+	require.NoError(t, sm.validateClusterSecretStore(context.Background(), "test-cluster-local"))
+	require.ErrorContains(t, sm.validateCredentialSecret(context.Background(), "missing"), "validate credential Secret")
+	require.ErrorContains(t, sm.validateClusterSecretStore(context.Background(), "missing"), "was not found after apply")
 }


### PR DESCRIPTION
## 📝 Summary

Automatically provision the STACKIT Secrets Manager credential Secret and `ClusterSecretStore` during bootstrap when `external-secrets` is enabled.

The bootstrap flow now:

- respects `--with-es-css-file` as an explicit override
- reuses an existing `<cluster>-<stage>` store
- reads the STACKIT read-only username, password, API URL, and mount path from Terraform or OpenTofu outputs when no store exists
- applies and verifies both the credential Secret and ClusterSecretStore
- skips all discovery and provisioning when `external-secrets` is disabled
- retains the generated T Cloud Public OpenBao flow

Users of another secret backend can continue to provide a manifest with `--with-es-css-file` or create the expected store before bootstrap.

## 🧩 Type of change
- [x] 🔧 CLI / Go code
- [x] 📝 Documentation
- [x] 🧪 Test or CI change
- [ ] ♻️ Refactor / cleanup

## ⚠️ Is this a breaking change?
- [ ] Yes, this change breaks existing functionality (explain in summary)

## 🧪 Testing
- [ ] CI passed
- [ ] Manually tested (local/dev cluster)
- [x] Unit tested
- [ ] Not tested (explain why below)

Additional validation:

- `go test ./...`
- `go vet ./...`
- `make build-binary`
- `make docs-validate`
- generated a STACKIT SKE platform from the working-tree catalog
- verified the rendered Terraform outputs with `terraform fmt -check`

## 🔗 Additional Context / Related Issues / Tickets

Requires kubara-io/catalogs#72 for the new `vault_api_url` and `vault_path` outputs.

The automatic path runs only for STACKIT. Custom secret backends remain supported through an existing store or `--with-es-css-file`.

## ✅ Checklist
- [x] Code compiles and passes all tests
- [x] Linting and style checks pass
- [ ] Comments added for complex logic
- [x] Documentation updated (if applicable)
