### PR TITLE
feat(bootstrap): add spoke credential onboarding

### DIFF
--- a/src/cmd/bootstrap.go
+++ b/src/cmd/bootstrap.go
@@ -29,6 +29,9 @@ type BootstrapFlags struct {
 	EnvPrefixFlag          string
 	DryRun                 bool
 	Timeout                time.Duration
+
+	InitialKubeconfig string
+	AgentNamespace    string
 }
 
 var deprecatedBootstrapCRDFlags = []string{
@@ -38,9 +41,10 @@ var deprecatedBootstrapCRDFlags = []string{
 
 func NewBootstrapFlags() *BootstrapFlags {
 	return &BootstrapFlags{
-		EnvFile:       ".env",
-		EnvPrefixFlag: "KUBARA_",
-		Timeout:       2 * time.Minute,
+		EnvFile:        ".env",
+		EnvPrefixFlag:  "KUBARA_",
+		Timeout:        2 * time.Minute,
+		AgentNamespace: "kubara",
 	}
 }
 
@@ -48,11 +52,12 @@ func NewBootstrapCmd() *cli.Command {
 	flags := NewBootstrapFlags()
 
 	cmd := &cli.Command{
-		Name:        "bootstrap",
-		Usage:       "Bootstrap Argo CD onto a cluster",
-		UsageText:   "kubara bootstrap CLUSTER_NAME [--local]",
+		Name:  "bootstrap",
+		Usage: "Bootstrap a hub or onboard a spoke cluster",
+		UsageText: `kubara bootstrap CLUSTER_NAME [--local]
+kubara bootstrap CLUSTER_NAME --initial-kubeconfig PATH [--namespace NAMESPACE]`,
 		ArgsUsage:   "CLUSTER_NAME",
-		Description: "Bootstraps Argo CD onto the specified cluster. The optional --local mode provisions an isolated local evaluation environment and is not intended for production use.",
+		Description: "Bootstraps Argo CD onto a hub cluster, or onboards a spoke cluster when --initial-kubeconfig is provided.",
 		Arguments: []cli.Argument{
 			&cli.StringArg{
 				Name:      "cluster-name",
@@ -62,19 +67,22 @@ func NewBootstrapCmd() *cli.Command {
 		Action: func(c context.Context, cmd *cli.Command) error {
 			printDeprecatedBootstrapCRDFlagNotice(cmd)
 
+			clusterName := cmd.StringArg("cluster-name")
+			if clusterName == "" {
+				return fmt.Errorf("missing argument %q", "cluster-name")
+			}
+
 			o, err := flags.ToOptions(cmd)
 			if err != nil {
 				return fmt.Errorf("convert flags to options: %w", err)
 			}
-			if cmd.StringArg("cluster-name") == "" {
-				return fmt.Errorf("missing argument %q", "cluster-name")
-			}
-			o.ClusterName = cmd.StringArg("cluster-name")
+
+			o.ClusterName = clusterName
 			return Run(c, o)
 		},
 	}
-	flags.AddFlags(cmd)
 
+	flags.AddFlags(cmd)
 	return cmd
 }
 
@@ -84,14 +92,115 @@ func (flags *BootstrapFlags) ToOptions(cmd *cli.Command) (*bootstrap.Options, er
 		return nil, fmt.Errorf("get working directory: %w", err)
 	}
 
+	kubeconfigPath := cmd.String("kubeconfig")
+	if !cmd.IsSet("kubeconfig") {
+		if envKubeconfig := os.Getenv("KUBECONFIG"); envKubeconfig != "" {
+			kubeconfigPath = envKubeconfig
+		}
+	}
+
+	kubeconf, err := utils.GetFullPath(kubeconfigPath, cwd)
+	if err != nil {
+		return nil, fmt.Errorf("get kubeconfig path: %w", err)
+	}
+
+	catalogOptions, err := catalogLoadOptionsFromCommand(cmd, "")
+	if err != nil {
+		return nil, fmt.Errorf("get catalog options: %w", err)
+	}
+
+	configFilePath, err := utils.GetFullPath(cmd.String("config-file"), cwd)
+	if err != nil {
+		return nil, fmt.Errorf("get config file path: %w", err)
+	}
+
+	cs := config.NewConfigStore(cwd, configFilePath, catalogOptions)
+	if err := cs.Load(); err != nil {
+		return nil, fmt.Errorf("load config: %w", err)
+	}
+
+	clusterName := cmd.StringArg("cluster-name")
+
+	var clusterConfig *config.Cluster
+	for i := range cs.GetConfig().Clusters {
+		if cs.GetConfig().Clusters[i].Name == clusterName {
+			clusterConfig = &cs.GetConfig().Clusters[i]
+			break
+		}
+	}
+
+	if clusterConfig == nil {
+		return nil, fmt.Errorf(
+			"cluster %q not found in config file %q",
+			clusterName,
+			configFilePath,
+		)
+	}
+
+	// Spoke onboarding is intentionally routed before the existing hub bootstrap
+	// environment/catalog preparation. The spoke path only needs the Kubara
+	// configuration, a Hub kubeconfig, and the initial Spoke kubeconfig.
+	if flags.InitialKubeconfig != "" {
+		if flags.Local {
+			return nil, fmt.Errorf(
+				"--local cannot be used with --initial-kubeconfig",
+			)
+		}
+
+		if flags.DryRun {
+			return nil, fmt.Errorf(
+				"--dry-run is not supported with --initial-kubeconfig",
+			)
+		}
+
+		if clusterConfig.Type != "spoke" {
+			return nil, fmt.Errorf(
+				"--initial-kubeconfig can only be used with a spoke cluster; cluster %q has type %q",
+				clusterConfig.Name,
+				clusterConfig.Type,
+			)
+		}
+
+		initialKubeconfig, err := utils.GetFullPath(
+			flags.InitialKubeconfig,
+			cwd,
+		)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"resolve initial kubeconfig path: %w",
+				err,
+			)
+		}
+
+		if _, err := os.Stat(initialKubeconfig); err != nil {
+			return nil, fmt.Errorf(
+				"initial kubeconfig %q is not accessible: %w",
+				initialKubeconfig,
+				err,
+			)
+		}
+
+		return &bootstrap.Options{
+			Kubeconfig:        kubeconf,
+			InitialKubeconfig: initialKubeconfig,
+			AgentNamespace:    flags.AgentNamespace,
+			ClusterConfig:     clusterConfig,
+			ClusterName:       clusterName,
+			Timeout:           flags.Timeout,
+			WorkDir:           cwd,
+			ConfigFilePath:    configFilePath,
+		}, nil
+	}
+
+	if cmd.IsSet("namespace") {
+		return nil, fmt.Errorf(
+			"--namespace can only be used together with --initial-kubeconfig",
+		)
+	}
+
 	envFilePath, err := utils.GetFullPath(cmd.String("env-file"), cwd)
 	if err != nil {
 		return nil, fmt.Errorf("get env file path: %w", err)
-	}
-
-	kubeconf, err := utils.GetFullPath(cmd.String("kubeconfig"), cwd)
-	if err != nil {
-		return nil, fmt.Errorf("get kubeconfig path: %w", err)
 	}
 
 	componentsAbsPath := flags.PlatformComponentsPath
@@ -112,35 +221,6 @@ func (flags *BootstrapFlags) ToOptions(cmd *cli.Command) (*bootstrap.Options, er
 		}
 	}
 
-	catalogOptions, err := catalogLoadOptionsFromCommand(cmd, "")
-	if err != nil {
-		return nil, fmt.Errorf("get catalog options: %w", err)
-	}
-
-	// Load config file and find cluster by name
-	configFilePath, err := utils.GetFullPath(cmd.String("config-file"), cwd)
-	if err != nil {
-		return nil, fmt.Errorf("get config file path: %w", err)
-	}
-
-	cs := config.NewConfigStore(cwd, configFilePath, catalogOptions)
-	if err := cs.Load(); err != nil {
-		return nil, fmt.Errorf("load config: %w", err)
-	}
-
-	// Find the cluster by name from the argument
-	clusterName := cmd.StringArg("cluster-name")
-	var clusterConfig *config.Cluster
-	for i := range cs.GetConfig().Clusters {
-		if cs.GetConfig().Clusters[i].Name == clusterName {
-			clusterConfig = &cs.GetConfig().Clusters[i]
-			break
-		}
-	}
-	if clusterConfig == nil {
-		return nil, fmt.Errorf("cluster %q not found in config file %q", clusterName, configFilePath)
-	}
-
 	es := envconfig.NewEnvStore(envFilePath, ".", flags.EnvPrefixFlag)
 	if err := es.Load(); err != nil {
 		return nil, fmt.Errorf("load env: %w", err)
@@ -151,28 +231,36 @@ func (flags *BootstrapFlags) ToOptions(cmd *cli.Command) (*bootstrap.Options, er
 		return nil, fmt.Errorf("prepare env: %w", err)
 	}
 
-	// Validate and normalize ClusterSecretStore path if provided
 	var cssAbsPath string
 	if flags.ClusterSecretStorePath != "" {
 		if !filepath.IsAbs(flags.ClusterSecretStorePath) {
 			cssAbsPath = filepath.Join(cwd, flags.ClusterSecretStorePath)
 			cssAbsPath, err = filepath.Abs(cssAbsPath)
 			if err != nil {
-				return nil, fmt.Errorf("getting absolute path for ClusterSecretStore file: %w", err)
+				return nil, fmt.Errorf(
+					"getting absolute path for ClusterSecretStore file: %w",
+					err,
+				)
 			}
 		} else {
 			cssAbsPath = flags.ClusterSecretStorePath
 		}
 
-		// Verify file exists
 		if _, err := os.Stat(cssAbsPath); err != nil {
-			return nil, fmt.Errorf("cluster secret store file not found: %w", err)
+			return nil, fmt.Errorf(
+				"cluster secret store file not found: %w",
+				err,
+			)
 		}
 	}
 
 	loadedCatalog, err := cs.GetCatalogForCluster(*clusterConfig)
 	if err != nil {
-		return nil, fmt.Errorf("load catalog for cluster %q: %w", clusterConfig.Name, err)
+		return nil, fmt.Errorf(
+			"load catalog for cluster %q: %w",
+			clusterConfig.Name,
+			err,
+		)
 	}
 
 	bootstrapCatalog := catalog.DefaultBootstrapCatalog
@@ -256,13 +344,34 @@ func (flags *BootstrapFlags) AddFlags(cmd *cli.Command) {
 			Usage:       "Timeout for kubernetes API calls (e.g. 10s, 1m)",
 			Destination: &flags.Timeout,
 		},
+		&cli.StringFlag{
+			Name:        "initial-kubeconfig",
+			Usage:       "Path to the initial kubeconfig used to onboard a spoke cluster",
+			Destination: &flags.InitialKubeconfig,
+			Config: cli.StringConfig{
+				TrimSpace: true,
+			},
+		},
+		&cli.StringFlag{
+			Name:        "namespace",
+			Value:       flags.AgentNamespace,
+			Usage:       "Namespace for the kubara-agent ServiceAccount on the spoke cluster",
+			Destination: &flags.AgentNamespace,
+			Config: cli.StringConfig{
+				TrimSpace: true,
+			},
+		},
 	}
 
 	cmd.Flags = append(cmd.Flags, bootstrapFlags...)
 }
 
 func Run(ctx context.Context, o *bootstrap.Options) error {
-	ctx, cancelSignal := signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
+	ctx, cancelSignal := signal.NotifyContext(
+		ctx,
+		os.Interrupt,
+		syscall.SIGTERM,
+	)
 	defer cancelSignal()
 
 	return bootstrap.Bootstrap(ctx, o)
@@ -271,19 +380,31 @@ func Run(ctx context.Context, o *bootstrap.Options) error {
 func printDeprecatedBootstrapCRDFlagNotice(cmd *cli.Command) {
 	for _, flagName := range deprecatedBootstrapCRDFlags {
 		if cmd.IsSet(flagName) {
-			log.Warn().Msgf("--%s is deprecated and ignored; CRDs are applied automatically during bootstrap.\n", flagName)
+			log.Warn().
+				Msgf(
+					"--%s is deprecated and ignored; CRDs are applied automatically during bootstrap.\n",
+					flagName,
+				)
 		}
 	}
 }
 
-func prepareBootstrapEnv(cluster *config.Cluster, envMap *envconfig.EnvMap, local bool) (*envconfig.EnvMap, error) {
+func prepareBootstrapEnv(
+	cluster *config.Cluster,
+	envMap *envconfig.EnvMap,
+	local bool,
+) (*envconfig.EnvMap, error) {
 	if err := envMap.Validate(); err != nil {
 		return nil, err
 	}
 
-	if (envconfig.IsConfiguredEnvValue(envMap.ArgocdGitUsername) && !envconfig.IsConfiguredEnvValue(envMap.ArgocdGitPatOrPassword)) ||
-		(!envconfig.IsConfiguredEnvValue(envMap.ArgocdGitUsername) && envconfig.IsConfiguredEnvValue(envMap.ArgocdGitPatOrPassword)) {
-		return nil, fmt.Errorf("if you are using a private repository you need to configure both ARGOCD_GIT_PAT_OR_PASSWORD and ARGOCD_GIT_USERNAME")
+	if (envconfig.IsConfiguredEnvValue(envMap.ArgocdGitUsername) &&
+		!envconfig.IsConfiguredEnvValue(envMap.ArgocdGitPatOrPassword)) ||
+		(!envconfig.IsConfiguredEnvValue(envMap.ArgocdGitUsername) &&
+			envconfig.IsConfiguredEnvValue(envMap.ArgocdGitPatOrPassword)) {
+		return nil, fmt.Errorf(
+			"if you are using a private repository you need to configure both ARGOCD_GIT_PAT_OR_PASSWORD and ARGOCD_GIT_USERNAME",
+		)
 	}
 
 	if !local {
@@ -291,9 +412,11 @@ func prepareBootstrapEnv(cluster *config.Cluster, envMap *envconfig.EnvMap, loca
 	}
 
 	prepared := *envMap
+
 	if !envconfig.IsConfiguredEnvValue(prepared.ProjectName) {
 		prepared.ProjectName = cluster.Name
 	}
+
 	if !envconfig.IsConfiguredEnvValue(prepared.ProjectStage) {
 		prepared.ProjectStage = cluster.Stage
 	}

--- a/src/cmd/bootstrap.go
+++ b/src/cmd/bootstrap.go
@@ -29,9 +29,8 @@ type BootstrapFlags struct {
 	EnvPrefixFlag          string
 	DryRun                 bool
 	Timeout                time.Duration
-
-	InitialKubeconfig string
-	AgentNamespace    string
+	InitialKubeconfig      string
+	AgentNamespace         string
 }
 
 var deprecatedBootstrapCRDFlags = []string{
@@ -57,7 +56,7 @@ func NewBootstrapCmd() *cli.Command {
 		UsageText: `kubara bootstrap CLUSTER_NAME [--local]
 kubara bootstrap CLUSTER_NAME --initial-kubeconfig PATH [--namespace NAMESPACE]`,
 		ArgsUsage:   "CLUSTER_NAME",
-		Description: "Bootstraps Argo CD onto a hub cluster, or onboards a spoke cluster when --initial-kubeconfig is provided.",
+		Description: "Bootstraps Argo CD onto a hub cluster, or onboards a spoke cluster. When --local is defined for a hub cluster, it automatically provisions an isolated local environment using kind.",
 		Arguments: []cli.Argument{
 			&cli.StringArg{
 				Name:      "cluster-name",
@@ -120,7 +119,6 @@ func (flags *BootstrapFlags) ToOptions(cmd *cli.Command) (*bootstrap.Options, er
 	}
 
 	clusterName := cmd.StringArg("cluster-name")
-
 	var clusterConfig *config.Cluster
 	for i := range cs.GetConfig().Clusters {
 		if cs.GetConfig().Clusters[i].Name == clusterName {
@@ -130,82 +128,93 @@ func (flags *BootstrapFlags) ToOptions(cmd *cli.Command) (*bootstrap.Options, er
 	}
 
 	if clusterConfig == nil {
+		return nil, fmt.Errorf("cluster %q not found in config file %q", clusterName, configFilePath)
+	}
+
+	if clusterConfig.Type == config.Spoke {
+		return flags.bootstrapSpoke(cwd, kubeconf, configFilePath, clusterConfig)
+	}
+
+	loadedCatalog, err := cs.GetCatalogForCluster(*clusterConfig)
+	if err != nil {
+		return nil, fmt.Errorf("load catalog for cluster %q: %w", clusterConfig.Name, err)
+	}
+
+	bootstrapCatalog := catalog.DefaultBootstrapCatalog
+	if cs.GetConfig() != nil && cs.GetConfig().BootstrapCatalog != nil {
+		bootstrapCatalog = *cs.GetConfig().BootstrapCatalog
+	}
+
+	return flags.bootstrapHub(
+		cmd,
+		&bootstrap.Options{
+			Kubeconfig:       kubeconf,
+			Catalog:          loadedCatalog,
+			ClusterConfig:    clusterConfig,
+			ClusterName:      clusterName,
+			WorkDir:          cwd,
+			ConfigFilePath:   configFilePath,
+			Catalogs:         catalogOptions.Catalogs,
+			CatalogOverwrite: catalogOptions.Overwrite,
+			BootstrapCatalog: bootstrapCatalog,
+		},
+	)
+}
+
+func (flags *BootstrapFlags) bootstrapSpoke(
+	cwd string,
+	kubeconf string,
+	configFilePath string,
+	clusterConfig *config.Cluster,
+) (*bootstrap.Options, error) {
+	if flags.InitialKubeconfig == "" {
+		return nil, fmt.Errorf("--initial-kubeconfig is required for spoke clusters")
+	}
+
+	if flags.DryRun {
+		return nil, fmt.Errorf("--dry-run is not supported for spoke clusters")
+	}
+
+	initialKubeconfig, err := utils.GetFullPath(flags.InitialKubeconfig, cwd)
+	if err != nil {
+		return nil, fmt.Errorf("resolve initial kubeconfig path: %w", err)
+	}
+
+	if _, err := os.Stat(initialKubeconfig); err != nil {
 		return nil, fmt.Errorf(
-			"cluster %q not found in config file %q",
-			clusterName,
-			configFilePath,
+			"initial kubeconfig %q is not accessible: %w",
+			initialKubeconfig, err,
 		)
 	}
 
-	// Spoke onboarding is intentionally routed before the existing hub bootstrap
-	// environment/catalog preparation. The spoke path only needs the Kubara
-	// configuration, a Hub kubeconfig, and the initial Spoke kubeconfig.
-	if flags.InitialKubeconfig != "" {
-		if flags.Local {
-			return nil, fmt.Errorf(
-				"--local cannot be used with --initial-kubeconfig",
-			)
-		}
+	return &bootstrap.Options{
+		Kubeconfig:        kubeconf,
+		InitialKubeconfig: initialKubeconfig,
+		AgentNamespace:    flags.AgentNamespace,
+		ClusterConfig:     clusterConfig,
+		ClusterName:       clusterConfig.Name,
+		Timeout:           flags.Timeout,
+		WorkDir:           cwd,
+		ConfigFilePath:    configFilePath,
+	}, nil
+}
 
-		if flags.DryRun {
-			return nil, fmt.Errorf(
-				"--dry-run is not supported with --initial-kubeconfig",
-			)
-		}
-
-		if clusterConfig.Type != "spoke" {
-			return nil, fmt.Errorf(
-				"--initial-kubeconfig can only be used with a spoke cluster; cluster %q has type %q",
-				clusterConfig.Name,
-				clusterConfig.Type,
-			)
-		}
-
-		initialKubeconfig, err := utils.GetFullPath(
-			flags.InitialKubeconfig,
-			cwd,
-		)
-		if err != nil {
-			return nil, fmt.Errorf(
-				"resolve initial kubeconfig path: %w",
-				err,
-			)
-		}
-
-		if _, err := os.Stat(initialKubeconfig); err != nil {
-			return nil, fmt.Errorf(
-				"initial kubeconfig %q is not accessible: %w",
-				initialKubeconfig,
-				err,
-			)
-		}
-
-		return &bootstrap.Options{
-			Kubeconfig:        kubeconf,
-			InitialKubeconfig: initialKubeconfig,
-			AgentNamespace:    flags.AgentNamespace,
-			ClusterConfig:     clusterConfig,
-			ClusterName:       clusterName,
-			Timeout:           flags.Timeout,
-			WorkDir:           cwd,
-			ConfigFilePath:    configFilePath,
-		}, nil
-	}
-
+func (flags *BootstrapFlags) bootstrapHub(
+	cmd *cli.Command,
+	opts *bootstrap.Options,
+) (*bootstrap.Options, error) {
 	if cmd.IsSet("namespace") {
-		return nil, fmt.Errorf(
-			"--namespace can only be used together with --initial-kubeconfig",
-		)
+		return nil, fmt.Errorf("--namespace can only be used with spoke clusters")
 	}
 
-	envFilePath, err := utils.GetFullPath(cmd.String("env-file"), cwd)
+	envFilePath, err := utils.GetFullPath(cmd.String("env-file"), opts.WorkDir)
 	if err != nil {
 		return nil, fmt.Errorf("get env file path: %w", err)
 	}
 
 	componentsAbsPath := flags.PlatformComponentsPath
 	if !filepath.IsAbs(componentsAbsPath) {
-		componentsAbsPath = filepath.Join(cwd, componentsAbsPath)
+		componentsAbsPath = filepath.Join(opts.WorkDir, componentsAbsPath)
 		componentsAbsPath, err = filepath.Abs(componentsAbsPath)
 		if err != nil {
 			return nil, fmt.Errorf("resolve absolute path: %w", err)
@@ -214,7 +223,7 @@ func (flags *BootstrapFlags) ToOptions(cmd *cli.Command) (*bootstrap.Options, er
 
 	configsAbsPath := flags.PlatformConfigsPath
 	if !filepath.IsAbs(configsAbsPath) {
-		configsAbsPath = filepath.Join(cwd, configsAbsPath)
+		configsAbsPath = filepath.Join(opts.WorkDir, configsAbsPath)
 		configsAbsPath, err = filepath.Abs(configsAbsPath)
 		if err != nil {
 			return nil, fmt.Errorf("resolve absolute path: %w", err)
@@ -226,7 +235,7 @@ func (flags *BootstrapFlags) ToOptions(cmd *cli.Command) (*bootstrap.Options, er
 		return nil, fmt.Errorf("load env: %w", err)
 	}
 
-	envMap, err := prepareBootstrapEnv(clusterConfig, es.GetConfig(), flags.Local)
+	envMap, err := prepareBootstrapEnv(opts.ClusterConfig, es.GetConfig(), flags.Local)
 	if err != nil {
 		return nil, fmt.Errorf("prepare env: %w", err)
 	}
@@ -234,38 +243,18 @@ func (flags *BootstrapFlags) ToOptions(cmd *cli.Command) (*bootstrap.Options, er
 	var cssAbsPath string
 	if flags.ClusterSecretStorePath != "" {
 		if !filepath.IsAbs(flags.ClusterSecretStorePath) {
-			cssAbsPath = filepath.Join(cwd, flags.ClusterSecretStorePath)
+			cssAbsPath = filepath.Join(opts.WorkDir, flags.ClusterSecretStorePath)
 			cssAbsPath, err = filepath.Abs(cssAbsPath)
 			if err != nil {
-				return nil, fmt.Errorf(
-					"getting absolute path for ClusterSecretStore file: %w",
-					err,
-				)
+				return nil, fmt.Errorf("getting absolute path for ClusterSecretStore file: %w", err)
 			}
 		} else {
 			cssAbsPath = flags.ClusterSecretStorePath
 		}
 
 		if _, err := os.Stat(cssAbsPath); err != nil {
-			return nil, fmt.Errorf(
-				"cluster secret store file not found: %w",
-				err,
-			)
+			return nil, fmt.Errorf("cluster secret store file not found: %w", err)
 		}
-	}
-
-	loadedCatalog, err := cs.GetCatalogForCluster(*clusterConfig)
-	if err != nil {
-		return nil, fmt.Errorf(
-			"load catalog for cluster %q: %w",
-			clusterConfig.Name,
-			err,
-		)
-	}
-
-	bootstrapCatalog := catalog.DefaultBootstrapCatalog
-	if cs.GetConfig() != nil && cs.GetConfig().BootstrapCatalog != nil {
-		bootstrapCatalog = *cs.GetConfig().BootstrapCatalog
 	}
 
 	timeout := flags.Timeout
@@ -273,24 +262,15 @@ func (flags *BootstrapFlags) ToOptions(cmd *cli.Command) (*bootstrap.Options, er
 		timeout = 20 * time.Minute
 	}
 
-	return &bootstrap.Options{
-		Kubeconfig:         kubeconf,
-		PlatformComponents: componentsAbsPath,
-		PlatformConfigs:    configsAbsPath,
-		Local:              flags.Local,
-		WithESCSSPath:      cssAbsPath,
-		EnvMap:             envMap,
-		Catalog:            loadedCatalog,
-		ClusterConfig:      clusterConfig,
-		DryRun:             flags.DryRun,
-		Timeout:            timeout,
-		ClusterName:        clusterName,
-		WorkDir:            cwd,
-		ConfigFilePath:     configFilePath,
-		Catalogs:           catalogOptions.Catalogs,
-		CatalogOverwrite:   catalogOptions.Overwrite,
-		BootstrapCatalog:   bootstrapCatalog,
-	}, nil
+	opts.PlatformComponents = componentsAbsPath
+	opts.PlatformConfigs = configsAbsPath
+	opts.Local = flags.Local
+	opts.WithESCSSPath = cssAbsPath
+	opts.EnvMap = envMap
+	opts.DryRun = flags.DryRun
+	opts.Timeout = timeout
+
+	return opts, nil
 }
 
 func (flags *BootstrapFlags) AddFlags(cmd *cli.Command) {
@@ -367,11 +347,7 @@ func (flags *BootstrapFlags) AddFlags(cmd *cli.Command) {
 }
 
 func Run(ctx context.Context, o *bootstrap.Options) error {
-	ctx, cancelSignal := signal.NotifyContext(
-		ctx,
-		os.Interrupt,
-		syscall.SIGTERM,
-	)
+	ctx, cancelSignal := signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
 	defer cancelSignal()
 
 	return bootstrap.Bootstrap(ctx, o)
@@ -380,31 +356,19 @@ func Run(ctx context.Context, o *bootstrap.Options) error {
 func printDeprecatedBootstrapCRDFlagNotice(cmd *cli.Command) {
 	for _, flagName := range deprecatedBootstrapCRDFlags {
 		if cmd.IsSet(flagName) {
-			log.Warn().
-				Msgf(
-					"--%s is deprecated and ignored; CRDs are applied automatically during bootstrap.\n",
-					flagName,
-				)
+			log.Warn().Msgf("--%s is deprecated and ignored; CRDs are applied automatically during bootstrap.\n", flagName)
 		}
 	}
 }
 
-func prepareBootstrapEnv(
-	cluster *config.Cluster,
-	envMap *envconfig.EnvMap,
-	local bool,
-) (*envconfig.EnvMap, error) {
+func prepareBootstrapEnv(cluster *config.Cluster, envMap *envconfig.EnvMap, local bool) (*envconfig.EnvMap, error) {
 	if err := envMap.Validate(); err != nil {
 		return nil, err
 	}
 
-	if (envconfig.IsConfiguredEnvValue(envMap.ArgocdGitUsername) &&
-		!envconfig.IsConfiguredEnvValue(envMap.ArgocdGitPatOrPassword)) ||
-		(!envconfig.IsConfiguredEnvValue(envMap.ArgocdGitUsername) &&
-			envconfig.IsConfiguredEnvValue(envMap.ArgocdGitPatOrPassword)) {
-		return nil, fmt.Errorf(
-			"if you are using a private repository you need to configure both ARGOCD_GIT_PAT_OR_PASSWORD and ARGOCD_GIT_USERNAME",
-		)
+	if (envconfig.IsConfiguredEnvValue(envMap.ArgocdGitUsername) && !envconfig.IsConfiguredEnvValue(envMap.ArgocdGitPatOrPassword)) ||
+		(!envconfig.IsConfiguredEnvValue(envMap.ArgocdGitUsername) && envconfig.IsConfiguredEnvValue(envMap.ArgocdGitPatOrPassword)) {
+		return nil, fmt.Errorf("if you are using a private repository you need to configure both ARGOCD_GIT_PAT_OR_PASSWORD and ARGOCD_GIT_USERNAME")
 	}
 
 	if !local {
@@ -412,7 +376,6 @@ func prepareBootstrapEnv(
 	}
 
 	prepared := *envMap
-
 	if !envconfig.IsConfiguredEnvValue(prepared.ProjectName) {
 		prepared.ProjectName = cluster.Name
 	}

--- a/src/internal/cmd/bootstrap/bootstrap.go
+++ b/src/internal/cmd/bootstrap/bootstrap.go
@@ -43,6 +43,8 @@ type Options struct {
 	CatalogOverwrite   bool
 	LocalState         *LocalState
 	BootstrapCatalog   string
+	InitialKubeconfig  string
+	AgentNamespace     string
 }
 
 type BootstrapChart struct {
@@ -85,7 +87,9 @@ func Bootstrap(ctx context.Context, opts *Options) error {
 		ctx, cancel = context.WithTimeout(ctx, opts.Timeout)
 		defer cancel()
 	}
-
+	if opts.ClusterConfig.Type == config.Spoke {
+		return BootstrapSpoke(ctx, opts)
+	}
 	if opts.Local {
 		if err := prepareLocalBootstrap(ctx, opts); err != nil {
 			return fmt.Errorf("prepare local bootstrap: %w", err)

--- a/src/internal/cmd/bootstrap/spoke.go
+++ b/src/internal/cmd/bootstrap/spoke.go
@@ -1,0 +1,603 @@
+package bootstrap
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/rs/zerolog/log"
+)
+
+const (
+	spokeBootstrapHubNamespace = "argocd"
+
+	rotatorLabelKey   = "kubara.io/cluster-credential-rotator"
+	rotatorLabelValue = "true"
+
+	agentNamespaceAnnotation = "kubara.io/agent-namespace"
+
+	bootstrapKubeconfigKey = "bootstrapKubeconfig"
+	generatedConfigKey     = "config"
+
+	bootstrapSecretType = "kubara.io/argocd-cluster-bootstrap"
+
+	clusterConfigMapSuffix = "-config"
+	clusterSecretSuffix    = "-cluster-secret"
+
+	argoClusterLabel      = "argocd.argoproj.io/secret-type"
+	argoClusterLabelValue = "cluster"
+
+	rotatorSelector      = "app.kubernetes.io/name=cluster-credential-rotator"
+	rotatorContainerName = "cluster-credential-rotator"
+
+	targetSecretEnvName = "KUBARA_TARGET_SECRET_NAME"
+)
+
+// BootstrapSpoke onboards an already-existing spoke cluster through the
+// credential rotator running on the Hub.
+//
+// The Hub is reached with opts.Kubeconfig. opts.InitialKubeconfig is stored
+// only as the initial bootstrap credential for the target spoke. The rotator
+// uses it to create kubara-agent and mint the first rotating credential.
+func BootstrapSpoke(ctx context.Context, opts *Options) error {
+	if opts.ClusterConfig == nil {
+		return fmt.Errorf("cluster configuration is required")
+	}
+
+	if opts.ClusterConfig.Type != "spoke" {
+		return fmt.Errorf(
+			"cluster %q is not a spoke cluster",
+			opts.ClusterName,
+		)
+	}
+
+	if opts.InitialKubeconfig == "" {
+		return fmt.Errorf("initial kubeconfig is required for spoke onboarding")
+	}
+
+	agentNamespace := opts.AgentNamespace
+	if agentNamespace == "" {
+		agentNamespace = "kubara"
+	}
+
+	if errs := validation.IsDNS1123Label(agentNamespace); len(errs) > 0 {
+		return fmt.Errorf(
+			"invalid kubara-agent namespace %q: %s",
+			agentNamespace,
+			strings.Join(errs, "; "),
+		)
+	}
+
+	initialKubeconfig, err := os.ReadFile(opts.InitialKubeconfig)
+	if err != nil {
+		return fmt.Errorf("read initial kubeconfig: %w", err)
+	}
+
+	if _, err := clientcmd.Load(initialKubeconfig); err != nil {
+		return fmt.Errorf("parse initial kubeconfig: %w", err)
+	}
+
+	restConfig, err := clientcmd.BuildConfigFromFlags("", opts.Kubeconfig)
+	if err != nil {
+		return fmt.Errorf("load hub kubeconfig: %w", err)
+	}
+
+	restConfig.QPS = 50
+	restConfig.Burst = 100
+	restConfig.Timeout = 30 * time.Second
+	restConfig.UserAgent = "kubara-spoke-bootstrap"
+
+	client, err := kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		return fmt.Errorf("create hub kubernetes client: %w", err)
+	}
+
+	configMapName := opts.ClusterName + clusterConfigMapSuffix
+
+	configMap, err := client.CoreV1().
+		ConfigMaps(spokeBootstrapHubNamespace).
+		Get(ctx, configMapName, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf(
+			"get cluster configuration ConfigMap %q in namespace %q: %w",
+			configMapName,
+			spokeBootstrapHubNamespace,
+			err,
+		)
+	}
+
+	if configMap.Labels[rotatorLabelKey] != rotatorLabelValue {
+		return fmt.Errorf(
+			"ConfigMap %q is not enabled for automatic credential rotation: expected label %s=%s",
+			configMapName,
+			rotatorLabelKey,
+			rotatorLabelValue,
+		)
+	}
+
+	if configMap.Labels[argoClusterLabel] != argoClusterLabelValue {
+		return fmt.Errorf(
+			"ConfigMap %q does not contain required label %s=%s",
+			configMapName,
+			argoClusterLabel,
+			argoClusterLabelValue,
+		)
+	}
+
+	cronJob, err := findCredentialRotatorCronJob(ctx, client)
+	if err != nil {
+		return err
+	}
+
+	secretName := opts.ClusterName + clusterSecretSuffix
+
+	if err := upsertInitialSpokeSecret(
+		ctx,
+		client,
+		secretName,
+		initialKubeconfig,
+		agentNamespace,
+	); err != nil {
+		return err
+	}
+
+	job, err := createTargetedRotatorJob(
+		ctx,
+		client,
+		cronJob,
+		secretName,
+	)
+	if err != nil {
+		return err
+	}
+
+	log.Info().
+		Msgf(
+			"Started credential rotator job %q for spoke %q",
+			job.Name,
+			opts.ClusterName,
+		)
+
+	if err := waitForRotatorJob(ctx, client, job.Name); err != nil {
+		logCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		jobLogs := getRotatorJobLogs(logCtx, client, job.Name)
+		if jobLogs != "" {
+			return fmt.Errorf(
+				"%w\ncredential rotator logs:\n%s",
+				err,
+				jobLogs,
+			)
+		}
+
+		return err
+	}
+
+	secret, err := client.CoreV1().
+		Secrets(spokeBootstrapHubNamespace).
+		Get(ctx, secretName, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf(
+			"read onboarded cluster secret %q: %w",
+			secretName,
+			err,
+		)
+	}
+
+	if len(secret.Data[generatedConfigKey]) == 0 {
+		return fmt.Errorf(
+			"credential rotator job completed but secret %q contains no generated credentials",
+			secretName,
+		)
+	}
+
+	if len(secret.Data["server"]) == 0 {
+		return fmt.Errorf(
+			"credential rotator job completed but secret %q contains no cluster server",
+			secretName,
+		)
+	}
+
+	if len(secret.Data["name"]) == 0 {
+		return fmt.Errorf(
+			"credential rotator job completed but secret %q contains no cluster name",
+			secretName,
+		)
+	}
+
+	if secret.Annotations[agentNamespaceAnnotation] != agentNamespace {
+		return fmt.Errorf(
+			"credential rotator job completed but secret %q has unexpected %s annotation %q",
+			secretName,
+			agentNamespaceAnnotation,
+			secret.Annotations[agentNamespaceAnnotation],
+		)
+	}
+
+	if !stringMapsEqual(secret.Labels, configMap.Labels) {
+		return fmt.Errorf(
+			"credential rotator job completed but labels on secret %q do not exactly match authoritative ConfigMap %q",
+			secretName,
+			configMapName,
+		)
+	}
+
+	log.Info().
+		Msgf(
+			"Spoke cluster %q onboarded successfully with kubara-agent namespace %q",
+			opts.ClusterName,
+			agentNamespace,
+		)
+
+	return nil
+}
+
+func upsertInitialSpokeSecret(
+	ctx context.Context,
+	client kubernetes.Interface,
+	secretName string,
+	initialKubeconfig []byte,
+	agentNamespace string,
+) error {
+	secrets := client.CoreV1().Secrets(spokeBootstrapHubNamespace)
+
+	secret, err := secrets.Get(
+		ctx,
+		secretName,
+		metav1.GetOptions{},
+	)
+
+	if apierrors.IsNotFound(err) {
+		_, err = secrets.Create(
+			ctx,
+			&corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      secretName,
+					Namespace: spokeBootstrapHubNamespace,
+					Labels: map[string]string{
+						rotatorLabelKey: rotatorLabelValue,
+					},
+					Annotations: map[string]string{
+						agentNamespaceAnnotation: agentNamespace,
+					},
+				},
+				Type: corev1.SecretType(bootstrapSecretType),
+				Data: map[string][]byte{
+					bootstrapKubeconfigKey: initialKubeconfig,
+				},
+			},
+			metav1.CreateOptions{},
+		)
+		if err != nil {
+			return fmt.Errorf(
+				"create initial cluster secret %q: %w",
+				secretName,
+				err,
+			)
+		}
+
+		log.Info().Msgf("Created initial cluster secret %q", secretName)
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf(
+			"read initial cluster secret %q: %w",
+			secretName,
+			err,
+		)
+	}
+
+	if len(secret.Data[generatedConfigKey]) > 0 {
+		return fmt.Errorf(
+			"cluster secret %q already contains generated credentials; refusing to re-onboard it",
+			secretName,
+		)
+	}
+
+	updated := secret.DeepCopy()
+
+	if updated.Data == nil {
+		updated.Data = map[string][]byte{}
+	}
+	updated.Data[bootstrapKubeconfigKey] = initialKubeconfig
+
+	if updated.Labels == nil {
+		updated.Labels = map[string]string{}
+	}
+	updated.Labels[rotatorLabelKey] = rotatorLabelValue
+
+	if updated.Annotations == nil {
+		updated.Annotations = map[string]string{}
+	}
+	updated.Annotations[agentNamespaceAnnotation] = agentNamespace
+
+	updated.Type = corev1.SecretType(bootstrapSecretType)
+
+	if _, err := secrets.Update(
+		ctx,
+		updated,
+		metav1.UpdateOptions{},
+	); err != nil {
+		return fmt.Errorf(
+			"update initial cluster secret %q: %w",
+			secretName,
+			err,
+		)
+	}
+
+	log.Info().Msgf("Updated initial cluster secret %q", secretName)
+	return nil
+}
+
+func findCredentialRotatorCronJob(
+	ctx context.Context,
+	client kubernetes.Interface,
+) (*batchv1.CronJob, error) {
+	cronJobs, err := client.BatchV1().
+		CronJobs(spokeBootstrapHubNamespace).
+		List(
+			ctx,
+			metav1.ListOptions{
+				LabelSelector: rotatorSelector,
+			},
+		)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"discover credential rotator CronJob: %w",
+			err,
+		)
+	}
+
+	switch len(cronJobs.Items) {
+	case 0:
+		return nil, fmt.Errorf(
+			"credential rotator CronJob not found in namespace %q; ensure the Hub has reconciled the credential rotator",
+			spokeBootstrapHubNamespace,
+		)
+	case 1:
+		return &cronJobs.Items[0], nil
+	default:
+		names := make([]string, 0, len(cronJobs.Items))
+		for _, item := range cronJobs.Items {
+			names = append(names, item.Name)
+		}
+
+		return nil, fmt.Errorf(
+			"found multiple credential rotator CronJobs in namespace %q: %s",
+			spokeBootstrapHubNamespace,
+			strings.Join(names, ", "),
+		)
+	}
+}
+
+func createTargetedRotatorJob(
+	ctx context.Context,
+	client kubernetes.Interface,
+	cronJob *batchv1.CronJob,
+	secretName string,
+) (*batchv1.Job, error) {
+	jobTemplate := cronJob.Spec.JobTemplate.DeepCopy()
+
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: cronJob.Name + "-bootstrap-",
+			Namespace:    spokeBootstrapHubNamespace,
+			Labels:       copyStringMap(jobTemplate.Labels),
+			Annotations:  copyStringMap(jobTemplate.Annotations),
+		},
+		Spec: jobTemplate.Spec,
+	}
+
+	if job.Labels == nil {
+		job.Labels = map[string]string{}
+	}
+	job.Labels["app.kubernetes.io/name"] = "cluster-credential-rotator"
+	job.Labels["app.kubernetes.io/managed-by"] = "kubara"
+
+	if job.Annotations == nil {
+		job.Annotations = map[string]string{}
+	}
+	job.Annotations["cronjob.kubernetes.io/instantiate"] = "manual"
+
+	foundContainer := false
+
+	for i := range job.Spec.Template.Spec.Containers {
+		container := &job.Spec.Template.Spec.Containers[i]
+
+		if container.Name != rotatorContainerName {
+			continue
+		}
+
+		foundContainer = true
+
+		foundEnv := false
+		for j := range container.Env {
+			if container.Env[j].Name == targetSecretEnvName {
+				container.Env[j].Value = secretName
+				container.Env[j].ValueFrom = nil
+				foundEnv = true
+				break
+			}
+		}
+
+		if !foundEnv {
+			container.Env = append(
+				container.Env,
+				corev1.EnvVar{
+					Name:  targetSecretEnvName,
+					Value: secretName,
+				},
+			)
+		}
+	}
+
+	if !foundContainer {
+		return nil, fmt.Errorf(
+			"credential rotator CronJob does not contain container %q",
+			rotatorContainerName,
+		)
+	}
+
+	createdJob, err := client.BatchV1().
+		Jobs(spokeBootstrapHubNamespace).
+		Create(
+			ctx,
+			job,
+			metav1.CreateOptions{},
+		)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"create credential rotator Job: %w",
+			err,
+		)
+	}
+
+	return createdJob, nil
+}
+
+func waitForRotatorJob(
+	ctx context.Context,
+	client kubernetes.Interface,
+	jobName string,
+) error {
+	ticker := time.NewTicker(2 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		job, err := client.BatchV1().
+			Jobs(spokeBootstrapHubNamespace).
+			Get(
+				ctx,
+				jobName,
+				metav1.GetOptions{},
+			)
+		if err != nil {
+			return fmt.Errorf(
+				"read credential rotator Job %q: %w",
+				jobName,
+				err,
+			)
+		}
+
+		for _, condition := range job.Status.Conditions {
+			if condition.Type == batchv1.JobComplete &&
+				condition.Status == corev1.ConditionTrue {
+				return nil
+			}
+
+			if condition.Type == batchv1.JobFailed &&
+				condition.Status == corev1.ConditionTrue {
+				message := condition.Message
+				if message == "" {
+					message = condition.Reason
+				}
+				if message == "" {
+					message = "Job reported failed condition"
+				}
+
+				return fmt.Errorf(
+					"credential rotator Job %q failed: %s",
+					jobName,
+					message,
+				)
+			}
+		}
+
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf(
+				"waiting for credential rotator Job %q: %w",
+				jobName,
+				ctx.Err(),
+			)
+		case <-ticker.C:
+		}
+	}
+}
+
+func getRotatorJobLogs(
+	ctx context.Context,
+	client kubernetes.Interface,
+	jobName string,
+) string {
+	pods, err := client.CoreV1().
+		Pods(spokeBootstrapHubNamespace).
+		List(
+			ctx,
+			metav1.ListOptions{
+				LabelSelector: "job-name=" + jobName,
+			},
+		)
+	if err != nil {
+		return ""
+	}
+
+	var output []string
+
+	for _, pod := range pods.Items {
+		data, err := client.CoreV1().
+			Pods(spokeBootstrapHubNamespace).
+			GetLogs(
+				pod.Name,
+				&corev1.PodLogOptions{
+					Container: rotatorContainerName,
+				},
+			).
+			DoRaw(ctx)
+		if err != nil {
+			continue
+		}
+
+		logs := strings.TrimSpace(string(data))
+		if logs == "" {
+			continue
+		}
+
+		output = append(
+			output,
+			fmt.Sprintf("[%s]\n%s", pod.Name, logs),
+		)
+	}
+
+	return strings.Join(output, "\n")
+}
+
+func copyStringMap(input map[string]string) map[string]string {
+	if input == nil {
+		return nil
+	}
+
+	output := make(map[string]string, len(input))
+
+	for key, value := range input {
+		output[key] = value
+	}
+
+	return output
+}
+
+func stringMapsEqual(left, right map[string]string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+
+	for key, value := range left {
+		if right[key] != value {
+			return false
+		}
+	}
+
+	return true
+}

--- a/src/internal/cmd/bootstrap/spoke.go
+++ b/src/internal/cmd/bootstrap/spoke.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"reflect"
 	"strings"
 	"time"
 
@@ -15,30 +16,22 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 
+	"github.com/kubara-io/kubara/internal/config"
 	"github.com/rs/zerolog/log"
 )
 
 const (
-	spokeBootstrapHubNamespace = "argocd"
-
-	rotatorLabelKey   = "kubara.io/cluster-credential-rotator"
-	rotatorLabelValue = "true"
+	spokeCredentialsNamespace = "argocd"
 
 	agentNamespaceAnnotation = "kubara.io/agent-namespace"
 
 	bootstrapKubeconfigKey = "bootstrapKubeconfig"
 	generatedConfigKey     = "config"
 
-	bootstrapSecretType = "kubara.io/argocd-cluster-bootstrap"
-
-	clusterConfigMapSuffix = "-config"
-	clusterSecretSuffix    = "-cluster-secret"
+	clusterCredentialsSecretType = "kubara.io/cluster-credentials"
 
 	argoClusterLabel      = "argocd.argoproj.io/secret-type"
 	argoClusterLabelValue = "cluster"
-
-	rotatorSelector      = "app.kubernetes.io/name=cluster-credential-rotator"
-	rotatorContainerName = "cluster-credential-rotator"
 
 	targetSecretEnvName = "KUBARA_TARGET_SECRET_NAME"
 )
@@ -54,11 +47,8 @@ func BootstrapSpoke(ctx context.Context, opts *Options) error {
 		return fmt.Errorf("cluster configuration is required")
 	}
 
-	if opts.ClusterConfig.Type != "spoke" {
-		return fmt.Errorf(
-			"cluster %q is not a spoke cluster",
-			opts.ClusterName,
-		)
+	if opts.ClusterConfig.Type != config.Spoke {
+		return fmt.Errorf("cluster %q is not a spoke cluster", opts.ClusterName)
 	}
 
 	if opts.InitialKubeconfig == "" {
@@ -71,11 +61,7 @@ func BootstrapSpoke(ctx context.Context, opts *Options) error {
 	}
 
 	if errs := validation.IsDNS1123Label(agentNamespace); len(errs) > 0 {
-		return fmt.Errorf(
-			"invalid kubara-agent namespace %q: %s",
-			agentNamespace,
-			strings.Join(errs, "; "),
-		)
+		return fmt.Errorf("invalid kubara-agent namespace %q: %s", agentNamespace, strings.Join(errs, "; "))
 	}
 
 	initialKubeconfig, err := os.ReadFile(opts.InitialKubeconfig)
@@ -102,26 +88,17 @@ func BootstrapSpoke(ctx context.Context, opts *Options) error {
 		return fmt.Errorf("create hub kubernetes client: %w", err)
 	}
 
-	configMapName := opts.ClusterName + clusterConfigMapSuffix
+	configMapName := opts.ClusterName + "-config"
 
 	configMap, err := client.CoreV1().
-		ConfigMaps(spokeBootstrapHubNamespace).
+		ConfigMaps(spokeCredentialsNamespace).
 		Get(ctx, configMapName, metav1.GetOptions{})
 	if err != nil {
 		return fmt.Errorf(
 			"get cluster configuration ConfigMap %q in namespace %q: %w",
 			configMapName,
-			spokeBootstrapHubNamespace,
+			spokeCredentialsNamespace,
 			err,
-		)
-	}
-
-	if configMap.Labels[rotatorLabelKey] != rotatorLabelValue {
-		return fmt.Errorf(
-			"ConfigMap %q is not enabled for automatic credential rotation: expected label %s=%s",
-			configMapName,
-			rotatorLabelKey,
-			rotatorLabelValue,
 		)
 	}
 
@@ -134,12 +111,12 @@ func BootstrapSpoke(ctx context.Context, opts *Options) error {
 		)
 	}
 
-	cronJob, err := findCredentialRotatorCronJob(ctx, client)
+	cronJob, err := getCredsRotatorCronJob(ctx, client)
 	if err != nil {
 		return err
 	}
 
-	secretName := opts.ClusterName + clusterSecretSuffix
+	secretName := opts.ClusterName + "-cluster-secret"
 
 	if err := upsertInitialSpokeSecret(
 		ctx,
@@ -151,48 +128,29 @@ func BootstrapSpoke(ctx context.Context, opts *Options) error {
 		return err
 	}
 
-	job, err := createTargetedRotatorJob(
-		ctx,
-		client,
-		cronJob,
-		secretName,
-	)
+	job, err := startOnboardingJob(ctx, client, cronJob, secretName)
 	if err != nil {
 		return err
 	}
 
-	log.Info().
-		Msgf(
-			"Started credential rotator job %q for spoke %q",
-			job.Name,
-			opts.ClusterName,
-		)
+	log.Info().Msgf("Started credential rotator job %q for spoke %q", job.Name, opts.ClusterName)
 
 	if err := waitForRotatorJob(ctx, client, job.Name); err != nil {
 		logCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
 
-		jobLogs := getRotatorJobLogs(logCtx, client, job.Name)
-		if jobLogs != "" {
-			return fmt.Errorf(
-				"%w\ncredential rotator logs:\n%s",
-				err,
-				jobLogs,
-			)
+		if jobLogs := getRotatorJobLogs(logCtx, client, job.Name); jobLogs != "" {
+			log.Error().Msgf("credential rotator logs:\n%s", jobLogs)
 		}
 
 		return err
 	}
 
 	secret, err := client.CoreV1().
-		Secrets(spokeBootstrapHubNamespace).
+		Secrets(spokeCredentialsNamespace).
 		Get(ctx, secretName, metav1.GetOptions{})
 	if err != nil {
-		return fmt.Errorf(
-			"read onboarded cluster secret %q: %w",
-			secretName,
-			err,
-		)
+		return fmt.Errorf("read onboarded cluster secret %q: %w", secretName, err)
 	}
 
 	if len(secret.Data[generatedConfigKey]) == 0 {
@@ -203,17 +161,11 @@ func BootstrapSpoke(ctx context.Context, opts *Options) error {
 	}
 
 	if len(secret.Data["server"]) == 0 {
-		return fmt.Errorf(
-			"credential rotator job completed but secret %q contains no cluster server",
-			secretName,
-		)
+		return fmt.Errorf("credential rotator job completed but secret %q contains no cluster server", secretName)
 	}
 
 	if len(secret.Data["name"]) == 0 {
-		return fmt.Errorf(
-			"credential rotator job completed but secret %q contains no cluster name",
-			secretName,
-		)
+		return fmt.Errorf("credential rotator job completed but secret %q contains no cluster name", secretName)
 	}
 
 	if secret.Annotations[agentNamespaceAnnotation] != agentNamespace {
@@ -225,7 +177,7 @@ func BootstrapSpoke(ctx context.Context, opts *Options) error {
 		)
 	}
 
-	if !stringMapsEqual(secret.Labels, configMap.Labels) {
+	if !reflect.DeepEqual(secret.Labels, configMap.Labels) {
 		return fmt.Errorf(
 			"credential rotator job completed but labels on secret %q do not exactly match authoritative ConfigMap %q",
 			secretName,
@@ -233,12 +185,11 @@ func BootstrapSpoke(ctx context.Context, opts *Options) error {
 		)
 	}
 
-	log.Info().
-		Msgf(
-			"Spoke cluster %q onboarded successfully with kubara-agent namespace %q",
-			opts.ClusterName,
-			agentNamespace,
-		)
+	log.Info().Msgf(
+		"Spoke cluster %q onboarded successfully with kubara-agent namespace %q",
+		opts.ClusterName,
+		agentNamespace,
+	)
 
 	return nil
 }
@@ -250,13 +201,9 @@ func upsertInitialSpokeSecret(
 	initialKubeconfig []byte,
 	agentNamespace string,
 ) error {
-	secrets := client.CoreV1().Secrets(spokeBootstrapHubNamespace)
+	secrets := client.CoreV1().Secrets(spokeCredentialsNamespace)
 
-	secret, err := secrets.Get(
-		ctx,
-		secretName,
-		metav1.GetOptions{},
-	)
+	secret, err := secrets.Get(ctx, secretName, metav1.GetOptions{})
 
 	if apierrors.IsNotFound(err) {
 		_, err = secrets.Create(
@@ -264,15 +211,12 @@ func upsertInitialSpokeSecret(
 			&corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      secretName,
-					Namespace: spokeBootstrapHubNamespace,
-					Labels: map[string]string{
-						rotatorLabelKey: rotatorLabelValue,
-					},
+					Namespace: spokeCredentialsNamespace,
 					Annotations: map[string]string{
 						agentNamespaceAnnotation: agentNamespace,
 					},
 				},
-				Type: corev1.SecretType(bootstrapSecretType),
+				Type: corev1.SecretType(clusterCredentialsSecretType),
 				Data: map[string][]byte{
 					bootstrapKubeconfigKey: initialKubeconfig,
 				},
@@ -280,11 +224,7 @@ func upsertInitialSpokeSecret(
 			metav1.CreateOptions{},
 		)
 		if err != nil {
-			return fmt.Errorf(
-				"create initial cluster secret %q: %w",
-				secretName,
-				err,
-			)
+			return fmt.Errorf("create initial cluster secret %q: %w", secretName, err)
 		}
 
 		log.Info().Msgf("Created initial cluster secret %q", secretName)
@@ -292,11 +232,7 @@ func upsertInitialSpokeSecret(
 	}
 
 	if err != nil {
-		return fmt.Errorf(
-			"read initial cluster secret %q: %w",
-			secretName,
-			err,
-		)
+		return fmt.Errorf("read initial cluster secret %q: %w", secretName, err)
 	}
 
 	if len(secret.Data[generatedConfigKey]) > 0 {
@@ -313,79 +249,52 @@ func upsertInitialSpokeSecret(
 	}
 	updated.Data[bootstrapKubeconfigKey] = initialKubeconfig
 
-	if updated.Labels == nil {
-		updated.Labels = map[string]string{}
-	}
-	updated.Labels[rotatorLabelKey] = rotatorLabelValue
-
 	if updated.Annotations == nil {
 		updated.Annotations = map[string]string{}
 	}
 	updated.Annotations[agentNamespaceAnnotation] = agentNamespace
 
-	updated.Type = corev1.SecretType(bootstrapSecretType)
+	updated.Type = corev1.SecretType(clusterCredentialsSecretType)
 
-	if _, err := secrets.Update(
-		ctx,
-		updated,
-		metav1.UpdateOptions{},
-	); err != nil {
-		return fmt.Errorf(
-			"update initial cluster secret %q: %w",
-			secretName,
-			err,
-		)
+	if _, err := secrets.Update(ctx, updated, metav1.UpdateOptions{}); err != nil {
+		return fmt.Errorf("update initial cluster secret %q: %w", secretName, err)
 	}
 
 	log.Info().Msgf("Updated initial cluster secret %q", secretName)
 	return nil
 }
 
-func findCredentialRotatorCronJob(
-	ctx context.Context,
-	client kubernetes.Interface,
-) (*batchv1.CronJob, error) {
+func getCredsRotatorCronJob(ctx context.Context, client kubernetes.Interface) (batchv1.CronJob, error) {
 	cronJobs, err := client.BatchV1().
-		CronJobs(spokeBootstrapHubNamespace).
-		List(
-			ctx,
-			metav1.ListOptions{
-				LabelSelector: rotatorSelector,
-			},
-		)
+		CronJobs(spokeCredentialsNamespace).
+		List(ctx, metav1.ListOptions{
+			LabelSelector: "app.kubernetes.io/name=cluster-credential-rotator",
+		})
 	if err != nil {
-		return nil, fmt.Errorf(
-			"discover credential rotator CronJob: %w",
-			err,
+		return batchv1.CronJob{}, fmt.Errorf("discover credential rotator CronJob: %w", err)
+	}
+
+	if len(cronJobs.Items) == 1 {
+		return cronJobs.Items[0], nil
+	}
+
+	if len(cronJobs.Items) > 1 {
+		return batchv1.CronJob{}, fmt.Errorf(
+			"invalid setup: found multiple credential rotator CronJobs in namespace %q",
+			spokeCredentialsNamespace,
 		)
 	}
 
-	switch len(cronJobs.Items) {
-	case 0:
-		return nil, fmt.Errorf(
-			"credential rotator CronJob not found in namespace %q; ensure the Hub has reconciled the credential rotator",
-			spokeBootstrapHubNamespace,
-		)
-	case 1:
-		return &cronJobs.Items[0], nil
-	default:
-		names := make([]string, 0, len(cronJobs.Items))
-		for _, item := range cronJobs.Items {
-			names = append(names, item.Name)
-		}
-
-		return nil, fmt.Errorf(
-			"found multiple credential rotator CronJobs in namespace %q: %s",
-			spokeBootstrapHubNamespace,
-			strings.Join(names, ", "),
-		)
-	}
+	return batchv1.CronJob{}, fmt.Errorf(
+		"credential rotator CronJob not found in namespace %q; ensure the Hub has reconciled the credential rotator",
+		spokeCredentialsNamespace,
+	)
 }
 
-func createTargetedRotatorJob(
+func startOnboardingJob(
 	ctx context.Context,
 	client kubernetes.Interface,
-	cronJob *batchv1.CronJob,
+	cronJob batchv1.CronJob,
 	secretName string,
 ) (*batchv1.Job, error) {
 	jobTemplate := cronJob.Spec.JobTemplate.DeepCopy()
@@ -393,9 +302,9 @@ func createTargetedRotatorJob(
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: cronJob.Name + "-bootstrap-",
-			Namespace:    spokeBootstrapHubNamespace,
-			Labels:       copyStringMap(jobTemplate.Labels),
-			Annotations:  copyStringMap(jobTemplate.Annotations),
+			Namespace:    spokeCredentialsNamespace,
+			Labels:       jobTemplate.Labels,
+			Annotations:  jobTemplate.Annotations,
 		},
 		Spec: jobTemplate.Spec,
 	}
@@ -411,84 +320,45 @@ func createTargetedRotatorJob(
 	}
 	job.Annotations["cronjob.kubernetes.io/instantiate"] = "manual"
 
-	foundContainer := false
-
-	for i := range job.Spec.Template.Spec.Containers {
-		container := &job.Spec.Template.Spec.Containers[i]
-
-		if container.Name != rotatorContainerName {
-			continue
-		}
-
-		foundContainer = true
-
-		foundEnv := false
-		for j := range container.Env {
-			if container.Env[j].Name == targetSecretEnvName {
-				container.Env[j].Value = secretName
-				container.Env[j].ValueFrom = nil
-				foundEnv = true
-				break
-			}
-		}
-
-		if !foundEnv {
-			container.Env = append(
-				container.Env,
-				corev1.EnvVar{
-					Name:  targetSecretEnvName,
-					Value: secretName,
-				},
-			)
-		}
-	}
-
-	if !foundContainer {
+	if len(job.Spec.Template.Spec.Containers) != 1 {
 		return nil, fmt.Errorf(
-			"credential rotator CronJob does not contain container %q",
-			rotatorContainerName,
+			"credential rotator CronJob must contain exactly one container, found %d",
+			len(job.Spec.Template.Spec.Containers),
 		)
 	}
+
+	container := &job.Spec.Template.Spec.Containers[0]
+	container.Env = append(
+		container.Env,
+		corev1.EnvVar{
+			Name:  targetSecretEnvName,
+			Value: secretName,
+		},
+	)
 
 	createdJob, err := client.BatchV1().
-		Jobs(spokeBootstrapHubNamespace).
-		Create(
-			ctx,
-			job,
-			metav1.CreateOptions{},
-		)
+		Jobs(spokeCredentialsNamespace).
+		Create(ctx, job, metav1.CreateOptions{})
 	if err != nil {
-		return nil, fmt.Errorf(
-			"create credential rotator Job: %w",
-			err,
-		)
+		return nil, fmt.Errorf("create credential rotator Job: %w", err)
 	}
 
 	return createdJob, nil
 }
 
-func waitForRotatorJob(
-	ctx context.Context,
-	client kubernetes.Interface,
-	jobName string,
-) error {
+func waitForRotatorJob(ctx context.Context, client kubernetes.Interface, jobName string) error {
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+	defer cancel()
+
 	ticker := time.NewTicker(2 * time.Second)
 	defer ticker.Stop()
 
 	for {
 		job, err := client.BatchV1().
-			Jobs(spokeBootstrapHubNamespace).
-			Get(
-				ctx,
-				jobName,
-				metav1.GetOptions{},
-			)
+			Jobs(spokeCredentialsNamespace).
+			Get(ctx, jobName, metav1.GetOptions{})
 		if err != nil {
-			return fmt.Errorf(
-				"read credential rotator Job %q: %w",
-				jobName,
-				err,
-			)
+			return fmt.Errorf("read credential rotator Job %q: %w", jobName, err)
 		}
 
 		for _, condition := range job.Status.Conditions {
@@ -507,39 +377,24 @@ func waitForRotatorJob(
 					message = "Job reported failed condition"
 				}
 
-				return fmt.Errorf(
-					"credential rotator Job %q failed: %s",
-					jobName,
-					message,
-				)
+				return fmt.Errorf("credential rotator Job %q failed: %s", jobName, message)
 			}
 		}
 
 		select {
 		case <-ctx.Done():
-			return fmt.Errorf(
-				"waiting for credential rotator Job %q: %w",
-				jobName,
-				ctx.Err(),
-			)
+			return fmt.Errorf("waiting for credential rotator Job %q: %w", jobName, ctx.Err())
 		case <-ticker.C:
 		}
 	}
 }
 
-func getRotatorJobLogs(
-	ctx context.Context,
-	client kubernetes.Interface,
-	jobName string,
-) string {
+func getRotatorJobLogs(ctx context.Context, client kubernetes.Interface, jobName string) string {
 	pods, err := client.CoreV1().
-		Pods(spokeBootstrapHubNamespace).
-		List(
-			ctx,
-			metav1.ListOptions{
-				LabelSelector: "job-name=" + jobName,
-			},
-		)
+		Pods(spokeCredentialsNamespace).
+		List(ctx, metav1.ListOptions{
+			LabelSelector: "job-name=" + jobName,
+		})
 	if err != nil {
 		return ""
 	}
@@ -548,13 +403,8 @@ func getRotatorJobLogs(
 
 	for _, pod := range pods.Items {
 		data, err := client.CoreV1().
-			Pods(spokeBootstrapHubNamespace).
-			GetLogs(
-				pod.Name,
-				&corev1.PodLogOptions{
-					Container: rotatorContainerName,
-				},
-			).
+			Pods(spokeCredentialsNamespace).
+			GetLogs(pod.Name, &corev1.PodLogOptions{}).
 			DoRaw(ctx)
 		if err != nil {
 			continue
@@ -565,39 +415,8 @@ func getRotatorJobLogs(
 			continue
 		}
 
-		output = append(
-			output,
-			fmt.Sprintf("[%s]\n%s", pod.Name, logs),
-		)
+		output = append(output, fmt.Sprintf("[%s]\n%s", pod.Name, logs))
 	}
 
 	return strings.Join(output, "\n")
-}
-
-func copyStringMap(input map[string]string) map[string]string {
-	if input == nil {
-		return nil
-	}
-
-	output := make(map[string]string, len(input))
-
-	for key, value := range input {
-		output[key] = value
-	}
-
-	return output
-}
-
-func stringMapsEqual(left, right map[string]string) bool {
-	if len(left) != len(right) {
-		return false
-	}
-
-	for key, value := range left {
-		if right[key] != value {
-			return false
-		}
-	}
-
-	return true
 }


### PR DESCRIPTION
## 📝 Summary

Adds spoke credential onboarding support to `kubara bootstrap`.

A spoke can now be onboarded using an initial kubeconfig:

```bash
kubara bootstrap <spoke-name> \
  --initial-kubeconfig <path> \
  --namespace <agent-namespace>

## 🧩 Type of change
- [x] 🔧 CLI / Go code
- [ ] 📝 Documentation
- [ ] 🧪 Test or CI change
- [ ] ♻️ Refactor / cleanup

## ⚠️ Is this a breaking change?
- [ ] Yes, this change breaks existing functionality (explain in summary)

## 🧪 Testing
- [ ] CI passed
- [x] Manually tested (local/dev cluster)
- [ ] Unit tested
- [ ] Not tested (explain why below)
  
## ✅ Checklist
- [ ] Code compiles and passes all tests
- [ ] Linting and style checks pass
- [ ] Comments added for complex logic
- [ ] Documentation updated (if applicable)
