### PR TITLE
Fix deletion of platform-components folder in multi-hub setups

### DIFF
--- a/docs/content/1_getting_started/commands.md
+++ b/docs/content/1_getting_started/commands.md
@@ -99,13 +99,15 @@ Shows a list of commands or help for one command
 
 Generate files from catalog templates
 
->kubara generate [--terraform|--helm] [--catalog PATH_OR_OCI [--catalog-overwrite]] [--dry-run]
+>kubara generate [--terraform|--helm] [--reset] [--catalog PATH_OR_OCI [--catalog-overwrite]] [--dry-run]
 
 **--dry-run**: Preview generation without creating files
 
 **--helm**: Only generate Helm files
 
 **--help, -h**: show help
+
+**--reset**: Delete existing platform-components before generation
 
 **--terraform**: Only generate Terraform files
 

--- a/src/cmd/generate.go
+++ b/src/cmd/generate.go
@@ -16,6 +16,7 @@ type GenerateFlags struct {
 	Terraform bool
 	Helm      bool
 	DryRun    bool
+	Reset     bool
 }
 
 func NewGenerateFlags() *GenerateFlags {
@@ -23,18 +24,18 @@ func NewGenerateFlags() *GenerateFlags {
 		Terraform: false,
 		Helm:      false,
 		DryRun:    false,
+		Reset:     false,
 	}
 }
 
 // NewGenerateCmd returns the command with flags added
-// TODO implement deep-merge and/or --reset flag
 func NewGenerateCmd() *cli.Command {
 	flags := NewGenerateFlags()
 
 	cmd := &cli.Command{
 		Name:        "generate",
 		Usage:       "Generate files from catalog templates",
-		UsageText:   "kubara generate [--terraform|--helm] [--catalog PATH_OR_OCI [--catalog-overwrite]] [--dry-run]",
+		UsageText:   "kubara generate [--terraform|--helm] [--reset] [--catalog PATH_OR_OCI [--catalog-overwrite]] [--dry-run]",
 		Description: "Renders Helm and Terraform templates from configured local or OCI catalogs using values from the config file. By default, it generates both template types.",
 		Action: func(c context.Context, cmd *cli.Command) error {
 			o, err := flags.ToOptions(cmd)
@@ -79,6 +80,7 @@ func (flags *GenerateFlags) ToOptions(cmd *cli.Command) (*generate.Options, erro
 	o := &generate.Options{
 		TemplateType:       render.All,
 		DryRun:             flags.DryRun,
+		Reset:              flags.Reset,
 		CWD:                cwd,
 		ConfigFilePath:     configFilePath,
 		Catalogs:           catalogOptions.Catalogs,
@@ -116,6 +118,12 @@ func (flags *GenerateFlags) AddFlags(cmd *cli.Command) {
 			Usage:       "Preview generation without creating files",
 			Value:       flags.DryRun,
 			Destination: &flags.DryRun,
+		},
+		&cli.BoolFlag{
+			Name:        "reset",
+			Usage:       "Delete existing platform-components before generation",
+			Value:       flags.Reset,
+			Destination: &flags.Reset,
 		},
 	}
 

--- a/src/cmd/generate_test.go
+++ b/src/cmd/generate_test.go
@@ -51,6 +51,7 @@ func TestNewGenerateFlags(t *testing.T) {
 	assert.False(t, flags.Terraform)
 	assert.False(t, flags.Helm)
 	assert.False(t, flags.DryRun)
+	assert.False(t, flags.Reset)
 }
 
 func TestNewGenerateCmd(t *testing.T) {
@@ -60,11 +61,11 @@ func TestNewGenerateCmd(t *testing.T) {
 
 	assert.Equal(t, "generate", command.Name)
 	assert.Equal(t, "Generate files from catalog templates", command.Usage)
-	assert.Equal(t, "kubara generate [--terraform|--helm] [--catalog PATH_OR_OCI [--catalog-overwrite]] [--dry-run]", command.UsageText)
+	assert.Equal(t, "kubara generate [--terraform|--helm] [--reset] [--catalog PATH_OR_OCI [--catalog-overwrite]] [--dry-run]", command.UsageText)
 	assert.Equal(t, "Renders Helm and Terraform templates from configured local or OCI catalogs using values from the config file. By default, it generates both template types.", command.Description)
 
 	// Check that flags are added
-	require.Len(t, command.Flags, 3)
+	require.Len(t, command.Flags, 4)
 
 	flagNames := make(map[string]bool)
 	for _, flag := range command.Flags {
@@ -74,6 +75,7 @@ func TestNewGenerateCmd(t *testing.T) {
 	assert.True(t, flagNames["terraform"])
 	assert.True(t, flagNames["helm"])
 	assert.True(t, flagNames["dry-run"])
+	assert.True(t, flagNames["reset"])
 }
 
 func TestGenerateCmd(t *testing.T) {
@@ -529,6 +531,122 @@ func TestDisabledServicesDontGetWritten(t *testing.T) {
 	}
 	require.NoError(t, err)
 	assert.NotContains(t, names, serviceName)
+}
+
+func TestGenerateCmd_PreservesExistingFilesWithoutReset(t *testing.T) {
+	tempDir := t.TempDir()
+	configPath := testutil.CreateTestConfig(t, tempDir, config.Cluster{
+		Name:             "test-cluster",
+		Stage:            "dev",
+		IngressClassName: "traefik",
+		Type:             "hub",
+		DNSName:          "test.example.com",
+		Terraform: &config.Terraform{
+			Provider:          "stackit",
+			ProjectID:         "00000000-0000-0000-0000-000000000000",
+			KubernetesType:    "ske",
+			KubernetesVersion: "1.28.0",
+			DNS: config.DNS{
+				Name:  "example.com",
+				Email: "[EMAIL_REDACTED]",
+			},
+		},
+		ArgoCD: config.ArgoCD{
+			Repo: config.RepoProto{
+				HTTPS: &config.RepoType{
+					Configs: config.Repository{
+						URL:            "https://github.com/example/configs",
+						TargetRevision: "main",
+					},
+					Components: config.Repository{
+						URL:            "https://github.com/example/components",
+						TargetRevision: "main",
+					},
+				},
+			},
+		},
+		Services: service.Services{},
+	})
+	testutil.CreateDefaultGenerateTestEnv(t, tempDir)
+
+	// Pre-create an unreferenced module from another config
+	otherModulePath := filepath.Join(tempDir, "platform-components", "terraform", "other", "main.tf")
+	require.NoError(t, os.MkdirAll(filepath.Dir(otherModulePath), 0o750))
+	require.NoError(t, os.WriteFile(otherModulePath, []byte("other content"), 0o644))
+
+	// Pre-create a file that would normally be generated to test no-overwrite
+	existingGeneratedPath := filepath.Join(tempDir, "platform-components", "terraform", "stackit", "modules", "ske-cluster", "main.tf")
+	require.NoError(t, os.MkdirAll(filepath.Dir(existingGeneratedPath), 0o750))
+	require.NoError(t, os.WriteFile(existingGeneratedPath, []byte("custom content"), 0o644))
+
+	app := CreateTestApp(NewGenerateCmd())
+	args := []string{"kubara", "--config-file", configPath, "--work-dir", tempDir, "generate", "--terraform"}
+	err := app.Run(context.Background(), args)
+	require.NoError(t, err)
+
+	// Verify unreferenced file from another config was preserved
+	assert.FileExists(t, otherModulePath)
+	otherContent, err := os.ReadFile(otherModulePath)
+	require.NoError(t, err)
+	assert.Equal(t, "other content", string(otherContent))
+
+	// Verify existing generated file was not overwritten
+	existingContent, err := os.ReadFile(existingGeneratedPath)
+	require.NoError(t, err)
+	assert.Equal(t, "custom content", string(existingContent))
+}
+
+func TestGenerateCmd_DeletesWithReset(t *testing.T) {
+	tempDir := t.TempDir()
+	configPath := testutil.CreateTestConfig(t, tempDir, config.Cluster{
+		Name:             "test-cluster",
+		Stage:            "dev",
+		IngressClassName: "traefik",
+		Type:             "hub",
+		DNSName:          "test.example.com",
+		Terraform: &config.Terraform{
+			Provider:          "stackit",
+			ProjectID:         "00000000-0000-0000-0000-000000000000",
+			KubernetesType:    "ske",
+			KubernetesVersion: "1.28.0",
+			DNS: config.DNS{
+				Name:  "example.com",
+				Email: "[EMAIL_REDACTED]",
+			},
+		},
+		ArgoCD: config.ArgoCD{
+			Repo: config.RepoProto{
+				HTTPS: &config.RepoType{
+					Configs: config.Repository{
+						URL:            "https://github.com/example/configs",
+						TargetRevision: "main",
+					},
+					Components: config.Repository{
+						URL:            "https://github.com/example/components",
+						TargetRevision: "main",
+					},
+				},
+			},
+		},
+		Services: service.Services{},
+	})
+	testutil.CreateDefaultGenerateTestEnv(t, tempDir)
+
+	// Pre-create an unreferenced module
+	otherModulePath := filepath.Join(tempDir, "platform-components", "terraform", "other", "main.tf")
+	require.NoError(t, os.MkdirAll(filepath.Dir(otherModulePath), 0o750))
+	require.NoError(t, os.WriteFile(otherModulePath, []byte("other content"), 0o644))
+
+	app := CreateTestApp(NewGenerateCmd())
+	args := []string{"kubara", "--config-file", configPath, "--work-dir", tempDir, "generate", "--terraform", "--reset"}
+	err := app.Run(context.Background(), args)
+	require.NoError(t, err)
+
+	// Verify old terraform directory was wiped and otherModulePath is gone
+	assert.NoFileExists(t, otherModulePath)
+
+	// Verify new files were generated
+	assert.FileExists(t, filepath.Join(tempDir, "platform-components", "terraform", "stackit", "modules", "ske-cluster", "main.tf"))
 }
 
 // Helper function

--- a/src/go.mod
+++ b/src/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/Masterminds/sprig/v3 v3.3.0
 	github.com/external-secrets/external-secrets/apis v0.0.0-20260906103413-12e79a4ffa89
 	github.com/fatih/color v1.19.0
-	github.com/go-git/go-git/v5 v5.19.2
 	github.com/go-viper/mapstructure/v2 v2.5.0
 	github.com/invopop/jsonschema v0.14.0
 	github.com/knadh/koanf/parsers/dotenv v1.1.2
@@ -48,8 +47,6 @@ require (
 	github.com/evanphx/json-patch/v5 v5.9.11 // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.1 // indirect
-	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
-	github.com/go-git/go-billy/v5 v5.9.0 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-openapi/jsonpointer v1.0.0 // indirect
 	github.com/go-openapi/jsonreference v1.0.0 // indirect
@@ -70,7 +67,6 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/huandu/xstrings v1.5.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
 	github.com/joho/godotenv v1.5.1 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/knadh/koanf/maps v0.1.2 // indirect
@@ -110,7 +106,6 @@ require (
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	gopkg.in/warnings.v0 v0.1.2 // indirect
 	k8s.io/apiserver v0.37.0 // indirect
 	k8s.io/component-base v0.37.0 // indirect
 	k8s.io/klog/v2 v2.140.0 // indirect

--- a/src/go.sum
+++ b/src/go.sum
@@ -52,12 +52,6 @@ github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/fxamacker/cbor/v2 v2.9.1 h1:2rWm8B193Ll4VdjsJY28jxs70IdDsHRWgQYAI80+rMQ=
 github.com/fxamacker/cbor/v2 v2.9.1/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
-github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 h1:+zs/tPmkDkHx3U66DAb0lQFJrpS6731Oaa12ikc+DiI=
-github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376/go.mod h1:an3vInlBmSxCcxctByoQdvwPiA7DTK7jaaFDBTtu0ic=
-github.com/go-git/go-billy/v5 v5.9.0 h1:jItGXszUDRtR/AlferWPTMN4j38BQ88XnXKbilmmBPA=
-github.com/go-git/go-billy/v5 v5.9.0/go.mod h1:jCnQMLj9eUgGU7+ludSTYoZL/GGmii14RxKFj7ROgHw=
-github.com/go-git/go-git/v5 v5.19.2 h1:wkfn7vOlUBu8ivAWKBWisTiwJK4jYHzTF8Ndv1LyGqY=
-github.com/go-git/go-git/v5 v5.19.2/go.mod h1:QqCBE1EFN5ddFmrliLQ3/ntRCUjZU3EJuwuB/jWEHjk=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
@@ -129,8 +123,6 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/invopop/jsonschema v0.14.0 h1:MHQqLhvpNUZfw+hM3AZDYK7jxO8FZoQeQM77g8iyZjg=
 github.com/invopop/jsonschema v0.14.0/go.mod h1:ygm6C2EaVNMBDPpaPlnOA2pFAxBnxGjFlMZABxm9n2I=
-github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
-github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
 github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
@@ -294,14 +286,10 @@ google.golang.org/grpc v1.82.1/go.mod h1:yzTZ1TB1Z3SG+LIYaI+WiE8D5+PZ3ArnrSp8zF3
 google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af h1:+5/Sw3GsDNlEmu7TfklWKPdQ0Ykja5VEmq2i817+jbI=
 google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
-gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/evanphx/json-patch.v4 v4.13.0 h1:czT3CmqEaQ1aanPc5SdlgQrrEIb8w/wwCvWWnfEbYzo=
 gopkg.in/evanphx/json-patch.v4 v4.13.0/go.mod h1:p8EYWUEYMpynmqDbY58zCKCFZw8pRWMG4EsWvDvM72M=
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
-gopkg.in/warnings.v0 v0.1.2 h1:wFXVbFY8DY5/xOe1ECiWdKCzZlxgshcYVNkBHstARME=
-gopkg.in/warnings.v0 v0.1.2/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRNI=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 k8s.io/api v0.37.0 h1:Z//Vj9N7RA/yS2sDmxyeo7h+RR4zbUrd2vrd3Z0TbB4=

--- a/src/internal/cmd/generate/generator.go
+++ b/src/internal/cmd/generate/generator.go
@@ -21,6 +21,7 @@ import (
 type Options struct {
 	TemplateType       render.TemplateType
 	DryRun             bool
+	Reset              bool
 	CWD                string
 	ConfigFilePath     string
 	Catalogs           []string
@@ -162,7 +163,7 @@ func toJSONMap(value any) (map[string]any, error) {
 }
 
 func (o *Options) cleanupOldFiles() error {
-	if o.DryRun {
+	if o.DryRun || !o.Reset {
 		return nil
 	}
 
@@ -185,6 +186,11 @@ func (o *Options) writeTemplateResults(results []render.TemplateResult) error {
 	for _, t := range results {
 		if o.DryRun {
 			fmt.Println("DRY-RUN: " + t.Path)
+			continue
+		}
+
+		if _, err := os.Stat(t.Path); err == nil {
+			log.Warn().Str("path", t.Path).Msg("file already exists, skipping")
 			continue
 		}
 

--- a/src/internal/cmd/generate/generator_test.go
+++ b/src/internal/cmd/generate/generator_test.go
@@ -1,6 +1,7 @@
 package generate
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -10,6 +11,7 @@ import (
 	"github.com/kubara-io/kubara/internal/service"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestBuildEnabledServiceTemplatePathPredicate_SkipsDisabledConfigsService(t *testing.T) {
@@ -48,4 +50,80 @@ func TestBuildEnabledServiceTemplatePathPredicate_AlwaysIncludesBootstrapService
 	)
 
 	assert.True(t, predicate(filepath.Join(render.DefaultPlatformConfigsPath, render.Helm.String(), "argo-cd", "values.generated.yaml.tplt")))
+}
+
+func TestCleanupOldFiles_OnlyDeletesOnReset(t *testing.T) {
+	tempDir := t.TempDir()
+	platformComponents := filepath.Join(tempDir, "platform-components")
+	tfDir := filepath.Join(platformComponents, "terraform")
+	helmDir := filepath.Join(platformComponents, "helm")
+
+	require.NoError(t, os.MkdirAll(tfDir, 0o750))
+	require.NoError(t, os.MkdirAll(helmDir, 0o750))
+
+	// Without Reset: directories must NOT be deleted
+	optsNoReset := &Options{
+		PlatformComponents: platformComponents,
+		TemplateType:       render.All,
+		Reset:              false,
+	}
+	require.NoError(t, optsNoReset.cleanupOldFiles())
+	assert.DirExists(t, tfDir)
+	assert.DirExists(t, helmDir)
+
+	// With DryRun and Reset: directories must NOT be deleted
+	optsDryRun := &Options{
+		PlatformComponents: platformComponents,
+		TemplateType:       render.All,
+		Reset:              true,
+		DryRun:             true,
+	}
+	require.NoError(t, optsDryRun.cleanupOldFiles())
+	assert.DirExists(t, tfDir)
+	assert.DirExists(t, helmDir)
+
+	// With Reset: directories MUST be deleted
+	optsReset := &Options{
+		PlatformComponents: platformComponents,
+		TemplateType:       render.All,
+		Reset:              true,
+	}
+	require.NoError(t, optsReset.cleanupOldFiles())
+	assert.NoDirExists(t, tfDir)
+	assert.NoDirExists(t, helmDir)
+}
+
+func TestWriteTemplateResults_DoesNotOverwriteExistingFiles(t *testing.T) {
+	tempDir := t.TempDir()
+	existingFilePath := filepath.Join(tempDir, "existing.txt")
+	newFilePath := filepath.Join(tempDir, "new.txt")
+
+	require.NoError(t, os.WriteFile(existingFilePath, []byte("original content"), 0o644))
+
+	opts := &Options{
+		DryRun: false,
+	}
+
+	results := []render.TemplateResult{
+		{
+			Path:    existingFilePath,
+			Content: "modified content",
+		},
+		{
+			Path:    newFilePath,
+			Content: "brand new content",
+		},
+	}
+
+	require.NoError(t, opts.writeTemplateResults(results))
+
+	// Existing file must not be overwritten
+	existingContent, err := os.ReadFile(existingFilePath)
+	require.NoError(t, err)
+	assert.Equal(t, "original content", string(existingContent))
+
+	// New file must be written
+	newContent, err := os.ReadFile(newFilePath)
+	require.NoError(t, err)
+	assert.Equal(t, "brand new content", string(newContent))
 }

--- a/src/internal/utils/utils.go
+++ b/src/internal/utils/utils.go
@@ -11,7 +11,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/go-git/go-git/v5/plumbing/format/gitignore"
 	"github.com/rs/zerolog/log"
 )
 
@@ -214,15 +213,6 @@ func readGitignoreLines(filePath string) ([]string, error) {
 				lines = append(lines, "")
 			}
 			continue
-		}
-
-		// Validate non-comment lines
-		if !strings.HasPrefix(trimmed, "#") {
-			pattern := gitignore.ParsePattern(line, nil)
-			if pattern == nil {
-				fmt.Printf("Warning: Invalid pattern ignored: %s\n", line)
-				continue
-			}
 		}
 
 		lines = append(lines, line)


### PR DESCRIPTION
## 📝 Summary
- disables deletion of existing platform-components folder each time kubara generate is run
- adds --reset flag to manually delete gernerated files if desired.

This is relevant for multi-hub, multi-config setups.

## 🧩 Type of change
- [x] 🔧 CLI / Go code
- [x] 📝 Documentation
- [x] 🧪 Test or CI change
- [ ] ♻️ Refactor / cleanup

## ⚠️ Is this a breaking change?
- [ ] Yes, this change breaks existing functionality (explain in summary)

## 🧪 Testing
- [ ] CI passed
- [ ] Manually tested (local/dev cluster)
- [ ] Unit tested
- [ ] Not tested (explain why below)
  
## 🔗 Additional Context / Related Issues / Tickets
Fixes https://github.com/kubara-io/kubara/issues/600 

## ✅ Checklist
- [ ] Code compiles and passes all tests
- [ ] Linting and style checks pass
- [ ] Comments added for complex logic
- [ ] Documentation updated (if applicable)
