### PR TITLE
fix(docs): update STACKIT Edge Cloud links

### DIFF
--- a/docs/content/3_infrastructure/stackit_edge_cloud.md
+++ b/docs/content/3_infrastructure/stackit_edge_cloud.md
@@ -22,7 +22,7 @@ All paths are valid:
 - UI is often the fastest manual path for image and cluster creation.
 - CLI/API with manifests is better for reproducibility and change history (for example in Git).
 
-For general STEC background, see the official [Edge Cloud overview](https://docs.stackit.cloud/products/runtime/edge-cloud/), [Authentication](https://docs.stackit.cloud/products/runtime/edge-cloud/getting-started/authentication/), and [Using the API](https://docs.stackit.cloud/products/runtime/edge-cloud/tutorials/using-the-api/) guides.
+For general STEC background, see the official [Edge Cloud overview](https://docs.stackit.cloud/products/runtime/edge-cloud/), [Authentication](https://docs.stackit.cloud/products/runtime/edge-cloud/getting-started/authentication/), and [Using the API](https://docs.stackit.cloud/products/runtime/edge-cloud/configuration-and-deployment/using-the-api/) guides.
 
 ## 1. Generate Terraform modules
 
@@ -234,7 +234,7 @@ curl https://image-factory.edge.$INSTANCE_REGION.stackit.cloud/versions
 
 Use one of the returned versions in `EdgeImage.spec.talosVersion`.
 If your kubara cluster will use Longhorn, include `siderolabs/iscsi-tools` and `siderolabs/util-linux-tools` in the `EdgeImage` system extensions.
-Read more in the official STACKIT guide: [Using extensions](https://docs.stackit.cloud/products/runtime/edge-cloud/tutorials/using-extensions/) and the [Longhorn Talos Linux support](https://longhorn.io/docs/1.11.0/advanced-resources/os-distro-specific/talos-linux-support/) documentation.
+Read more in the official STACKIT guide: [Using extensions](https://docs.stackit.cloud/products/runtime/edge-cloud/configuration-and-deployment/using-extensions/) and the [Longhorn Talos Linux support](https://longhorn.io/docs/1.11.0/advanced-resources/os-distro-specific/talos-linux-support/) documentation.
 
 === "UI"
 


### PR DESCRIPTION
## 📝 Summary
<!-- Please read first: https://github.com/kubara-io/kubara/blob/main/CONTRIBUTING.md -->
 Updates two broken STACKIT Edge Cloud documentation links in `docs/content/3_infrastructure/stackit_edge_cloud.md`.

STACKIT moved the `Using the API` and `Using extensions` pages from `/tutorials/` to `/configuration-and-deployment/`, causing the existing links to return HTTP 404.

This change replaces both outdated paths with their current official URLs while preserving the existing link text and surrounding documentation. 
<!-- What does this PR do? -->

## 🧩 Type of change
- [ ] 🔧 CLI / Go code
- [x] 📝 Documentation
- [ ] 🧪 Test or CI change
- [ ] ♻️ Refactor / cleanup

## ⚠️ Is this a breaking change?
- [ ] Yes, this change breaks existing functionality (explain in summary)

## 🧪 Testing
- [ ] CI passed
- [x] Manually tested (local/dev cluster)
- [ ] Unit tested
- [ ] Not tested (explain why below)
  
## 🔗 Additional Context / Related Issues / Tickets
<!-- e.g. Closes #42, Related to #99 -->
Closes #602  
Related to #574
<!-- Add logs, screenshots, diagrams, or design notes. -->

## ✅ Checklist
- [ ] Code compiles and passes all tests
- [x] Linting and style checks pass
- [ ] Comments added for complex logic
- [x] Documentation updated (if applicable)