### PR TITLE
Dependabot/uv/docs/pymdown extensions 11.0.2

### DIFF
--- a/docs/uv.lock
+++ b/docs/uv.lock
@@ -402,15 +402,15 @@ wheels = [
 
 [[package]]
 name = "pymdown-extensions"
-version = "10.21.3"
+version = "11.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9e/26/d1015444da4d952a1ca487a236b522eb979766f0295a0bd0c5fc089989a9/pymdown_extensions-10.21.3.tar.gz", hash = "sha256:72cfcf55f07aea0d4af2c4f11dd4e52466ddfb1bb819673146398e0bd3a77354", size = 854140, upload-time = "2026-05-13T12:57:32.267Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/a9/5f0c535ba3b08fe09270c16808e053a968868242ecbd5676d4e3a488bf28/pymdown_extensions-11.0.1.tar.gz", hash = "sha256:dd2905ae6fc5b75582fafb139a1266ffc754705efa902aa50067fa7ff4f94ec0", size = 857113, upload-time = "2026-07-02T17:59:22.955Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/85/545a951eecc270fcd688288c600017e2050a1aacb56c711d208586d3e470/pymdown_extensions-10.21.3-py3-none-any.whl", hash = "sha256:d7a5d08014fc571e80ca21dd6f854e31f94c489800350564d55d15b3c41e76b6", size = 269002, upload-time = "2026-05-13T12:57:30.296Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/54/da572c98c0b77626a91b5d3b89f0231d8bff5125c225420908632f8b342d/pymdown_extensions-11.0.1-py3-none-any.whl", hash = "sha256:db3943a62bab7e03af1364f0c4083e64b91fb097675a4b6cceccfbe9a77e5eb2", size = 269455, upload-time = "2026-07-02T17:59:21.271Z" },
 ]
 
 [[package]]

--- a/docs/uv.lock
+++ b/docs/uv.lock
@@ -402,7 +402,7 @@ wheels = [
 
 [[package]]
 name = "pymdown-extensions"
-version = "11.0.1"
+version = "11.0.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown" },


### PR DESCRIPTION
## 📝 Summary
<!-- Please read first: https://github.com/kubara-io/kubara/blob/main/CONTRIBUTING.md -->
  
 Dependabot created a security PR to 11.0.1...
 I tested with 11.0.2 to include a more recent patch version.
 
 see: https://github.com/kubara-io/kubara/pull/609
  
  
<!-- What does this PR do? -->

## 🧩 Type of change
- [ ] 🔧 CLI / Go code
- [x] 📝 Documentation
- [ ] 🧪 Test or CI change
- [ ] ♻️ Refactor / cleanup

## ⚠️ Is this a breaking change?
- [ ] Yes, this change breaks existing functionality (explain in summary)
There are breaking changes in the library, that shouldn't affect us.
I verified with manual testing.

## 🧪 Testing
- [ ] CI passed
- [ x ] Manually tested (local/dev cluster)
- [ ] Unit tested
- [ ] Not tested (explain why below)
  
## 🔗 Additional Context / Related Issues / Tickets
<!-- e.g. Closes #42, Related to #99 -->
<!-- Add logs, screenshots, diagrams, or design notes. -->

## ✅ Checklist
- [ ] Code compiles and passes all tests
- [ ] Linting and style checks pass
- [ ] Comments added for complex logic
- [ ] Documentation updated (if applicable)
