### PR TITLE
feat(argocd): support Git repository auth modes

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -278,12 +278,36 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      # TODO: Remove this checkout and the local packaging step once releases
+      # containing kubara-io/catalogs#6 have been published and pinned by kubara.
+      - name: Checkout matching catalogs
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: kubara-io/catalogs
+          ref: 69bfcbbaa9a82967a30ae1ff3c8aec088e4abe53 # kubara-io/catalogs#6
+          path: .ci/catalogs
+
       - name: Setup Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: src/go.mod
           cache: true
           cache-dependency-path: src/go.sum
+
+      - name: Build kubara CLI
+        working-directory: src
+        run: go build -o "${RUNNER_TEMP}/kubara" .
+
+      - name: Package matching catalogs locally
+        run: |
+          set -euo pipefail
+          for catalog in bootstrap general; do
+            (
+              cd ".ci/catalogs/${catalog}"
+              "${RUNNER_TEMP}/kubara" catalog package \
+                oci://ghcr.io/kubara-io/catalogs/
+            )
+          done
 
       - name: Create output directory
         run: |
@@ -293,8 +317,9 @@ jobs:
       - name: kubara init --prep
         run: |
           set -euo pipefail
-          cd src
-          go run main.go --work-dir "${{ env.OUTPUT_GENERATED_DIR }}" init --prep
+          "${RUNNER_TEMP}/kubara" \
+            --work-dir "${{ env.OUTPUT_GENERATED_DIR }}" \
+            init --prep
 
       - name: Update .env (strict template mode)
         run: |
@@ -304,8 +329,9 @@ jobs:
       - name: kubara init
         run: |
           set -euo pipefail
-          cd src
-          go run main.go --work-dir "${{ env.OUTPUT_GENERATED_DIR }}" init
+          "${RUNNER_TEMP}/kubara" \
+            --work-dir "${{ env.OUTPUT_GENERATED_DIR }}" \
+            init
 
       - name: Update config.yaml (strict mode)
         run: |
@@ -314,8 +340,9 @@ jobs:
 
       - name: Generate kubara artifacts
         run: |
-          cd src
-          go run main.go --work-dir "${{ env.OUTPUT_GENERATED_DIR }}" generate
+          "${RUNNER_TEMP}/kubara" \
+            --work-dir "${{ env.OUTPUT_GENERATED_DIR }}" \
+            generate
 
       - name: Upload generated helm and terraform files
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/docs/content/1_getting_started/bootstrapping.md
+++ b/docs/content/1_getting_started/bootstrapping.md
@@ -61,6 +61,34 @@ The easiest way is to run `kubara` inside the repository (but do not add the bin
         Keep in mind that weak passwords such as `123456` for `ARGOCD_WIZARD_ACCOUNT_PASSWORD` are a bad idea, since your
         platform will be publicly available by default via your DNS zone.
 
+#### Git repository authentication
+
+kubara creates the initial Argo CD repository secret during `kubara bootstrap`.
+`ARGOCD_GIT_AUTH_MODE` controls which credential fields are written:
+
+| Mode | Required values | Notes |
+| --- | --- | --- |
+| `https` | `ARGOCD_GIT_URL` or legacy `ARGOCD_GIT_HTTPS_URL` | Backward-compatible default. `ARGOCD_GIT_USERNAME` + `ARGOCD_GIT_PAT_OR_PASSWORD` are optional: omit them for public repositories, set both for private ones. `PAT` usually means Personal Access Token and is often tied to a user account. Prefer a technical or machine account and use that account name for `ARGOCD_GIT_USERNAME`; exact username behavior is provider-dependent. |
+| `ssh` | `ARGOCD_GIT_URL`, `ARGOCD_GIT_SSH_PRIVATE_KEY` | Use an SSH repository URL such as `git@github.com:org/repo.git`. Argo CD must know the SSH host key before it can connect securely. |
+| `github-app` | `ARGOCD_GIT_URL`, `ARGOCD_GIT_GITHUB_APP_ID`, `ARGOCD_GIT_GITHUB_APP_INSTALLATION_ID`, `ARGOCD_GIT_GITHUB_APP_PRIVATE_KEY` | Use GitHub App authentication for organization-owned automation. For GitHub Enterprise, set `ARGOCD_GIT_GITHUB_APP_ENTERPRISE_BASE_URL` as well. |
+
+For new setups, prefer `ARGOCD_GIT_URL`.
+`ARGOCD_GIT_HTTPS_URL` is still supported for existing HTTPS/PAT setups.
+
+For SSH, keep strict host verification enabled.
+The bundled Argo CD Helm chart already includes known hosts for common public providers.
+For private Git hosts, add trusted host keys to the generated Argo CD values before bootstrapping, for example in `platform-configs/<cluster>/helm/argo-cd/values-additional.yaml`:
+
+```yaml
+argo-cd:
+  configs:
+    ssh:
+      extraHosts: |
+        git.example.com ssh-ed25519 <trusted-host-key>
+```
+
+If the required host key is missing, Argo CD will reject the SSH connection as an unknown SSH host.
+
 
 
 ### 1.3 Generate Base Configuration
@@ -83,6 +111,9 @@ For Renovate to discover the generated file, use the Git repository root as kuba
 Kubara does not modify an existing Renovate configuration. In that case, `init` logs a warning and you can add the [Renovate settings for catalog updates](../2_concepts/catalog_distribution.md#automatic-catalog-updates-with-renovate) manually.
 
 If you make changes to `.env` later, you can re-run the command with `--overwrite` to update the configuration.
+The generated Argo CD repository config records the selected Git auth mode in `argocd.repo.authMode`.
+Repository URLs are stored under `argocd.repo.git`.
+Older configs are migrated up to `v1alpha5` when kubara loads and saves the config: the old `argocd.repo.https` key moves to `argocd.repo.git`.
 
 By default, the generated cluster references kubara's versioned general catalog. Use repeated `--catalog` flags to initialize it with a different ordered catalog set:
 

--- a/docs/content/5_workload_onboarding/add_app_repository.md
+++ b/docs/content/5_workload_onboarding/add_app_repository.md
@@ -7,34 +7,104 @@ For more information check:
 https://argo-cd.readthedocs.io/en/stable/user-guide/private-repositories/
 
 ## **Add credentials to vault**
-Add the repository credentials to your vault at
-`<cluster-name>/<stage>/repo_pat`. This can be a `password` or a `PAT`.
+Add the repository credentials to your vault below `<cluster-name>/<stage>`.
+The examples below use one secret value per repository credential.
+
+For HTTPS username + password/PAT authentication, `PAT` usually means Personal Access Token and is often tied to a user account.
+For platform automation, prefer a technical or machine account instead of a personal user account.
+Set `username` to the account name expected by your Git provider; the exact value is provider-dependent.
+
 ```json
 {
   "repo_pat": {
-    "pat": "<the kubeconfig>"
+    "pat": "<password-or-PAT>"
   }
 }
 ```
-## **Modify Argo CD overlays**
-Add the following to your Argo CD overlay, typically `platform-configs/<hub-cluster-name>/helm/argo-cd/values-additional.yaml`.
-```yaml
-repositories:
-    - name: user-repo-mock
-      projectScope: k8s-spoke-0
-      # # This points to the secret in vault
-      remoteRef:
-        remoteKey: <cluster-name>/<stage>/repo_pat
-        remoteKeyProperty: pat
-      repoType: git
-      secretStoreRef:
-        kind: ClusterSecretStore
-        name: hub-0-production
-      url: <the repo url you want to add>
-      username: <the username for connection. also needed for PAT>
+
+For SSH deploy key authentication:
+
+```json
+{
+  "repo_ssh": {
+    "privateKey": "-----BEGIN OPENSSH PRIVATE KEY-----\n...\n-----END OPENSSH PRIVATE KEY-----"
+  }
+}
 ```
 
-That whats happening behind the scenes:
+For GitHub App authentication:
+
+```json
+{
+  "repo_github_app": {
+    "privateKey": "-----BEGIN RSA PRIVATE KEY-----\n...\n-----END RSA PRIVATE KEY-----"
+  }
+}
+```
+
+## **Modify Argo CD overlays**
+Add one of the following repository definitions to your Argo CD overlay, typically
+`platform-configs/<hub-cluster-name>/helm/argo-cd/values-additional.yaml`.
+
+HTTPS username + password/PAT:
+
+```yaml
+repositories:
+  - name: user-repo-mock
+    authMode: https
+    projectScope: k8s-spoke-0
+    remoteRef:
+      remoteKey: <cluster-name>/<stage>/repo_pat
+      remoteKeyProperty: pat
+    repoType: git
+    secretStoreRef:
+      kind: ClusterSecretStore
+      name: hub-0-production
+    url: https://git.example.com/org/repo.git
+    username: <technical-account-username>
+```
+
+SSH deploy key:
+
+```yaml
+repositories:
+  - name: user-repo-ssh
+    authMode: ssh
+    projectScope: k8s-spoke-0
+    sshPrivateKeyRemoteRef:
+      remoteKey: <cluster-name>/<stage>/repo_ssh
+      remoteKeyProperty: privateKey
+    repoType: git
+    secretStoreRef:
+      kind: ClusterSecretStore
+      name: hub-0-production
+    url: git@git.example.com:org/repo.git
+```
+
+For SSH repositories, make sure Argo CD already trusts the SSH host key. See the bootstrap documentation for `configs.ssh.extraHosts`.
+
+GitHub App:
+
+```yaml
+repositories:
+  - name: user-repo-github-app
+    authMode: github-app
+    projectScope: k8s-spoke-0
+    githubAppID: "123456"
+    githubAppInstallationID: "987654"
+    githubAppPrivateKeyRemoteRef:
+      remoteKey: <cluster-name>/<stage>/repo_github_app
+      remoteKeyProperty: privateKey
+    repoType: git
+    secretStoreRef:
+      kind: ClusterSecretStore
+      name: hub-0-production
+    url: https://github.com/org/repo.git
+```
+
+For GitHub Enterprise, also set `githubAppEnterpriseBaseUrl`.
+
+That's what's happening behind the scenes:
 
 ![Add Repository](../images/add-repository.png)
 

--- a/src/cmd/generate_test.go
+++ b/src/cmd/generate_test.go
@@ -191,7 +191,7 @@ func TestGenerateCmd(t *testing.T) {
 				},
 				ArgoCD: config.ArgoCD{
 					Repo: config.RepoProto{
-						HTTPS: &config.RepoType{
+						Git: &config.RepoType{
 							Configs:    config.Repository{URL: "https://github.com/example/configs", TargetRevision: "main"},
 							Components: config.Repository{URL: "https://github.com/example/components", TargetRevision: "main"},
 						},
@@ -251,7 +251,7 @@ func TestGenerateCmd(t *testing.T) {
 					},
 					ArgoCD: config.ArgoCD{
 						Repo: config.RepoProto{
-							HTTPS: &config.RepoType{
+							Git: &config.RepoType{
 								Configs: config.Repository{
 									URL:            "https://github.com/example/configs",
 									TargetRevision: "main",
@@ -328,7 +328,7 @@ func TestGenerateCmd_MissingProviderFailsForTerraform(t *testing.T) {
 		},
 		ArgoCD: config.ArgoCD{
 			Repo: config.RepoProto{
-				HTTPS: &config.RepoType{
+				Git: &config.RepoType{
 					Configs:    config.Repository{URL: "https://github.com/example/configs", TargetRevision: "main"},
 					Components: config.Repository{URL: "https://github.com/example/components", TargetRevision: "main"},
 				},
@@ -366,7 +366,7 @@ func TestGenerateCmd_MissingProviderUsesAllByDefault(t *testing.T) {
 		},
 		ArgoCD: config.ArgoCD{
 			Repo: config.RepoProto{
-				HTTPS: &config.RepoType{
+				Git: &config.RepoType{
 					Configs:    config.Repository{URL: "https://github.com/example/configs", TargetRevision: "main"},
 					Components: config.Repository{URL: "https://github.com/example/components", TargetRevision: "main"},
 				},
@@ -399,7 +399,7 @@ func TestGenerateCmd_MissingTerraformUsesAllByDefault(t *testing.T) {
 		Catalogs: []string{helperCatalogPath},
 		ArgoCD: config.ArgoCD{
 			Repo: config.RepoProto{
-				HTTPS: &config.RepoType{
+				Git: &config.RepoType{
 					Configs:    config.Repository{URL: "https://github.com/example/configs", TargetRevision: "main"},
 					Components: config.Repository{URL: "https://github.com/example/components", TargetRevision: "main"},
 				},
@@ -441,7 +441,7 @@ func TestGenerateCmd_TerraformProviderNoneUsesAllByDefault(t *testing.T) {
 		},
 		ArgoCD: config.ArgoCD{
 			Repo: config.RepoProto{
-				HTTPS: &config.RepoType{
+				Git: &config.RepoType{
 					Configs:    config.Repository{URL: "https://github.com/example/configs", TargetRevision: "main"},
 					Components: config.Repository{URL: "https://github.com/example/components", TargetRevision: "main"},
 				},
@@ -471,7 +471,7 @@ func TestGenerateCmd_MissingTerraformFailsForTerraform(t *testing.T) {
 		DNSName: "test.example.com",
 		ArgoCD: config.ArgoCD{
 			Repo: config.RepoProto{
-				HTTPS: &config.RepoType{
+				Git: &config.RepoType{
 					Configs:    config.Repository{URL: "https://github.com/example/configs", TargetRevision: "main"},
 					Components: config.Repository{URL: "https://github.com/example/components", TargetRevision: "main"},
 				},
@@ -505,7 +505,7 @@ func TestDisabledServicesDontGetWritten(t *testing.T) {
 		DNSName: "test.example.com",
 		ArgoCD: config.ArgoCD{
 			Repo: config.RepoProto{
-				HTTPS: &config.RepoType{
+				Git: &config.RepoType{
 					Configs:    config.Repository{URL: "https://github.com/example/configs", TargetRevision: "main"},
 					Components: config.Repository{URL: "https://github.com/example/components", TargetRevision: "main"},
 				},

--- a/src/cmd/testutil/testutil.go
+++ b/src/cmd/testutil/testutil.go
@@ -83,7 +83,8 @@ func CreateTestCluster(t *testing.T) config.Cluster {
 		ArgoCD: config.ArgoCD{
 			SelfManaged: config.ArgoCDSelfManagedEnabled,
 			Repo: config.RepoProto{
-				HTTPS: &config.RepoType{
+				AuthMode: envconfig.GitAuthModeHTTPS,
+				Git: &config.RepoType{
 					Configs:    config.Repository{URL: "https://github.com/example/configs", TargetRevision: "main"},
 					Components: config.Repository{URL: "https://github.com/example/components", TargetRevision: "main"},
 				},

--- a/src/internal/cmd/bootstrap/local.go
+++ b/src/internal/cmd/bootstrap/local.go
@@ -1175,8 +1175,8 @@ middleware:
 
 func localProjectSourceRepos(opts *Options) []string {
 	repos := []string{
-		opts.ClusterConfig.ArgoCD.Repo.HTTPS.Components.URL,
-		opts.ClusterConfig.ArgoCD.Repo.HTTPS.Configs.URL,
+		opts.ClusterConfig.ArgoCD.Repo.Git.Components.URL,
+		opts.ClusterConfig.ArgoCD.Repo.Git.Configs.URL,
 		"https://charts.external-secrets.io/",
 		"https://charts.jetstack.io",
 		"https://prometheus-community.github.io/helm-charts",

--- a/src/internal/cmd/bootstrap/secrets.go
+++ b/src/internal/cmd/bootstrap/secrets.go
@@ -92,17 +92,39 @@ func (sm *SecretManager) CreateHubSecrets(ctx context.Context, o *Options) error
 
 // createGitRepositorySecret creates the ArgoCD git repository secret
 func (sm *SecretManager) createGitRepositorySecret(em *envconfig.EnvMap) *corev1.Secret {
+	secretName := "https-init-repo-access"
+	switch em.GitAuthMode() {
+	case envconfig.GitAuthModeSSH:
+		secretName = "ssh-init-repo-access"
+	case envconfig.GitAuthModeGitHubApp:
+		secretName = "github-app-init-repo-access"
+	}
+
 	stringData := map[string]string{
 		"enableLfs": "true",
 		"insecure":  "false",
-		"name":      "https-init-repo-access",
-		"url":       em.ArgocdGitHttpsUrl,
+		"name":      secretName,
 		"project":   fmt.Sprintf("%s-%s", em.ProjectName, em.ProjectStage),
+		"type":      "git",
+		"url":       em.GitRepositoryURL(),
 	}
-	if envconfig.IsConfiguredEnvValue(em.ArgocdGitUsername) && envconfig.IsConfiguredEnvValue(em.ArgocdGitPatOrPassword) {
-		stringData["username"] = em.ArgocdGitUsername
-		stringData["password"] = em.ArgocdGitPatOrPassword
-		stringData["forceHttpBasicAuth"] = "true"
+
+	switch em.GitAuthMode() {
+	case envconfig.GitAuthModeSSH:
+		stringData["sshPrivateKey"] = em.ArgocdGitSshPrivateKey
+	case envconfig.GitAuthModeGitHubApp:
+		stringData["githubAppID"] = em.ArgocdGitGithubAppID
+		stringData["githubAppInstallationID"] = em.ArgocdGitGithubAppInstallationID
+		stringData["githubAppPrivateKey"] = em.ArgocdGitGithubAppPrivateKey
+		if envconfig.IsConfiguredEnvValue(em.ArgocdGitGithubAppEnterpriseBaseUrl) {
+			stringData["githubAppEnterpriseBaseUrl"] = em.ArgocdGitGithubAppEnterpriseBaseUrl
+		}
+	default:
+		if envconfig.IsConfiguredEnvValue(em.ArgocdGitUsername) && envconfig.IsConfiguredEnvValue(em.ArgocdGitPatOrPassword) {
+			stringData["username"] = em.ArgocdGitUsername
+			stringData["password"] = em.ArgocdGitPatOrPassword
+			stringData["forceHttpBasicAuth"] = "true"
+		}
 	}
 
 	return &corev1.Secret{
@@ -111,7 +133,7 @@ func (sm *SecretManager) createGitRepositorySecret(em *envconfig.EnvMap) *corev1
 			Kind:       "Secret",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "https-init-repo-access",
+			Name:      secretName,
 			Namespace: argocdNamespace,
 			Labels: map[string]string{
 				"argocd.argoproj.io/secret-type": "repository",

--- a/src/internal/cmd/bootstrap/secrets_test.go
+++ b/src/internal/cmd/bootstrap/secrets_test.go
@@ -9,6 +9,72 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestCreateGitRepositorySecret(t *testing.T) {
+	sm := &SecretManager{}
+
+	t.Run("creates legacy HTTPS repository secret", func(t *testing.T) {
+		secret := sm.createGitRepositorySecret(&envconfig.EnvMap{
+			ProjectName:            "test",
+			ProjectStage:           "dev",
+			ArgocdGitHttpsUrl:      "https://github.com/example/repo.git",
+			ArgocdGitPatOrPassword: "token",
+			ArgocdGitUsername:      "machine-user",
+		})
+
+		require.NotNil(t, secret)
+		assert.Equal(t, "https-init-repo-access", secret.Name)
+		assert.Equal(t, "https://github.com/example/repo.git", secret.StringData["url"])
+		assert.Equal(t, "machine-user", secret.StringData["username"])
+		assert.Equal(t, "token", secret.StringData["password"])
+		assert.Equal(t, "true", secret.StringData["forceHttpBasicAuth"])
+		assert.Equal(t, "git", secret.StringData["type"])
+		_, hasSSHKey := secret.StringData["sshPrivateKey"]
+		assert.False(t, hasSSHKey)
+	})
+
+	t.Run("creates SSH repository secret", func(t *testing.T) {
+		secret := sm.createGitRepositorySecret(&envconfig.EnvMap{
+			ProjectName:            "test",
+			ProjectStage:           "dev",
+			ArgocdGitAuthMode:      envconfig.GitAuthModeSSH,
+			ArgocdGitUrl:           "git@github.com:example/repo.git",
+			ArgocdGitSshPrivateKey: "-----BEGIN OPENSSH PRIVATE KEY-----\nkey\n-----END OPENSSH PRIVATE KEY-----",
+		})
+
+		require.NotNil(t, secret)
+		assert.Equal(t, "ssh-init-repo-access", secret.Name)
+		assert.Equal(t, "git@github.com:example/repo.git", secret.StringData["url"])
+		assert.Equal(t, "-----BEGIN OPENSSH PRIVATE KEY-----\nkey\n-----END OPENSSH PRIVATE KEY-----", secret.StringData["sshPrivateKey"])
+		_, hasUsername := secret.StringData["username"]
+		assert.False(t, hasUsername)
+		_, hasPassword := secret.StringData["password"]
+		assert.False(t, hasPassword)
+	})
+
+	t.Run("creates GitHub App repository secret", func(t *testing.T) {
+		secret := sm.createGitRepositorySecret(&envconfig.EnvMap{
+			ProjectName:                         "test",
+			ProjectStage:                        "dev",
+			ArgocdGitAuthMode:                   envconfig.GitAuthModeGitHubApp,
+			ArgocdGitUrl:                        "https://github.com/example/repo.git",
+			ArgocdGitGithubAppID:                "123",
+			ArgocdGitGithubAppInstallationID:    "456",
+			ArgocdGitGithubAppPrivateKey:        "-----BEGIN RSA PRIVATE KEY-----\nkey\n-----END RSA PRIVATE KEY-----",
+			ArgocdGitGithubAppEnterpriseBaseUrl: "https://github.example.com/api/v3",
+		})
+
+		require.NotNil(t, secret)
+		assert.Equal(t, "github-app-init-repo-access", secret.Name)
+		assert.Equal(t, "https://github.com/example/repo.git", secret.StringData["url"])
+		assert.Equal(t, "123", secret.StringData["githubAppID"])
+		assert.Equal(t, "456", secret.StringData["githubAppInstallationID"])
+		assert.Equal(t, "-----BEGIN RSA PRIVATE KEY-----\nkey\n-----END RSA PRIVATE KEY-----", secret.StringData["githubAppPrivateKey"])
+		assert.Equal(t, "https://github.example.com/api/v3", secret.StringData["githubAppEnterpriseBaseUrl"])
+		_, hasForceHTTPBasicAuth := secret.StringData["forceHttpBasicAuth"]
+		assert.False(t, hasForceHTTPBasicAuth)
+	})
+}
+
 func TestCreateHelmRepositorySecret(t *testing.T) {
 	sm := &SecretManager{}
 

--- a/src/internal/config/defaults_test.go
+++ b/src/internal/config/defaults_test.go
@@ -89,7 +89,8 @@ func TestApplyDefaults_RepositoryTargetRevision(t *testing.T) {
 			{
 				ArgoCD: ArgoCD{
 					Repo: RepoProto{
-						HTTPS: &RepoType{
+						AuthMode: "https",
+						Git: &RepoType{
 							Configs:    Repository{URL: "https://github.com/customer/repo.git"},
 							Components: Repository{URL: "https://github.com/managed/repo.git", TargetRevision: "release"},
 						},
@@ -102,10 +103,10 @@ func TestApplyDefaults_RepositoryTargetRevision(t *testing.T) {
 	applyDefaults(cfg)
 
 	argocd := cfg.Clusters[0].ArgoCD
-	https := argocd.Repo.HTTPS
+	git := cfg.Clusters[0].ArgoCD.Repo.Git
 	assert.Equal(t, ArgoCDSelfManagedEnabled, argocd.SelfManaged, "empty SelfManaged should default to enabled")
-	assert.Equal(t, "main", https.Configs.TargetRevision, "empty TargetRevision should default to main")
-	assert.Equal(t, "release", https.Components.TargetRevision, "explicit TargetRevision should not be overwritten")
+	assert.Equal(t, "main", git.Configs.TargetRevision, "empty TargetRevision should default to main")
+	assert.Equal(t, "release", git.Components.TargetRevision, "explicit TargetRevision should not be overwritten")
 }
 
 func TestApplyDefaults_MultipleSliceElements(t *testing.T) {

--- a/src/internal/config/factory.go
+++ b/src/internal/config/factory.go
@@ -10,7 +10,7 @@ import (
 
 func NewClusterFromEnvWithCatalog(e *envconfig.EnvMap, catalogOptions catalog.LoadOptions) (Cluster, error) {
 	effectiveCatalogOptions := clusterCatalogLoadOptions(catalogOptions)
-
+	gitRepoURL := e.GitRepositoryURL()
 	services, err := createServicesFromCatalogWithOptions(effectiveCatalogOptions, "")
 	if err != nil {
 		return Cluster{}, fmt.Errorf("create services from catalog: %w", err)
@@ -19,13 +19,14 @@ func NewClusterFromEnvWithCatalog(e *envconfig.EnvMap, catalogOptions catalog.Lo
 	argoCD := ArgoCD{
 		SelfManaged: ArgoCDSelfManagedEnabled,
 		Repo: RepoProto{
-			HTTPS: &RepoType{
+			AuthMode: e.GitAuthMode(),
+			Git: &RepoType{
 				Configs: Repository{
-					URL:            e.ArgocdGitHttpsUrl,
+					URL:            gitRepoURL,
 					TargetRevision: "main",
 				},
 				Components: Repository{
-					URL:            e.ArgocdGitHttpsUrl,
+					URL:            gitRepoURL,
 					TargetRevision: "main",
 				},
 			},
@@ -132,7 +133,8 @@ func CreateSpokeScaffolding(name string, catalogOptions catalog.LoadOptions) Clu
 		ArgoCD: ArgoCD{
 			SelfManaged: ArgoCDSelfManagedEnabled,
 			Repo: RepoProto{
-				HTTPS: &RepoType{
+				AuthMode: envconfig.GitAuthModeHTTPS,
+				Git: &RepoType{
 					Configs:    Repository{URL: "https://git.example.com/platform/repo.git", TargetRevision: "main"},
 					Components: Repository{URL: "https://git.example.com/platform/repo.git", TargetRevision: "main"},
 				},

--- a/src/internal/config/factory_test.go
+++ b/src/internal/config/factory_test.go
@@ -57,7 +57,8 @@ func TestNewClusterFromEnv(t *testing.T) {
 		ArgoCD: ArgoCD{
 			SelfManaged: ArgoCDSelfManagedEnabled,
 			Repo: RepoProto{
-				HTTPS: &RepoType{
+				AuthMode: envconfig.GitAuthModeHTTPS,
+				Git: &RepoType{
 					Configs: Repository{
 						URL:            "https://github.com/org/repo.git",
 						TargetRevision: "main",

--- a/src/internal/config/migrations/migrations.go
+++ b/src/internal/config/migrations/migrations.go
@@ -15,6 +15,7 @@ const (
 	ConfigVersionV1Alpha2 = "v1alpha2"
 	ConfigVersionV1Alpha3 = "v1alpha3"
 	ConfigVersionV1Alpha4 = "v1alpha4"
+	ConfigVersionV1Alpha5 = "v1alpha5"
 )
 
 // Apply runs all registered schema and repository layout migrations.
@@ -48,6 +49,13 @@ func Apply(cwd string, config map[string]any) (bool, error) {
 		migrated = true
 	}
 
+	if isV1Alpha4Config(config) {
+		if err := migrateV1Alpha4Config(config); err != nil {
+			return false, fmt.Errorf("migrate V1Alpha4 config: %w", err)
+		}
+		migrated = true
+	}
+
 	return migrated, nil
 }
 
@@ -69,6 +77,11 @@ func isV1Alpha2Config(raw map[string]any) bool {
 func isV1Alpha3Config(raw map[string]any) bool {
 	version, hasVersion := raw["version"]
 	return version == ConfigVersionV1Alpha3 && hasVersion
+}
+
+func isV1Alpha4Config(raw map[string]any) bool {
+	version, hasVersion := raw["version"]
+	return version == ConfigVersionV1Alpha4 && hasVersion
 }
 
 func clusterLabel(cluster map[string]any, clusterIndex int) string {

--- a/src/internal/config/migrations/migrations_test.go
+++ b/src/internal/config/migrations/migrations_test.go
@@ -38,6 +38,60 @@ func TestMigrateV1Alpha2FilesCleansUpEmptyLegacyCategoryDirs(t *testing.T) {
 	assert.FileExists(t, filepath.Join(otherTerraformSource, "keep.tf"))
 }
 
+func TestMigrateV1Alpha4ConfigRenamesRepo(t *testing.T) {
+	config := map[string]any{
+		"version": ConfigVersionV1Alpha4,
+		"clusters": []any{
+			map[string]any{
+				"name": "test-cluster",
+				"argocd": map[string]any{
+					"repo": map[string]any{
+						"oci": map[string]any{
+							"configs": map[string]any{"url": "ghcr.io/example/configs"},
+						},
+						"https": map[string]any{
+							"configs":    map[string]any{"url": "https://github.com/example/configs.git"},
+							"components": map[string]any{"url": "https://github.com/example/components.git"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	require.NoError(t, migrateV1Alpha4Config(config))
+
+	assert.Equal(t, ConfigVersionV1Alpha5, config["version"])
+
+	cluster := config["clusters"].([]any)[0].(map[string]any)
+	repo := cluster["argocd"].(map[string]any)["repo"].(map[string]any)
+	assert.Contains(t, repo, "git")
+	assert.NotContains(t, repo, "https")
+	assert.Contains(t, repo["git"].(map[string]any), "configs")
+	assert.Contains(t, repo, "oci")
+}
+
+func TestMigrateV1Alpha4ConfigRejectsConflictingKeys(t *testing.T) {
+	config := map[string]any{
+		"version": ConfigVersionV1Alpha4,
+		"clusters": []any{
+			map[string]any{
+				"name": "test-cluster",
+				"argocd": map[string]any{
+					"repo": map[string]any{
+						"https": map[string]any{"configs": map[string]any{}},
+						"git":   map[string]any{"configs": map[string]any{}},
+					},
+				},
+			},
+		},
+	}
+
+	err := migrateV1Alpha4Config(config)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "both legacy https and git")
+}
+
 func TestMigrateV1Alpha2ConfigMigratesReposAndCatalogDirs(t *testing.T) {
 	tempDir := t.TempDir()
 

--- a/src/internal/config/migrations/v1alpha4.go
+++ b/src/internal/config/migrations/v1alpha4.go
@@ -1,0 +1,63 @@
+package migrations
+
+import (
+	"fmt"
+
+	"github.com/rs/zerolog/log"
+)
+
+// migrateV1Alpha4Config migrates configurations with version ConfigVersionV1Alpha4 to the ConfigVersionV1Alpha5 schema format.
+// It renames argocd.repo.https to argocd.repo.git.
+func migrateV1Alpha4Config(config map[string]any) error {
+	log.Info().Msg("migrating config from v1alpha4 format to v1alpha5")
+	config["version"] = ConfigVersionV1Alpha5
+
+	clusters, ok := config["clusters"].([]any)
+	if !ok {
+		return nil
+	}
+
+	for i, clusterRaw := range clusters {
+		cluster, ok := clusterRaw.(map[string]any)
+		if !ok {
+			continue
+		}
+		if err := migrateRepoHTTPSKey(cluster, i); err != nil {
+			return fmt.Errorf("cannot migrate cluster number %d: %w", i, err)
+		}
+	}
+
+	return nil
+}
+
+func migrateRepoHTTPSKey(cluster map[string]any, clusterIndex int) error {
+	argocdRaw, ok := cluster["argocd"]
+	if !ok || argocdRaw == nil {
+		return nil
+	}
+	argocd, ok := argocdRaw.(map[string]any)
+	if !ok {
+		return fmt.Errorf("%s.argocd must be an object", clusterLabel(cluster, clusterIndex))
+	}
+
+	repoRaw, ok := argocd["repo"]
+	if !ok || repoRaw == nil {
+		return nil
+	}
+	repo, ok := repoRaw.(map[string]any)
+	if !ok {
+		return fmt.Errorf("%s.argocd.repo must be an object", clusterLabel(cluster, clusterIndex))
+	}
+
+	httpsRepo, hasHTTPS := repo["https"]
+	if !hasHTTPS {
+		return nil
+	}
+	if _, hasGit := repo["git"]; hasGit {
+		return fmt.Errorf("%s.argocd.repo has both legacy https and git repositories", clusterLabel(cluster, clusterIndex))
+	}
+
+	repo["git"] = httpsRepo
+	delete(repo, "https")
+	return nil
+}

--- a/src/internal/config/store.go
+++ b/src/internal/config/store.go
@@ -155,11 +155,27 @@ func generateSchemaWithCatalog(cat catalog.Catalog) (map[string]any, error) {
 	}
 	ensureServiceConfigDefinition(schemaDoc)
 	allowDisabledTerraformSchema(schemaDoc)
+	requireRepositorySchema(schemaDoc)
 	if err := composeServiceSchema(schemaDoc, cat); err != nil {
 		return nil, fmt.Errorf("compose service schema: %w", err)
 	}
 
 	return schemaDoc, nil
+}
+
+func requireRepositorySchema(schemaDoc map[string]any) {
+	defs, ok := schemaDoc["$defs"].(map[string]any)
+	if !ok {
+		return
+	}
+	repo, ok := defs["RepoProto"].(map[string]any)
+	if !ok {
+		return
+	}
+	repo["anyOf"] = []any{
+		map[string]any{"required": []any{"git"}},
+		map[string]any{"required": []any{"oci"}},
+	}
 }
 
 func allowDisabledTerraformSchema(schemaDoc map[string]any) {
@@ -368,7 +384,7 @@ func (cs *ConfigStore) GetFilepath() string {
 // SaveToFile saves the configuration to a YAML file
 func (cs *ConfigStore) SaveToFile() error {
 	if strings.TrimSpace(cs.config.Version) == "" {
-		cs.config.Version = ConfigVersionV1Alpha4
+		cs.config.Version = ConfigVersionV1Alpha5
 	}
 
 	// Ensure directory exists

--- a/src/internal/config/store_test.go
+++ b/src/internal/config/store_test.go
@@ -19,7 +19,7 @@ import (
 // Helper function to create a valid test config
 func newValidTestConfig() *Config {
 	return &Config{
-		Version:          ConfigVersionV1Alpha4,
+		Version:          ConfigVersionV1Alpha5,
 		BootstrapCatalog: testBootstrapCatalogPtr(),
 		Clusters: []Cluster{
 			{
@@ -42,7 +42,8 @@ func newValidTestConfig() *Config {
 				ArgoCD: ArgoCD{
 					SelfManaged: ArgoCDSelfManagedEnabled,
 					Repo: RepoProto{
-						HTTPS: &RepoType{
+						AuthMode: "https",
+						Git: &RepoType{
 							Configs: Repository{
 								URL:            "https://github.com/example/configs.git",
 								TargetRevision: "main",

--- a/src/internal/config/types.go
+++ b/src/internal/config/types.go
@@ -11,6 +11,7 @@ const (
 	ConfigVersionV1Alpha2 = "v1alpha2"
 	ConfigVersionV1Alpha3 = "v1alpha3"
 	ConfigVersionV1Alpha4 = "v1alpha4"
+	ConfigVersionV1Alpha5 = "v1alpha5"
 )
 
 const (
@@ -44,7 +45,7 @@ func SupportedTerraformProviders() []TerraformProvider {
 
 // Config is the root of the configuration structure.
 type Config struct {
-	Version          string    `json:"version,omitempty" yaml:"version,omitempty" jsonschema:"title=Config Version,description=The schema version of this config file.,enum=v1alpha4,default=v1alpha4"`
+	Version          string    `json:"version,omitempty" yaml:"version,omitempty" jsonschema:"title=Config Version,description=The schema version of this config file.,enum=v1alpha5,default=v1alpha5"`
 	BootstrapCatalog *string   `json:"bootstrapCatalog,omitempty" yaml:"bootstrapCatalog,omitempty" jsonschema:"title=Bootstrap Catalog,description=The global bootstrap catalog to use."`
 	Clusters         []Cluster `json:"clusters" yaml:"clusters" jsonschema:"title=Clusters,description=A list of cluster configurations."`
 }
@@ -94,9 +95,10 @@ type ArgoCD struct {
 }
 
 type RepoProto struct {
-	_     struct{}  `jsonschema:"minProperties=1,additionalProperties=false"`
-	HTTPS *RepoType `json:"https,omitempty" yaml:"https,omitempty" jsonschema:"title=Https Repository"`
-	OCI   *RepoType `json:"oci,omitempty" yaml:"oci,omitempty" jsonschema:"title=Oci Repository"`
+	_        struct{}  `jsonschema:"minProperties=1,additionalProperties=false"`
+	AuthMode string    `json:"authMode,omitempty" yaml:"authMode,omitempty" jsonschema:"title=Git Auth Mode,description=Authentication mode kubara uses for the initial Argo CD Git repository secret.,enum=https,enum=ssh,enum=github-app,default=https"`
+	Git      *RepoType `json:"git,omitempty" yaml:"git,omitempty" jsonschema:"title=Git Repository"`
+	OCI      *RepoType `json:"oci,omitempty" yaml:"oci,omitempty" jsonschema:"title=Oci Repository"`
 }
 
 type RepoType struct {
@@ -105,7 +107,7 @@ type RepoType struct {
 }
 
 type Repository struct {
-	URL            string `json:"url" yaml:"url" jsonschema:"required,title=Repository URL,description=The HTTPS URL of the Git repository.,format=uri"`
+	URL            string `json:"url" yaml:"url" jsonschema:"required,title=Repository URL,description=The Git repository URL used by Argo CD. Use an HTTP(S) URL for https/github-app auth modes or an SSH URL for ssh auth mode.,minLength=1"`
 	TargetRevision string `json:"targetRevision" yaml:"targetRevision" jsonschema:"title=Target Revision,description=The Git branch or tag to track.,minLength=1,default=main"`
 }
 

--- a/src/internal/envconfig/env.go
+++ b/src/internal/envconfig/env.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"sort"
 	"strings"
 
 	"github.com/kubara-io/kubara/internal/utils"
@@ -16,6 +17,13 @@ type ErrorEnvMap struct {
 
 var ErrEnvsNotSet = errors.New("EnvVars have not been set")
 var ErrDefaultIsSet = errors.New("EnvVars are set to default value")
+var ErrInvalidEnvValue = errors.New("EnvVars contain invalid value")
+
+const (
+	GitAuthModeHTTPS     = "https"
+	GitAuthModeSSH       = "ssh"
+	GitAuthModeGitHubApp = "github-app"
+)
 
 func (e *ErrorEnvMap) Error() string {
 	return fmt.Sprintf("Error: %s", e.Message)
@@ -27,32 +35,42 @@ func (e *ErrorEnvMap) Unwrap() error {
 
 // EnvMap holds the expected variables
 type EnvMap struct {
-	_                           struct{} `doc:"# ✅ These values MUST be known BEFORE running Terraform."`
-	_                           struct{} `doc:"# 🔁 Everything in <angle brackets> MUST be replaced."`
-	_                           struct{} `doc:"# 💡 Values without <> are optional and can be left as-is if not needed (e.g. no private image registry)."`
-	_                           struct{} `doc:"#    It will still create a secret, but it won't be valid."`
-	_                           struct{} `doc:"\n# Project related values"`
-	ProjectName                 string   `default:"<...>" koanf:"PROJECT_NAME"`
-	ProjectStage                string   `default:"<...>" koanf:"PROJECT_STAGE"`
-	_                           struct{} `doc:"\n# Argo CD related values"`
-	_                           struct{} `doc:"# Initial Admin Account Password for Argo CD."`
-	ArgocdWizardAccountPassword string   `default:"<...>" koanf:"ARGOCD_WIZARD_ACCOUNT_PASSWORD"`
-	_                           struct{} `doc:"\n# Git repository values"`
-	_                           struct{} `doc:"# The HTTPS URL of the git repository that Argo CD will use to pull the kubara generated manifests from."`
-	ArgocdGitHttpsUrl           string   `default:"<...>" koanf:"ARGOCD_GIT_HTTPS_URL"`
-	_                           struct{} `doc:"\n# Optional: Git repository credentials for Argo to pull your kubara manifests from."`
-	_                           struct{} `doc:"# Necessary if your repository isn't public."`
-	ArgocdGitUsername           string   `default:"" koanf:"ARGOCD_GIT_USERNAME" optional:"true"`
-	ArgocdGitPatOrPassword      string   `default:"" koanf:"ARGOCD_GIT_PAT_OR_PASSWORD" optional:"true"`
-	_                           struct{} `doc:"\n# Optional: Helm repository values (leave empty to disable)."`
-	_                           struct{} `doc:"# ARGOCD_HELM_REPO_URL supports: https://... (classic Helm repo) or registry.example.com/... (OCI Helm registry)."`
-	_                           struct{} `doc:"# Compatibility: oci://... is also accepted and normalized automatically."`
-	ArgocdHelmRepoUsername      string   `default:"" koanf:"ARGOCD_HELM_REPO_USERNAME" optional:"true"`
-	ArgocdHelmRepoPassword      string   `default:"" koanf:"ARGOCD_HELM_REPO_PASSWORD" optional:"true"`
-	ArgocdHelmRepoUrl           string   `default:"" koanf:"ARGOCD_HELM_REPO_URL" optional:"true"`
-	_                           struct{} `doc:"\n# Optional: Container Registry Config"`
-	_                           struct{} `doc:"# the variable must be base64 encoded - how to: https://docs.kubara.io/latest-stable/9_reference/faq/#how-do-i-create-a-dockerconfigjson-for-env-file"`
-	DockerconfigBase64          string   `default:"" koanf:"DOCKERCONFIG_BASE64" optional:"true"`
+	_                                   struct{} `doc:"# ✅ These values MUST be known BEFORE running Terraform."`
+	_                                   struct{} `doc:"# 🔁 Everything in <angle brackets> MUST be replaced."`
+	_                                   struct{} `doc:"# 💡 Values without <> are optional and can be left as-is if not needed (e.g. no private image registry)."`
+	_                                   struct{} `doc:"#    It will still create a secret, but it won't be valid."`
+	_                                   struct{} `doc:"\n# Project related values"`
+	ProjectName                         string   `default:"<...>" koanf:"PROJECT_NAME"`
+	ProjectStage                        string   `default:"<...>" koanf:"PROJECT_STAGE"`
+	_                                   struct{} `doc:"\n# Argo CD related values"`
+	_                                   struct{} `doc:"# Initial Admin Account Password for Argo CD."`
+	ArgocdWizardAccountPassword         string   `default:"<...>" koanf:"ARGOCD_WIZARD_ACCOUNT_PASSWORD"`
+	_                                   struct{} `doc:"\n# Git repository values"`
+	_                                   struct{} `doc:"# ARGOCD_GIT_AUTH_MODE supports: https, ssh, github-app. Empty keeps the legacy https mode."`
+	ArgocdGitAuthMode                   string   `default:"https" koanf:"ARGOCD_GIT_AUTH_MODE" optional:"true"`
+	_                                   struct{} `doc:"# The URL of the git repository that Argo CD will use to pull the kubara generated manifests from."`
+	_                                   struct{} `doc:"# Prefer ARGOCD_GIT_URL for new setups. ARGOCD_GIT_HTTPS_URL is kept for backward compatibility with existing .env files."`
+	ArgocdGitUrl                        string   `default:"" koanf:"ARGOCD_GIT_URL" optional:"true"`
+	ArgocdGitHttpsUrl                   string   `default:"" koanf:"ARGOCD_GIT_HTTPS_URL" optional:"true"`
+	_                                   struct{} `doc:"\n# https mode: username + password/PAT. Necessary if your repository isn't public."`
+	ArgocdGitUsername                   string   `default:"" koanf:"ARGOCD_GIT_USERNAME" optional:"true"`
+	ArgocdGitPatOrPassword              string   `default:"" koanf:"ARGOCD_GIT_PAT_OR_PASSWORD" optional:"true"`
+	_                                   struct{} `doc:"\n# ssh mode: ARGOCD_GIT_SSH_PRIVATE_KEY, and requires trusted SSH host keys in Argo CD known_hosts."`
+	ArgocdGitSshPrivateKey              string   `default:"" koanf:"ARGOCD_GIT_SSH_PRIVATE_KEY" optional:"true"`
+	_                                   struct{} `doc:"\n# github-app mode: GitHub App IDs and private key. Enterprise base URL is optional."`
+	ArgocdGitGithubAppID                string   `default:"" koanf:"ARGOCD_GIT_GITHUB_APP_ID" optional:"true"`
+	ArgocdGitGithubAppInstallationID    string   `default:"" koanf:"ARGOCD_GIT_GITHUB_APP_INSTALLATION_ID" optional:"true"`
+	ArgocdGitGithubAppPrivateKey        string   `default:"" koanf:"ARGOCD_GIT_GITHUB_APP_PRIVATE_KEY" optional:"true"`
+	ArgocdGitGithubAppEnterpriseBaseUrl string   `default:"" koanf:"ARGOCD_GIT_GITHUB_APP_ENTERPRISE_BASE_URL" optional:"true"`
+	_                                   struct{} `doc:"\n# Optional: Helm repository values (leave empty to disable)."`
+	_                                   struct{} `doc:"# ARGOCD_HELM_REPO_URL supports: https://... (classic Helm repo) or registry.example.com/... (OCI Helm registry)."`
+	_                                   struct{} `doc:"# Compatibility: oci://... is also accepted and normalized automatically."`
+	ArgocdHelmRepoUsername              string   `default:"" koanf:"ARGOCD_HELM_REPO_USERNAME" optional:"true"`
+	ArgocdHelmRepoPassword              string   `default:"" koanf:"ARGOCD_HELM_REPO_PASSWORD" optional:"true"`
+	ArgocdHelmRepoUrl                   string   `default:"" koanf:"ARGOCD_HELM_REPO_URL" optional:"true"`
+	_                                   struct{} `doc:"\n# Optional: Container Registry Config"`
+	_                                   struct{} `doc:"# the variable must be base64 encoded - how to: https://docs.kubara.io/latest-stable/9_reference/faq/#how-do-i-create-a-dockerconfigjson-for-env-file"`
+	DockerconfigBase64                  string   `default:"" koanf:"DOCKERCONFIG_BASE64" optional:"true"`
 }
 
 // Validate performs basic validation on the envMap.
@@ -98,7 +116,97 @@ func (em *EnvMap) Validate() error {
 		return defaultIsSetE
 	}
 
+	if err := em.validateGitAuth(); err != nil {
+		return err
+	}
+
 	return nil
+}
+
+func (em *EnvMap) validateGitAuth() error {
+	switch em.GitAuthMode() {
+	case GitAuthModeHTTPS:
+		if err := validateRequiredEnvValues(map[string]string{
+			"ARGOCD_GIT_URL or ARGOCD_GIT_HTTPS_URL": em.GitRepositoryURL(),
+		}); err != nil {
+			return err
+		}
+		usernameConfigured := IsConfiguredEnvValue(em.ArgocdGitUsername)
+		passwordConfigured := IsConfiguredEnvValue(em.ArgocdGitPatOrPassword)
+		if usernameConfigured != passwordConfigured {
+			return &ErrorEnvMap{
+				Message: "ARGOCD_GIT_USERNAME and ARGOCD_GIT_PAT_OR_PASSWORD must either both be set for a private repository or both be omitted for a public repository",
+				Err:     ErrInvalidEnvValue,
+			}
+		}
+		return validateHTTPGitURL(em.GitRepositoryURL(), GitAuthModeHTTPS)
+	case GitAuthModeSSH:
+		if err := validateRequiredEnvValues(map[string]string{
+			"ARGOCD_GIT_URL":             em.ArgocdGitUrl,
+			"ARGOCD_GIT_SSH_PRIVATE_KEY": em.ArgocdGitSshPrivateKey,
+		}); err != nil {
+			return err
+		}
+		return validateSSHGitURL(em.ArgocdGitUrl)
+	case GitAuthModeGitHubApp:
+		if err := validateRequiredEnvValues(map[string]string{
+			"ARGOCD_GIT_URL":                        em.ArgocdGitUrl,
+			"ARGOCD_GIT_GITHUB_APP_ID":              em.ArgocdGitGithubAppID,
+			"ARGOCD_GIT_GITHUB_APP_INSTALLATION_ID": em.ArgocdGitGithubAppInstallationID,
+			"ARGOCD_GIT_GITHUB_APP_PRIVATE_KEY":     em.ArgocdGitGithubAppPrivateKey,
+		}); err != nil {
+			return err
+		}
+		return validateHTTPGitURL(em.ArgocdGitUrl, GitAuthModeGitHubApp)
+	default:
+		return &ErrorEnvMap{
+			Message: fmt.Sprintf("Invalid ARGOCD_GIT_AUTH_MODE %q. Supported values: %s, %s, %s", em.ArgocdGitAuthMode, GitAuthModeHTTPS, GitAuthModeSSH, GitAuthModeGitHubApp),
+			Err:     ErrInvalidEnvValue,
+		}
+	}
+}
+
+func validateRequiredEnvValues(values map[string]string) error {
+	var missing []string
+	for name, value := range values {
+		if !IsConfiguredEnvValue(value) {
+			missing = append(missing, name)
+		}
+	}
+	if len(missing) == 0 {
+		return nil
+	}
+	sort.Strings(missing)
+
+	return &ErrorEnvMap{
+		Message: fmt.Sprintf("Vars not set: %+v", missing),
+		Err:     ErrEnvsNotSet,
+	}
+}
+
+func validateSSHGitURL(value string) error {
+	trimmed := strings.TrimSpace(value)
+	lower := strings.ToLower(trimmed)
+	if strings.HasPrefix(lower, "ssh://") || (!strings.HasPrefix(lower, "http://") && !strings.HasPrefix(lower, "https://") && strings.Contains(trimmed, "@")) {
+		return nil
+	}
+
+	return &ErrorEnvMap{
+		Message: "ARGOCD_GIT_AUTH_MODE=ssh requires ARGOCD_GIT_URL to be an SSH repository URL such as git@github.com:org/repo.git or ssh://git@example.com/org/repo.git",
+		Err:     ErrInvalidEnvValue,
+	}
+}
+
+func validateHTTPGitURL(value, mode string) error {
+	lower := strings.ToLower(strings.TrimSpace(value))
+	if strings.HasPrefix(lower, "https://") || strings.HasPrefix(lower, "http://") {
+		return nil
+	}
+
+	return &ErrorEnvMap{
+		Message: fmt.Sprintf("ARGOCD_GIT_AUTH_MODE=%s requires ARGOCD_GIT_URL to be an HTTP(S) repository URL", mode),
+		Err:     ErrInvalidEnvValue,
+	}
 }
 
 // setDefaults sets default values for empty fields based on the struct tag "default"
@@ -124,6 +232,25 @@ func (em *EnvMap) setDefaults() {
 func IsConfiguredEnvValue(v string) bool {
 	trimmed := strings.TrimSpace(v)
 	return trimmed != "" && trimmed != "<...>"
+}
+
+// GitAuthMode returns the configured Argo CD Git auth mode.
+// Empty values keep the legacy HTTPS username + PAT/password behavior.
+func (em *EnvMap) GitAuthMode() string {
+	mode := strings.ToLower(strings.TrimSpace(em.ArgocdGitAuthMode))
+	if mode == "" || mode == "<...>" {
+		return GitAuthModeHTTPS
+	}
+	return mode
+}
+
+// GitRepositoryURL returns the preferred repository URL for Argo CD.
+// ARGOCD_GIT_HTTPS_URL is a legacy fallback for existing .env files.
+func (em *EnvMap) GitRepositoryURL() string {
+	if IsConfiguredEnvValue(em.ArgocdGitUrl) {
+		return strings.TrimSpace(em.ArgocdGitUrl)
+	}
+	return strings.TrimSpace(em.ArgocdGitHttpsUrl)
 }
 
 // NormalizeHelmRepoURL normalizes Helm repository inputs for ArgoCD.

--- a/src/internal/envconfig/env_test.go
+++ b/src/internal/envconfig/env_test.go
@@ -219,7 +219,9 @@ func TestEnvMap_setDefaults_AllFields(t *testing.T) {
 		assert.Equal(t, "", em.ArgocdHelmRepoUsername)
 		assert.Equal(t, "", em.ArgocdHelmRepoPassword)
 		assert.Equal(t, "", em.ArgocdHelmRepoUrl)
-		assert.Equal(t, "<...>", em.ArgocdGitHttpsUrl)
+		assert.Equal(t, "https", em.ArgocdGitAuthMode)
+		assert.Equal(t, "", em.ArgocdGitUrl)
+		assert.Equal(t, "", em.ArgocdGitHttpsUrl)
 		assert.Equal(t, "", em.ArgocdGitPatOrPassword)
 		assert.Equal(t, "", em.ArgocdGitUsername)
 	})
@@ -263,7 +265,7 @@ func TestEnvMap_Validate_ErrorMessages(t *testing.T) {
 		var envMapErr *ErrorEnvMap
 		require.True(t, errors.As(err, &envMapErr))
 		assert.Contains(t, envMapErr.Message, "Vars not set:")
-		assert.Contains(t, envMapErr.Message, "ARGOCD_GIT_HTTPS_URL")
+		assert.Contains(t, envMapErr.Message, "ARGOCD_WIZARD_ACCOUNT_PASSWORD")
 	})
 
 	t.Run("Error message contains field names for default values", func(t *testing.T) {
@@ -285,6 +287,150 @@ func TestEnvMap_Validate_ErrorMessages(t *testing.T) {
 		assert.Contains(t, envMapErr.Message, "Vars are set to default:")
 		assert.Contains(t, envMapErr.Message, "PROJECT_NAME")
 	})
+}
+
+func TestEnvMap_GitAuthMode(t *testing.T) {
+	tests := []struct {
+		name string
+		mode string
+		want string
+	}{
+		{name: "empty defaults to https", mode: "", want: GitAuthModeHTTPS},
+		{name: "legacy placeholder defaults to https", mode: "<...>", want: GitAuthModeHTTPS},
+		{name: "uppercase is normalized", mode: "SSH", want: GitAuthModeSSH},
+		{name: "github-app is preserved", mode: "github-app", want: GitAuthModeGitHubApp},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			em := &EnvMap{ArgocdGitAuthMode: tt.mode}
+			assert.Equal(t, tt.want, em.GitAuthMode())
+		})
+	}
+}
+
+func TestEnvMap_GitRepositoryURL_PrefersGitURL(t *testing.T) {
+	em := &EnvMap{ArgocdGitUrl: "https://new.example.com/repo.git", ArgocdGitHttpsUrl: "https://legacy.example.com/repo.git"}
+	assert.Equal(t, "https://new.example.com/repo.git", em.GitRepositoryURL())
+
+	legacy := &EnvMap{ArgocdGitHttpsUrl: "https://legacy.example.com/repo.git"}
+	assert.Equal(t, "https://legacy.example.com/repo.git", legacy.GitRepositoryURL())
+}
+
+func TestEnvMap_ValidateGitAuth(t *testing.T) {
+	base := func() *EnvMap {
+		return &EnvMap{
+			ProjectName:                 "test-project",
+			ProjectStage:                "dev",
+			ArgocdWizardAccountPassword: "password123",
+		}
+	}
+
+	tests := []struct {
+		name    string
+		mutate  func(*EnvMap)
+		wantErr error
+	}{
+		{
+			name: "https without credentials is allowed (public repo)",
+			mutate: func(em *EnvMap) {
+				em.ArgocdGitAuthMode = "https"
+				em.ArgocdGitHttpsUrl = "https://github.com/example/repo.git"
+			},
+		},
+		{
+			name: "https with username and PAT is allowed (private repo)",
+			mutate: func(em *EnvMap) {
+				em.ArgocdGitAuthMode = "https"
+				em.ArgocdGitHttpsUrl = "https://github.com/example/repo.git"
+				em.ArgocdGitUsername = "git"
+				em.ArgocdGitPatOrPassword = "token"
+			},
+		},
+		{
+			name: "https with only username fails",
+			mutate: func(em *EnvMap) {
+				em.ArgocdGitAuthMode = "https"
+				em.ArgocdGitHttpsUrl = "https://github.com/example/repo.git"
+				em.ArgocdGitUsername = "git"
+			},
+			wantErr: ErrInvalidEnvValue,
+		},
+		{
+			name: "https with only PAT fails",
+			mutate: func(em *EnvMap) {
+				em.ArgocdGitAuthMode = "https"
+				em.ArgocdGitHttpsUrl = "https://github.com/example/repo.git"
+				em.ArgocdGitPatOrPassword = "token"
+			},
+			wantErr: ErrInvalidEnvValue,
+		},
+		{
+			name:    "https without any URL fails",
+			mutate:  func(em *EnvMap) { em.ArgocdGitAuthMode = "https" },
+			wantErr: ErrEnvsNotSet,
+		},
+		{
+			name:    "https with an ssh URL fails",
+			mutate:  func(em *EnvMap) { em.ArgocdGitAuthMode = "https"; em.ArgocdGitUrl = "git@github.com:example/repo.git" },
+			wantErr: ErrInvalidEnvValue,
+		},
+		{
+			name: "ssh with private key and ssh URL passes",
+			mutate: func(em *EnvMap) {
+				em.ArgocdGitAuthMode = "ssh"
+				em.ArgocdGitUrl = "git@github.com:example/repo.git"
+				em.ArgocdGitSshPrivateKey = "PRIVATE-KEY"
+			},
+		},
+		{
+			name: "ssh with non-ssh URL fails",
+			mutate: func(em *EnvMap) {
+				em.ArgocdGitAuthMode = "ssh"
+				em.ArgocdGitUrl = "https://github.com/example/repo.git"
+				em.ArgocdGitSshPrivateKey = "PRIVATE-KEY"
+			},
+			wantErr: ErrInvalidEnvValue,
+		},
+		{
+			name: "github-app with all fields passes",
+			mutate: func(em *EnvMap) {
+				em.ArgocdGitAuthMode = "github-app"
+				em.ArgocdGitUrl = "https://github.com/example/repo.git"
+				em.ArgocdGitGithubAppID = "123"
+				em.ArgocdGitGithubAppInstallationID = "456"
+				em.ArgocdGitGithubAppPrivateKey = "PRIVATE-KEY"
+			},
+		},
+		{
+			name: "github-app missing installation id fails",
+			mutate: func(em *EnvMap) {
+				em.ArgocdGitAuthMode = "github-app"
+				em.ArgocdGitUrl = "https://github.com/example/repo.git"
+				em.ArgocdGitGithubAppID = "123"
+				em.ArgocdGitGithubAppPrivateKey = "PRIVATE-KEY"
+			},
+			wantErr: ErrEnvsNotSet,
+		},
+		{
+			name:    "unknown auth mode fails",
+			mutate:  func(em *EnvMap) { em.ArgocdGitAuthMode = "totally-unknown" },
+			wantErr: ErrInvalidEnvValue,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			em := base()
+			tt.mutate(em)
+			err := em.Validate()
+			if tt.wantErr == nil {
+				assert.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.True(t, errors.Is(err, tt.wantErr), "expected %v, got %v", tt.wantErr, err)
+		})
+	}
 }
 
 func TestIsConfiguredEnvValue(t *testing.T) {

--- a/src/internal/envconfig/store_test.go
+++ b/src/internal/envconfig/store_test.go
@@ -238,7 +238,7 @@ func TestEnvStore_Validate(t *testing.T) {
 				ArgocdHelmRepoUsername:      "user",
 				ArgocdHelmRepoPassword:      "pass",
 				ArgocdHelmRepoUrl:           "url",
-				ArgocdGitHttpsUrl:           "url",
+				ArgocdGitHttpsUrl:           "https://github.com/example/repo.git",
 				ArgocdGitPatOrPassword:      "token",
 				ArgocdGitUsername:           "user",
 			},

--- a/src/internal/localmode/localmode.go
+++ b/src/internal/localmode/localmode.go
@@ -39,8 +39,8 @@ func PopulateInitEnv(env *envconfig.EnvMap) {
 	if !envconfig.IsConfiguredEnvValue(env.ProjectStage) {
 		env.ProjectStage = DefaultProjectStage
 	}
-	if !envconfig.IsConfiguredEnvValue(env.ArgocdGitHttpsUrl) {
-		env.ArgocdGitHttpsUrl = ExampleGitRepoURL
+	if !envconfig.IsConfiguredEnvValue(env.GitRepositoryURL()) {
+		env.ArgocdGitUrl = ExampleGitRepoURL
 	}
 	if !envconfig.IsConfiguredEnvValue(env.ArgocdWizardAccountPassword) {
 		env.ArgocdWizardAccountPassword = ExampleWizardPassword

--- a/src/internal/localmode/localmode_test.go
+++ b/src/internal/localmode/localmode_test.go
@@ -4,9 +4,30 @@ import (
 	"testing"
 
 	"github.com/kubara-io/kubara/internal/config"
+	"github.com/kubara-io/kubara/internal/envconfig"
 	"github.com/kubara-io/kubara/internal/service"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestPopulateInitEnvUsesGenericGitURLWithoutOverwritingLegacyConfig(t *testing.T) {
+	t.Run("sets the generic URL for a new local config", func(t *testing.T) {
+		env := &envconfig.EnvMap{}
+
+		PopulateInitEnv(env)
+
+		assert.Equal(t, ExampleGitRepoURL, env.ArgocdGitUrl)
+		assert.Empty(t, env.ArgocdGitHttpsUrl)
+	})
+
+	t.Run("preserves a configured legacy HTTPS URL", func(t *testing.T) {
+		env := &envconfig.EnvMap{ArgocdGitHttpsUrl: "https://example.com/legacy.git"}
+
+		PopulateInitEnv(env)
+
+		assert.Empty(t, env.ArgocdGitUrl)
+		assert.Equal(t, "https://example.com/legacy.git", env.GitRepositoryURL())
+	})
+}
 
 func TestApplyClusterProfileDisablesOAuth2ProxyForLocalMode(t *testing.T) {
 	cluster := &config.Cluster{

--- a/src/internal/workflow/orchestrator.go
+++ b/src/internal/workflow/orchestrator.go
@@ -17,9 +17,14 @@ func CreateOrUpdateCluster(cfg *config.Config, e *envconfig.EnvMap, catalogOptio
 			fmt.Printf("Found existing cluster '%s', updating fields...\n", clusterName)
 
 			// Apply the new values from the environment to the found cluster.
+			gitRepoURL := e.GitRepositoryURL()
 			cfg.Clusters[i].Stage = e.ProjectStage
-			cfg.Clusters[i].ArgoCD.Repo.HTTPS.Configs.URL = e.ArgocdGitHttpsUrl
-			cfg.Clusters[i].ArgoCD.Repo.HTTPS.Components.URL = e.ArgocdGitHttpsUrl
+			cfg.Clusters[i].ArgoCD.Repo.AuthMode = e.GitAuthMode()
+			if cfg.Clusters[i].ArgoCD.Repo.Git == nil {
+				cfg.Clusters[i].ArgoCD.Repo.Git = &config.RepoType{}
+			}
+			cfg.Clusters[i].ArgoCD.Repo.Git.Configs.URL = gitRepoURL
+			cfg.Clusters[i].ArgoCD.Repo.Git.Components.URL = gitRepoURL
 
 			if envconfig.IsConfiguredEnvValue(e.ArgocdHelmRepoUrl) {
 				helmRepoURL := envconfig.NormalizeHelmRepoURL(e.ArgocdHelmRepoUrl)

--- a/src/internal/workflow/orchestrator_test.go
+++ b/src/internal/workflow/orchestrator_test.go
@@ -43,7 +43,7 @@ func TestCreateOrUpdateCluster_UpdatesExistingClusterIncludingHelmRepo(t *testin
 				},
 				ArgoCD: config.ArgoCD{
 					Repo: config.RepoProto{
-						HTTPS: &config.RepoType{
+						Git: &config.RepoType{
 							Configs: config.Repository{
 								URL:            "https://github.com/old/repo.git",
 								TargetRevision: "main",
@@ -73,8 +73,8 @@ func TestCreateOrUpdateCluster_UpdatesExistingClusterIncludingHelmRepo(t *testin
 	assert.Equal(t, "dev", updated.Stage)
 	assert.Equal(t, "kubara-test-stage.example.com", updated.DNSName)
 	assert.Equal(t, "kubara-test-stage.example.com", updated.Terraform.DNS.Name)
-	assert.Equal(t, "https://github.com/new/repo.git", updated.ArgoCD.Repo.HTTPS.Components.URL)
-	assert.Equal(t, "https://github.com/new/repo.git", updated.ArgoCD.Repo.HTTPS.Configs.URL)
+	assert.Equal(t, "https://github.com/new/repo.git", updated.ArgoCD.Repo.Git.Components.URL)
+	assert.Equal(t, "https://github.com/new/repo.git", updated.ArgoCD.Repo.Git.Configs.URL)
 	require.NotNil(t, updated.ArgoCD.HelmRepo)
 	assert.Equal(t, "https://charts.example.com", updated.ArgoCD.HelmRepo.URL)
 }
@@ -89,7 +89,7 @@ func TestCreateOrUpdateCluster_UpdatesExistingClusterWithoutTerraform(t *testing
 				Terraform: nil,
 				ArgoCD: config.ArgoCD{
 					Repo: config.RepoProto{
-						HTTPS: &config.RepoType{
+						Git: &config.RepoType{
 							Configs: config.Repository{
 								URL:            "https://github.com/old/repo.git",
 								TargetRevision: "main",
@@ -118,8 +118,8 @@ func TestCreateOrUpdateCluster_UpdatesExistingClusterWithoutTerraform(t *testing
 	assert.Equal(t, "dev", updated.Stage)
 	assert.Equal(t, "kubara-test-stage.example.com", updated.DNSName)
 	assert.Nil(t, updated.Terraform)
-	assert.Equal(t, "https://github.com/new/repo.git", updated.ArgoCD.Repo.HTTPS.Components.URL)
-	assert.Equal(t, "https://github.com/new/repo.git", updated.ArgoCD.Repo.HTTPS.Configs.URL)
+	assert.Equal(t, "https://github.com/new/repo.git", updated.ArgoCD.Repo.Git.Components.URL)
+	assert.Equal(t, "https://github.com/new/repo.git", updated.ArgoCD.Repo.Git.Configs.URL)
 }
 
 func TestCreateOrUpdateCluster_CreatesNewClusterWithHelmRepo(t *testing.T) {
@@ -136,8 +136,8 @@ func TestCreateOrUpdateCluster_CreatesNewClusterWithHelmRepo(t *testing.T) {
 
 	require.Len(t, cfg.Clusters, 1)
 	cluster := cfg.Clusters[0]
-	assert.Equal(t, "https://github.com/new/repo.git", cluster.ArgoCD.Repo.HTTPS.Components.URL)
-	assert.Equal(t, "https://github.com/new/repo.git", cluster.ArgoCD.Repo.HTTPS.Configs.URL)
+	assert.Equal(t, "https://github.com/new/repo.git", cluster.ArgoCD.Repo.Git.Components.URL)
+	assert.Equal(t, "https://github.com/new/repo.git", cluster.ArgoCD.Repo.Git.Configs.URL)
 	require.NotNil(t, cluster.ArgoCD.HelmRepo)
 	assert.Equal(t, "https://charts.example.com", cluster.ArgoCD.HelmRepo.URL)
 }
@@ -156,7 +156,7 @@ func TestCreateOrUpdateCluster_DoesNotOverrideHelmRepoWhenEnvMissing(t *testing.
 				},
 				ArgoCD: config.ArgoCD{
 					Repo: config.RepoProto{
-						HTTPS: &config.RepoType{
+						Git: &config.RepoType{
 							Configs: config.Repository{
 								URL:            "https://github.com/old/repo.git",
 								TargetRevision: "main",


### PR DESCRIPTION
## 📝 Summary

Adds Argo CD Git authentication modes:

- supports `https`, `ssh`, and `github-app` through `ARGOCD_GIT_AUTH_MODE`
- adds `ARGOCD_GIT_URL` with legacy `ARGOCD_GIT_HTTPS_URL` fallback
- creates and validates mode-specific initial repository secrets
- moves Git config from `argocd.repo.https` to `argocd.repo.git`
- adds the `v1alpha4` → `v1alpha5` migration
- updates tests and documentation

## 🧩 Type of change
- [x] 🔧 CLI / Go code
- [x] 📝 Documentation
- [x] 🧪 Test or CI change
- [ ] ♻️ Refactor / cleanup

## ⚠️ Is this a breaking change?
- [ ] Yes, this change breaks existing functionality (explain in summary)

Existing configs and HTTPS `.env` files are migrated or supported automatically.

## 🧪 Testing
- [x] CI passed
- [ ] Manually tested (local/dev cluster)
- [x] Unit tested
- [ ] Not tested (explain why below)

Locally verified with tests, build, lint, documentation validation, and catalog-backed init/generate.

## 🔗 Additional Context / Related Issues / Tickets

Closes #246. Supersedes #388. Related to kubara-io/catalogs#6.

CI temporarily packages the merged catalog commit until matching releases are available.

## ✅ Checklist
- [x] Code compiles and passes all tests
- [x] Linting and style checks pass
- [x] Comments added for complex logic
- [x] Documentation updated (if applicable)